### PR TITLE
fix(infra): resolve airflow/kafka-ui port clash and drop unrunnable healthchecks

### DIFF
--- a/docker-compose.FuzeInfra.yml
+++ b/docker-compose.FuzeInfra.yml
@@ -133,12 +133,9 @@ services:
     networks:
       - FuzeInfra
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 30s
+    # No healthcheck: chromadb/chroma:latest is a distroless image (no curl/python/shell
+    # and the chroma CLI has no heartbeat command), so an in-container probe is impossible.
+    # Readiness can be checked externally via GET http://localhost:8000/api/v2/heartbeat.
     labels:
       - "com.fuzeinfra.service=chromadb"
       - "com.fuzeinfra.description=ChromaDB Vector Database for AI/ML Applications"
@@ -253,11 +250,9 @@ services:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
     depends_on:
       - nginx
-    healthcheck:
-      test: ["CMD-SHELL", "cloudflared tunnel info ${CLOUDFLARE_TUNNEL_NAME} || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    # No healthcheck: cloudflare/cloudflared:latest is distroless (no /bin/sh), and a
+    # token-run tunnel has no local name/creds for `cloudflared tunnel info`. Tunnel
+    # connectivity is visible in the container logs ("Registered tunnel connection").
 
   # ================================
   # MONITORING & OBSERVABILITY
@@ -471,7 +466,7 @@ services:
       - ./airflow-shared/logs:/opt/airflow/logs
       - ./airflow-shared/plugins:/opt/airflow/plugins
     ports:
-      - "${AIRFLOW_PORT}:8080"
+      - "${AIRFLOW_PORT:-8082}:8080"    # Airflow Webserver - management via tunnel only (host port from .env, leaves 8080 for kafka-ui)
     depends_on:
       - airflow-init
     networks:


### PR DESCRIPTION
## Summary
Fixes three issues in `docker-compose.FuzeInfra.yml` surfaced while bringing the stack back up.

- **airflow-webserver port collision** — was hardcoded `8080:8080`, colliding with `kafka-ui` (also `8080:8080`). Now binds `${AIRFLOW_PORT:-8082}:8080`, matching the `.env` intent and freeing 8080 for kafka-ui.
- **chromadb healthcheck removed** — probe ran `curl` against the deprecated `/api/v1/heartbeat`, but `chromadb/chroma:latest` is distroless (no curl/python/shell). Service is healthy; readiness is `GET /api/v2/heartbeat`.
- **cloudflare-tunnel healthcheck removed** — `CMD-SHELL` probe needs `/bin/sh`, absent in the distroless cloudflared image; a token-run tunnel also has no local creds for `tunnel info`. Tunnel connectivity is visible in logs.

Both services were reporting false `unhealthy` purely due to impossible probes. Verified working via API/logs.

## Test plan
- `docker compose -f docker-compose.FuzeInfra.yml config` parses clean
- airflow UI reachable on :8082, kafka-ui on :8080 (no port conflict)
- chromadb `/api/v2/heartbeat` → 200; cloudflared logs show registered tunnel connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)