### PR TITLE
Kubernetes migration (Phase 1): Helm chart, kind local cluster, EKS terraform, Kafka KRaft fix

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -1,0 +1,46 @@
+name: Helm Chart Validation
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'helm/**'
+      - '.github/workflows/helm-validate.yml'
+  pull_request:
+    paths:
+      - 'helm/**'
+      - '.github/workflows/helm-validate.yml'
+
+jobs:
+  validate:
+    name: Lint & schema-validate chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Helm lint (all overlays)
+        run: |
+          helm lint helm/fuzeinfra
+          helm lint helm/fuzeinfra -f helm/fuzeinfra/values-local.yaml
+          helm lint helm/fuzeinfra -f helm/fuzeinfra/values-aws.yaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sSLo /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /tmp
+          sudo install /tmp/kubeconform /usr/local/bin/kubeconform
+
+      - name: Render & validate (local + aws overlays)
+        run: |
+          for overlay in values-local.yaml values-aws.yaml; do
+            echo "::group::$overlay"
+            helm template fuzeinfra helm/fuzeinfra -f "helm/fuzeinfra/$overlay" \
+              | kubeconform -strict -summary -kubernetes-version 1.29.0
+            echo "::endgroup::"
+          done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# FuzeInfra - Kubernetes & Helm convenience targets.
+# (Docker Compose workflow remains via ./infra-up.sh / ./infra-down.sh)
+
+CHART      := helm/fuzeinfra
+NAMESPACE  := fuzeinfra
+RELEASE    := fuzeinfra
+
+.PHONY: help
+help:
+	@echo "FuzeInfra make targets:"
+	@echo "  Local Kubernetes (kind):"
+	@echo "    make kind-up         Create kind cluster + ingress + deploy chart"
+	@echo "    make kind-down       Delete the kind cluster"
+	@echo "    make k8s-deploy      Deploy/upgrade chart to current kube-context (local values)"
+	@echo "    make k8s-status      Show pods in the $(NAMESPACE) namespace"
+	@echo "  Chart validation (no cluster needed):"
+	@echo "    make helm-lint       helm lint the chart (all overlays)"
+	@echo "    make helm-template   Render the chart to stdout"
+	@echo "    make kubeconform     Render + validate against k8s schemas"
+	@echo "  AWS (EKS):"
+	@echo "    make eks-init        terraform init (terraform/eks)"
+	@echo "    make eks-plan        terraform plan"
+	@echo "    make eks-apply       terraform apply"
+
+# ----------------------------------------------------------------------------
+# Local kind
+# ----------------------------------------------------------------------------
+.PHONY: kind-up
+kind-up:
+	./k8s/kind/setup-kind.sh
+
+.PHONY: kind-down
+kind-down:
+	./k8s/kind/teardown-kind.sh
+
+.PHONY: k8s-deploy
+k8s-deploy:
+	helm upgrade --install $(RELEASE) $(CHART) \
+	  -n $(NAMESPACE) --create-namespace \
+	  -f $(CHART)/values-local.yaml
+
+.PHONY: k8s-status
+k8s-status:
+	kubectl -n $(NAMESPACE) get pods,svc,ingress
+
+# ----------------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------------
+.PHONY: helm-lint
+helm-lint:
+	helm lint $(CHART)
+	helm lint $(CHART) -f $(CHART)/values-local.yaml
+	helm lint $(CHART) -f $(CHART)/values-aws.yaml
+
+.PHONY: helm-template
+helm-template:
+	helm template $(RELEASE) $(CHART) -f $(CHART)/values-local.yaml
+
+.PHONY: kubeconform
+kubeconform:
+	helm template $(RELEASE) $(CHART) -f $(CHART)/values-local.yaml | \
+	  kubeconform -strict -summary -kubernetes-version 1.29.0
+
+# ----------------------------------------------------------------------------
+# AWS EKS
+# ----------------------------------------------------------------------------
+.PHONY: eks-init
+eks-init:
+	cd terraform/eks && terraform init
+
+.PHONY: eks-plan
+eks-plan:
+	cd terraform/eks && terraform plan
+
+.PHONY: eks-apply
+eks-apply:
+	cd terraform/eks && terraform apply

--- a/docker-compose.FuzeInfra.yml
+++ b/docker-compose.FuzeInfra.yml
@@ -144,34 +144,32 @@ services:
   # MESSAGE QUEUE SERVICES
   # ================================
 
-  # Zookeeper (for Kafka)
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.4.0
-    container_name: fuzeinfra-zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    volumes:
-      - zookeeper_data:/var/lib/zookeeper/data
-      - zookeeper_logs:/var/lib/zookeeper/log
-    networks:
-      - FuzeInfra
-    restart: unless-stopped
-
-  # Apache Kafka
+  # Apache Kafka (KRaft mode - no ZooKeeper).
+  # KRaft removes the separate ZooKeeper service and the startup race / deprecation
+  # warnings that produced the errors seen in `docker logs fuzeinfra-kafka`.
+  # NOTE: switching from the old ZooKeeper-based broker changes the on-disk format.
+  # If you previously ran the ZooKeeper version, remove the stale volumes first:
+  #   docker volume rm fuzeinfra_kafka_data fuzeinfra_zookeeper_data fuzeinfra_zookeeper_logs
   kafka:
-    image: confluentinc/cp-kafka:7.4.0
+    image: confluentinc/cp-kafka:7.6.1
     container_name: fuzeinfra-kafka
-    depends_on:
-      - zookeeper
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: fuzeinfra-zookeeper:2181
+      # KRaft single-node: this broker is also the controller.
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@fuzeinfra-kafka:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,PLAINTEXT_HOST://0.0.0.0:29092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://fuzeinfra-kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      # Fixed cluster id so the broker formats KRaft storage deterministically.
+      CLUSTER_ID: fuzeinfra-kafka-cluster01
     ports:
       - "29092:29092"
     volumes:
@@ -179,6 +177,12 @@ services:
     networks:
       - FuzeInfra
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
 
   # Kafka UI
   kafka-ui:
@@ -186,13 +190,14 @@ services:
     container_name: fuzeinfra-kafka-ui
     environment:
       KAFKA_CLUSTERS_0_NAME: local
+      # KRaft: bootstrap servers only (ZooKeeper config removed).
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: fuzeinfra-kafka:9092
-      KAFKA_CLUSTERS_0_ZOOKEEPER: fuzeinfra-zookeeper:2181
+      DYNAMIC_CONFIG_ENABLED: "true"
     ports:
       - "8080:8080"
     depends_on:
-      - kafka
-      - zookeeper
+      kafka:
+        condition: service_healthy
     networks:
       - FuzeInfra
     restart: unless-stopped
@@ -559,10 +564,6 @@ volumes:
   # Message queue volumes
   kafka_data:
     name: fuzeinfra_kafka_data
-  zookeeper_data:
-    name: fuzeinfra_zookeeper_data
-  zookeeper_logs:
-    name: fuzeinfra_zookeeper_logs
   rabbitmq_data:
     name: fuzeinfra_rabbitmq_data
   

--- a/docs/kubernetes-migration.md
+++ b/docs/kubernetes-migration.md
@@ -1,0 +1,131 @@
+# FuzeInfra Kubernetes Migration
+
+This document describes the migration of FuzeInfra from a Docker Compose stack
+to Kubernetes — running locally on **kind** and on AWS via **Amazon EKS**, using
+a single **Helm chart** as the source of truth for both.
+
+## Why
+
+The Docker Compose stack (`docker-compose.FuzeInfra.yml`) and the single-EC2
+Terraform deployment (`terraform/ec2-deployment/`) work, but don't scale, don't
+self-heal, and diverge between "local" and "cloud". Kubernetes gives us:
+
+- The **same manifests** locally (kind) and on AWS (EKS).
+- Self-healing, rolling updates, horizontal scaling (e.g. Airflow Celery workers).
+- Native service discovery (`postgres`, `redis`, `kafka`, … as in-cluster DNS),
+  so application connection strings are **unchanged** from the Compose setup.
+
+## What's in this change (Phase 1)
+
+| Area | Path | Status |
+|------|------|--------|
+| Helm chart (full stack) | `helm/fuzeinfra/` | ✅ renders + schema-valid |
+| Local cluster (kind) | `k8s/kind/` | ✅ scripted |
+| AWS cluster (EKS) | `terraform/eks/` | ✅ HCL written (`fmt` clean) |
+| gp3 StorageClass for EKS | `k8s/aws/gp3-storageclass.yaml` | ✅ |
+| Kafka KRaft fix (Compose) | `docker-compose.FuzeInfra.yml` | ✅ validated |
+
+### Validation performed in CI/sandbox
+
+- `helm lint` — passes.
+- `helm template` with `values.yaml`, `values-local.yaml`, `values-aws.yaml` —
+  renders 49 objects each.
+- `kubeconform -strict` against Kubernetes 1.29 schemas — **49/49 valid**.
+- `docker compose config` — valid.
+- `terraform fmt` — clean.
+
+> ⚠️ Not yet validated live: an actual `kind`/`EKS` deploy and `terraform plan`.
+> The sandbox has no running Docker daemon and blocks `registry.terraform.io`
+> (so the community VPC/EKS modules can't be fetched here). Run the live steps
+> below in an environment with cluster access and registry connectivity.
+
+## Architecture mapping (Compose → Kubernetes)
+
+| Compose service | Kubernetes workload | Notes |
+|-----------------|---------------------|-------|
+| postgres, mongodb, redis, neo4j, elasticsearch, chromadb | StatefulSet + headless/ClusterIP Service + PVC | Stable network id + persistent storage |
+| kafka (+ zookeeper) | **single** StatefulSet, **KRaft mode** | ZooKeeper removed — fixes startup races |
+| rabbitmq | StatefulSet + PVC | |
+| kafka-ui, mongo-express | Deployment + Service | |
+| prometheus, grafana, alertmanager, loki | StatefulSet + PVC | Configs as ConfigMaps |
+| promtail, node-exporter | DaemonSet | Per-node log/metric collection |
+| nginx (reverse proxy) | **Ingress** (ingress-nginx) | `*.dev.local` / `*.infra.<domain>` |
+| dnsmasq | **CoreDNS** (built-in) + host DNS | Not deployed by the chart |
+| cloudflare-tunnel | (optional, not in chart yet) | Add later if external access needed |
+| airflow-* (init/webserver/scheduler/worker/flower) | Job (Helm hook) + Deployments | CeleryExecutor, Redis broker, Postgres backend |
+
+Stateful data services run **in-cluster** for now (StatefulSets), with a
+documented path to AWS managed services later (see "Roadmap").
+
+## Run it locally (kind)
+
+Prereqs: `docker`, `kind`, `kubectl`, `helm`.
+
+```bash
+# One command: create cluster, install ingress-nginx, deploy the chart
+make kind-up          # or: ./k8s/kind/setup-kind.sh
+
+# Point *.dev.local at the ingress (add to /etc/hosts -> 127.0.0.1):
+#   grafana.dev.local prometheus.dev.local airflow.dev.local flower.dev.local
+#   kafka-ui.dev.local mongo-express.dev.local rabbitmq.dev.local neo4j.dev.local
+
+kubectl -n fuzeinfra get pods
+# Grafana:  http://grafana.dev.local   (admin / admin)
+# Airflow:  http://airflow.dev.local   (admin / admin)
+
+make kind-down        # tear everything down
+```
+
+## Deploy to AWS (EKS)
+
+Prereqs: `terraform`, `aws` CLI (configured), `kubectl`, `helm`, and network
+access to `registry.terraform.io`.
+
+```bash
+cd terraform/eks
+cp terraform.tfvars.example terraform.tfvars   # edit admin_access_cidrs etc.
+terraform init
+terraform apply
+
+# Wire up kubectl to the new cluster
+aws eks update-kubeconfig --region us-east-1 --name fuzeinfra
+
+# Default gp3 StorageClass for the chart's PVCs
+kubectl apply -f ../../k8s/aws/gp3-storageclass.yaml
+
+# Ingress controller (creates an AWS NLB)
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm install ingress-nginx ingress-nginx/ingress-nginx \
+  -n ingress-nginx --create-namespace
+
+# Deploy FuzeInfra
+helm upgrade --install fuzeinfra ../../helm/fuzeinfra \
+  -n fuzeinfra --create-namespace -f ../../helm/fuzeinfra/values-aws.yaml
+
+# Point a wildcard DNS record (*.infra.<domain>) at the ingress NLB:
+kubectl -n ingress-nginx get svc ingress-nginx-controller
+```
+
+## Configuration
+
+- **Credentials**: `helm/fuzeinfra/values.yaml > credentials`. For real
+  environments, set `credentials.existingSecret` to a Secret you manage instead.
+- **Storage class**: `global.storageClass` (`standard` for kind, `gp3` for EKS).
+- **Domain**: `global.domain` builds ingress hostnames.
+- **Enable/disable services**: every service has an `enabled` flag.
+- **Scale Airflow**: `airflow.workerReplicas`.
+
+## Roadmap (next phases)
+
+1. **Live validation**: `kind` bring-up + smoke tests; `terraform plan/apply` on EKS.
+2. **CI**: add a GitHub Actions job running `helm lint` + `kubeconform` (offline)
+   and a `kind`-based integration test of the chart.
+3. **TLS**: cert-manager + ClusterIssuer; enable `ingress.tls`.
+4. **Managed data services (AWS)**: optional swap of in-cluster StatefulSets for
+   RDS (Postgres), ElastiCache (Redis), MSK (Kafka), OpenSearch, DocumentDB.
+   Disable the corresponding chart services and point `credentials`/Secret at the
+   managed endpoints.
+5. **DAG delivery**: replace the example-DAG ConfigMap with git-sync or a baked
+   Airflow image.
+6. **Autoscaling**: HPAs for stateless services and Airflow workers; Cluster
+   Autoscaler / Karpenter on EKS.

--- a/helm/fuzeinfra/.helmignore
+++ b/helm/fuzeinfra/.helmignore
@@ -1,0 +1,6 @@
+.git
+*.tmp
+*.bak
+.DS_Store
+*.swp
+ci/

--- a/helm/fuzeinfra/Chart.yaml
+++ b/helm/fuzeinfra/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: fuzeinfra
+description: |
+  FuzeInfra - shared infrastructure platform for microservices development,
+  packaged as a single Helm chart. Runs the same stack on a local kind cluster
+  and on Amazon EKS: databases, message queues, monitoring/logging, an Nginx-style
+  ingress, and an Airflow + Celery workflow stack for data pipelines.
+type: application
+# Chart version - bump on chart changes. See version.json for platform version.
+version: 0.1.0
+# The platform/app version this chart deploys.
+appVersion: "0.3.0"
+keywords:
+  - infrastructure
+  - postgres
+  - redis
+  - mongodb
+  - kafka
+  - airflow
+  - monitoring
+maintainers:
+  - name: FuzeFrontier
+home: https://github.com/izzywdev/FuzeInfra

--- a/helm/fuzeinfra/templates/NOTES.txt
+++ b/helm/fuzeinfra/templates/NOTES.txt
@@ -1,0 +1,27 @@
+FuzeInfra has been deployed to namespace "{{ .Release.Namespace }}".
+
+Release: {{ .Release.Name }}
+Domain:  {{ .Values.global.domain }}
+
+Web UIs (via Ingress, class "{{ .Values.ingress.className }}"):
+{{- if .Values.grafana.enabled }}
+  Grafana        http://grafana.{{ .Values.global.domain }}{{ end }}
+{{- if .Values.prometheus.enabled }}
+  Prometheus     http://prometheus.{{ .Values.global.domain }}{{ end }}
+{{- if .Values.airflow.enabled }}
+  Airflow        http://airflow.{{ .Values.global.domain }}
+  Flower         http://flower.{{ .Values.global.domain }}{{ end }}
+{{- if and .Values.kafkaUi.enabled .Values.kafka.enabled }}
+  Kafka UI       http://kafka-ui.{{ .Values.global.domain }}{{ end }}
+{{- if and .Values.mongoExpress.enabled .Values.mongodb.enabled }}
+  Mongo Express  http://mongo-express.{{ .Values.global.domain }}{{ end }}
+
+For local (kind), ensure these hostnames resolve to 127.0.0.1, e.g. add to
+/etc/hosts or use the dnsmasq wildcard for *.{{ .Values.global.domain }}.
+
+In-cluster service DNS (use these from your apps):
+  postgres:5432  redis:6379  mongodb:27017  kafka:9092  rabbitmq:5672
+  elasticsearch:9200  neo4j:7687  chromadb:8000
+
+Check status:
+  kubectl -n {{ .Release.Namespace }} get pods

--- a/helm/fuzeinfra/templates/_helpers.tpl
+++ b/helm/fuzeinfra/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Common helpers for the FuzeInfra chart.
+*/}}
+
+{{- define "fuzeinfra.name" -}}
+fuzeinfra
+{{- end -}}
+
+{{/*
+Common labels applied to every object.
+*/}}
+{{- define "fuzeinfra.labels" -}}
+app.kubernetes.io/part-of: fuzeinfra
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{/*
+Per-component selector labels. Usage: {{ include "fuzeinfra.selectorLabels" (dict "component" "postgres") }}
+*/}}
+{{- define "fuzeinfra.selectorLabels" -}}
+app.kubernetes.io/name: {{ .component }}
+app.kubernetes.io/instance: fuzeinfra
+{{- end -}}
+
+{{/*
+Name of the Secret holding credentials (existing or chart-managed).
+*/}}
+{{- define "fuzeinfra.secretName" -}}
+{{- if .Values.credentials.existingSecret -}}
+{{ .Values.credentials.existingSecret }}
+{{- else -}}
+fuzeinfra-secrets
+{{- end -}}
+{{- end -}}
+
+{{/*
+imagePullPolicy shortcut.
+*/}}
+{{- define "fuzeinfra.pullPolicy" -}}
+{{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
+{{- end -}}
+
+{{/*
+storageClassName helper - emits the field only when a class is set.
+Usage:
+  {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+*/}}
+{{- define "fuzeinfra.storageClass" -}}
+{{- if .Values.global.storageClass }}
+storageClassName: {{ .Values.global.storageClass | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Ingress host for a component: <component>.<domain>
+Usage: {{ include "fuzeinfra.host" (dict "root" $ "sub" "grafana") }}
+*/}}
+{{- define "fuzeinfra.host" -}}
+{{ .sub }}.{{ .root.Values.global.domain }}
+{{- end -}}

--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -1,0 +1,289 @@
+{{- /*
+Shared Airflow env block. POSTGRES_USER/PASSWORD come from the secret and are
+referenced via $(VAR) interpolation to build the SQLAlchemy/Celery URLs.
+*/ -}}
+{{- define "fuzeinfra.airflowEnv" -}}
+- name: POSTGRES_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzeinfra.secretName" . }}
+      key: POSTGRES_USER
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzeinfra.secretName" . }}
+      key: POSTGRES_PASSWORD
+- name: AIRFLOW__CORE__EXECUTOR
+  value: CeleryExecutor
+- name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+  value: "postgresql+psycopg2://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/airflow"
+- name: AIRFLOW__CELERY__RESULT_BACKEND
+  value: "db+postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/airflow"
+- name: AIRFLOW__CELERY__BROKER_URL
+  value: "redis://redis:6379/0"
+- name: AIRFLOW__CORE__FERNET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzeinfra.secretName" . }}
+      key: AIRFLOW_FERNET_KEY
+- name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+  value: "true"
+- name: AIRFLOW__CORE__LOAD_EXAMPLES
+  value: {{ .Values.airflow.loadExamples | quote }}
+- name: AIRFLOW__API__AUTH_BACKENDS
+  value: "airflow.api.auth.backend.basic_auth"
+{{- end -}}
+
+{{- if .Values.airflow.enabled }}
+{{- /* Example DAG shipped as a ConfigMap so the stack works out of the box.
+     For production, replace with git-sync or a baked image. */ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airflow-dags
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  example_fuzeinfra_dag.py: |
+    from datetime import datetime
+    from airflow import DAG
+    from airflow.operators.bash import BashOperator
+
+    with DAG(
+        dag_id="example_fuzeinfra_pipeline",
+        start_date=datetime(2024, 1, 1),
+        schedule=None,
+        catchup=False,
+        tags=["fuzeinfra", "example"],
+    ) as dag:
+        BashOperator(
+            task_id="hello",
+            bash_command="echo 'FuzeInfra Airflow + Celery is running'",
+        )
+---
+{{- /* ===================== Airflow DB migrate / bootstrap Job ===================== */}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: airflow-init
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-init") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: airflow-init
+          image: {{ .Values.airflow.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
+            - name: AIRFLOW_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: AIRFLOW_ADMIN_USER
+            - name: AIRFLOW_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: AIRFLOW_ADMIN_PASSWORD
+          command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Waiting for PostgreSQL..."
+              until PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do
+                sleep 2
+              done
+              echo "Ensuring 'airflow' database exists..."
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U "$POSTGRES_USER" -d postgres -tc \
+                "SELECT 1 FROM pg_database WHERE datname = 'airflow'" | grep -q 1 || \
+                PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE airflow"
+              echo "Running airflow db migrate..."
+              airflow db migrate
+              echo "Creating admin user (idempotent)..."
+              airflow users create \
+                --username "$AIRFLOW_ADMIN_USER" --firstname Admin --lastname User \
+                --role Admin --email admin@example.com --password "$AIRFLOW_ADMIN_PASSWORD" || true
+---
+{{- /* ===================== Airflow Webserver ===================== */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-webserver
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.airflow.webPort }}
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-webserver
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 8 }}
+    spec:
+      containers:
+        - name: webserver
+          image: {{ .Values.airflow.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["webserver"]
+          env:
+            {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
+            - name: AIRFLOW__WEBSERVER__EXPOSE_CONFIG
+              value: "true"
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: dags
+              mountPath: /opt/airflow/dags
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 12
+      volumes:
+        - name: dags
+          configMap:
+            name: airflow-dags
+---
+{{- /* ===================== Airflow Scheduler ===================== */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-scheduler
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler") | nindent 8 }}
+    spec:
+      containers:
+        - name: scheduler
+          image: {{ .Values.airflow.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["scheduler"]
+          env:
+            {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: dags
+              mountPath: /opt/airflow/dags
+      volumes:
+        - name: dags
+          configMap:
+            name: airflow-dags
+---
+{{- /* ===================== Airflow Celery Worker ===================== */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-worker
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.airflow.workerReplicas }}
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker") | nindent 8 }}
+    spec:
+      containers:
+        - name: worker
+          image: {{ .Values.airflow.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["celery", "worker"]
+          env:
+            {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: dags
+              mountPath: /opt/airflow/dags
+      volumes:
+        - name: dags
+          configMap:
+            name: airflow-dags
+---
+{{- /* ===================== Airflow Flower (Celery monitoring) ===================== */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-flower
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.airflow.flowerPort }}
+      targetPort: 5555
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-flower
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 8 }}
+    spec:
+      containers:
+        - name: flower
+          image: {{ .Values.airflow.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["celery", "flower"]
+          env:
+            {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
+          ports:
+            - containerPort: 5555
+              name: http
+{{- end }}

--- a/helm/fuzeinfra/templates/configmaps-monitoring.yaml
+++ b/helm/fuzeinfra/templates/configmaps-monitoring.yaml
@@ -1,0 +1,173 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+      external_labels:
+        monitor: fuzeinfra-monitor
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets:
+              {{- if .Values.alertmanager.enabled }}
+                - alertmanager:{{ .Values.alertmanager.port }}
+              {{- end }}
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+      {{- if .Values.nodeExporter.enabled }}
+      - job_name: node-exporter
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: node-exporter
+      {{- end }}
+      # Scrape any pod annotated with prometheus.io/scrape: "true".
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+{{- end }}
+{{- if .Values.alertmanager.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  alertmanager.yml: |
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['alertname']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 3h
+      receiver: 'default'
+    receivers:
+      - name: 'default'
+{{- end }}
+{{- if .Values.loki.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    limits_config:
+      reject_old_samples: false
+{{- end }}
+{{- if .Values.promtail.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    server:
+      http_listen_port: 9080
+    positions:
+      filename: /run/promtail/positions.yaml
+    clients:
+      - url: http://loki:{{ .Values.loki.port }}/loki/api/v1/push
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: __host__
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          - replacement: /var/log/pods/*$1/*.log
+            separator: /
+            source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            target_label: __path__
+{{- end }}
+{{- if .Values.grafana.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      {{- if .Values.prometheus.enabled }}
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:{{ .Values.prometheus.port }}
+        isDefault: true
+      {{- end }}
+      {{- if .Values.loki.enabled }}
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki:{{ .Values.loki.port }}
+      {{- end }}
+{{- end }}

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -1,0 +1,463 @@
+{{- /* ============================ PostgreSQL ============================ */ -}}
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 4 }}
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.port }}
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          envFrom:
+            - secretRef:
+                name: {{ include "fuzeinfra.secretName" . }}
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\""]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\""]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage }}
+{{- end }}
+
+{{- /* ============================ MongoDB ============================ */ -}}
+{{- if .Values.mongodb.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 4 }}
+  ports:
+    - name: mongodb
+      port: {{ .Values.mongodb.port }}
+      targetPort: 27017
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 8 }}
+    spec:
+      containers:
+        - name: mongodb
+          image: {{ .Values.mongodb.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: MONGODB_USER
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: MONGODB_PASSWORD
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.mongodb.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.mongodb.storage }}
+{{- end }}
+
+{{- /* ============================ Redis ============================ */ -}}
+{{- if .Values.redis.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 4 }}
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port }}
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 8 }}
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["redis-server", "--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+              name: redis
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage }}
+{{- end }}
+
+{{- /* ============================ Neo4j ============================ */ -}}
+{{- if .Values.neo4j.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: neo4j
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.neo4j.httpPort }}
+      targetPort: 7474
+    - name: bolt
+      port: {{ .Values.neo4j.boltPort }}
+      targetPort: 7687
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: neo4j
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 8 }}
+    spec:
+      containers:
+        - name: neo4j
+          image: {{ .Values.neo4j.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: NEO4J_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: NEO4J_AUTH
+            - name: NEO4J_PLUGINS
+              value: '["apoc"]'
+          ports:
+            - containerPort: 7474
+              name: http
+            - containerPort: 7687
+              name: bolt
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: logs
+              mountPath: /logs
+          readinessProbe:
+            tcpSocket:
+              port: 7687
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 12
+          resources:
+            {{- toYaml .Values.neo4j.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.neo4j.storage }}
+    - metadata:
+        name: logs
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: 1Gi
+{{- end }}
+
+{{- /* ============================ Elasticsearch ============================ */ -}}
+{{- if .Values.elasticsearch.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.elasticsearch.port }}
+      targetPort: 9200
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: elasticsearch
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 8 }}
+    spec:
+      initContainers:
+        # Elasticsearch requires vm.max_map_count >= 262144.
+        - name: sysctl
+          image: busybox:1.36
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command: ["sh", "-c", "sysctl -w vm.max_map_count=262144 || true"]
+      containers:
+        - name: elasticsearch
+          image: {{ .Values.elasticsearch.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+            - name: ES_JAVA_OPTS
+              value: {{ .Values.elasticsearch.javaOpts | quote }}
+          ports:
+            - containerPort: 9200
+              name: http
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health?local=true
+              port: 9200
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 12
+          resources:
+            {{- toYaml .Values.elasticsearch.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.elasticsearch.storage }}
+{{- end }}
+
+{{- /* ============================ ChromaDB ============================ */ -}}
+{{- if .Values.chromadb.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chromadb
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.chromadb.port }}
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: chromadb
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: chromadb
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 8 }}
+    spec:
+      containers:
+        - name: chromadb
+          image: {{ .Values.chromadb.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: IS_PERSISTENT
+              value: "true"
+            - name: PERSIST_DIRECTORY
+              value: /chroma/chroma
+            - name: ALLOW_RESET
+              value: "true"
+          ports:
+            - containerPort: 8000
+              name: http
+          volumeMounts:
+            - name: data
+              mountPath: /chroma/chroma
+          # chromadb/chroma is distroless; probe externally via TCP.
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.chromadb.storage }}
+{{- end }}

--- a/helm/fuzeinfra/templates/ingress.yaml
+++ b/helm/fuzeinfra/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled }}
+{{- $root := . -}}
+{{- /* service name -> service port for each web UI we expose */ -}}
+{{- $routes := dict
+  "grafana"           (dict "svc" "grafana"           "port" $root.Values.grafana.port           "enabled" $root.Values.grafana.enabled)
+  "prometheus"        (dict "svc" "prometheus"        "port" $root.Values.prometheus.port        "enabled" $root.Values.prometheus.enabled)
+  "alertmanager"      (dict "svc" "alertmanager"      "port" $root.Values.alertmanager.port      "enabled" $root.Values.alertmanager.enabled)
+  "airflow"           (dict "svc" "airflow-webserver" "port" $root.Values.airflow.webPort        "enabled" $root.Values.airflow.enabled)
+  "flower"            (dict "svc" "airflow-flower"    "port" $root.Values.airflow.flowerPort     "enabled" $root.Values.airflow.enabled)
+  "kafka-ui"          (dict "svc" "kafka-ui"          "port" $root.Values.kafkaUi.port           "enabled" (and $root.Values.kafkaUi.enabled $root.Values.kafka.enabled))
+  "mongo-express"     (dict "svc" "mongo-express"     "port" $root.Values.mongoExpress.port      "enabled" (and $root.Values.mongoExpress.enabled $root.Values.mongodb.enabled))
+  "rabbitmq"          (dict "svc" "rabbitmq"          "port" $root.Values.rabbitmq.managementPort "enabled" $root.Values.rabbitmq.enabled)
+  "neo4j"             (dict "svc" "neo4j"             "port" $root.Values.neo4j.httpPort         "enabled" $root.Values.neo4j.enabled)
+-}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fuzeinfra
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range $sub, $r := $routes }}
+        {{- if $r.enabled }}
+        - {{ include "fuzeinfra.host" (dict "root" $root "sub" $sub) }}
+        {{- end }}
+        {{- end }}
+      secretName: fuzeinfra-tls
+  {{- end }}
+  rules:
+    {{- range $sub, $r := $routes }}
+    {{- if $r.enabled }}
+    - host: {{ include "fuzeinfra.host" (dict "root" $root "sub" $sub) }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $r.svc }}
+                port:
+                  number: {{ $r.port }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/fuzeinfra/templates/messaging.yaml
+++ b/helm/fuzeinfra/templates/messaging.yaml
@@ -1,0 +1,303 @@
+{{- /* ===================== Kafka (KRaft, no ZooKeeper) ===================== */ -}}
+{{- if .Values.kafka.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 4 }}
+  ports:
+    - name: broker
+      port: {{ .Values.kafka.port }}
+      targetPort: 9092
+    - name: controller
+      port: 9093
+      targetPort: 9093
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 8 }}
+    spec:
+      containers:
+        - name: kafka
+          image: {{ .Values.kafka.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            # --- KRaft single-node config (broker + controller in one process) ---
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@kafka-0.kafka:9093"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "PLAINTEXT"
+            # Single-node replication factors must be 1.
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            # cp-kafka auto-formats KRaft storage when CLUSTER_ID is provided.
+            - name: CLUSTER_ID
+              value: {{ .Values.kafka.clusterId | quote }}
+            - name: KAFKA_LOG_DIRS
+              value: "/var/lib/kafka/data"
+          ports:
+            - containerPort: 9092
+              name: broker
+            - containerPort: 9093
+              name: controller
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka/data
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 12
+          resources:
+            {{- toYaml .Values.kafka.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.kafka.storage }}
+{{- end }}
+
+{{- /* ===================== Kafka UI ===================== */ -}}
+{{- if and .Values.kafkaUi.enabled .Values.kafka.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-ui
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.kafkaUi.port }}
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-ui
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 8 }}
+    spec:
+      containers:
+        - name: kafka-ui
+          image: {{ .Values.kafkaUi.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: KAFKA_CLUSTERS_0_NAME
+              value: "local"
+            # KRaft mode: bootstrap servers only, no ZooKeeper.
+            - name: KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS
+              value: "kafka:9092"
+            - name: DYNAMIC_CONFIG_ENABLED
+              value: "true"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 10
+{{- end }}
+
+{{- /* ===================== RabbitMQ ===================== */ -}}
+{{- if .Values.rabbitmq.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 4 }}
+  ports:
+    - name: amqp
+      port: {{ .Values.rabbitmq.amqpPort }}
+      targetPort: 5672
+    - name: management
+      port: {{ .Values.rabbitmq.managementPort }}
+      targetPort: 15672
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: rabbitmq
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 8 }}
+    spec:
+      containers:
+        - name: rabbitmq
+          image: {{ .Values.rabbitmq.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: RABBITMQ_USER
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: RABBITMQ_PASSWORD
+          ports:
+            - containerPort: 5672
+              name: amqp
+            - containerPort: 15672
+              name: management
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/rabbitmq
+          readinessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "-q", "ping"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 6
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits:   { cpu: "1",  memory: 1Gi }
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.rabbitmq.storage }}
+{{- end }}
+
+{{- /* ===================== Mongo Express ===================== */ -}}
+{{- if and .Values.mongoExpress.enabled .Values.mongodb.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo-express
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.mongoExpress.port }}
+      targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo-express
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 8 }}
+    spec:
+      containers:
+        - name: mongo-express
+          image: {{ .Values.mongoExpress.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: MONGODB_USER
+            - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: MONGODB_PASSWORD
+            - name: ME_CONFIG_MONGODB_URL
+              value: "mongodb://$(ME_CONFIG_MONGODB_ADMINUSERNAME):$(ME_CONFIG_MONGODB_ADMINPASSWORD)@mongodb:27017/"
+            - name: ME_CONFIG_BASICAUTH_USERNAME
+              value: "admin"
+            - name: ME_CONFIG_BASICAUTH_PASSWORD
+              value: "admin"
+          ports:
+            - containerPort: 8081
+              name: http
+{{- end }}

--- a/helm/fuzeinfra/templates/monitoring.yaml
+++ b/helm/fuzeinfra/templates/monitoring.yaml
@@ -1,0 +1,460 @@
+{{- /* ===================== RBAC for Prometheus & Promtail SD ===================== */ -}}
+{{- if or .Values.prometheus.enabled .Values.promtail.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fuzeinfra-monitoring
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-fuzeinfra-monitoring
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "nodes/metrics", "services", "endpoints", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-fuzeinfra-monitoring
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-fuzeinfra-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: fuzeinfra-monitoring
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- /* ===================== Prometheus ===================== */ -}}
+{{- if .Values.prometheus.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.prometheus.port }}
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: prometheus
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 8 }}
+    spec:
+      serviceAccountName: fuzeinfra-monitoring
+      securityContext:
+        fsGroup: 65534
+      containers:
+        - name: prometheus
+          image: {{ .Values.prometheus.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args:
+            - '--config.file=/etc/prometheus/prometheus.yml'
+            - '--storage.tsdb.path=/prometheus'
+            - '--web.enable-lifecycle'
+          ports:
+            - containerPort: 9090
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.prometheus.storage }}
+{{- end }}
+
+{{- /* ===================== Alertmanager ===================== */ -}}
+{{- if .Values.alertmanager.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.alertmanager.port }}
+      targetPort: 9093
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: alertmanager
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: alertmanager
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 8 }}
+    spec:
+      containers:
+        - name: alertmanager
+          image: {{ .Values.alertmanager.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args:
+            - '--config.file=/etc/alertmanager/alertmanager.yml'
+            - '--storage.path=/alertmanager'
+          ports:
+            - containerPort: 9093
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alertmanager
+            - name: data
+              mountPath: /alertmanager
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.alertmanager.storage }}
+{{- end }}
+
+{{- /* ===================== Grafana ===================== */ -}}
+{{- if .Values.grafana.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.grafana.port }}
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: grafana
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: grafana
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 8 }}
+    spec:
+      securityContext:
+        fsGroup: 472
+      containers:
+        - name: grafana
+          image: {{ .Values.grafana.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: GRAFANA_ADMIN_PASSWORD
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+          ports:
+            - containerPort: 3000
+              name: http
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.grafana.storage }}
+{{- end }}
+
+{{- /* ===================== Loki ===================== */ -}}
+{{- if .Values.loki.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 4 }}
+spec:
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.loki.port }}
+      targetPort: 3100
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 8 }}
+    spec:
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: loki
+          image: {{ .Values.loki.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["-config.file=/etc/loki/loki-config.yaml"]
+          ports:
+            - containerPort: 3100
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 20
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- include "fuzeinfra.storageClass" . | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.loki.storage }}
+{{- end }}
+
+{{- /* ===================== Promtail (DaemonSet) ===================== */ -}}
+{{- if .Values.promtail.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "promtail") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "promtail") | nindent 8 }}
+    spec:
+      serviceAccountName: fuzeinfra-monitoring
+      containers:
+        - name: promtail
+          image: {{ .Values.promtail.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args: ["-config.file=/etc/promtail/config.yml"]
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: run
+              mountPath: /run/promtail
+            - name: pods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: run
+          hostPath:
+            path: /run/promtail
+        - name: pods
+          hostPath:
+            path: /var/log/pods
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
+{{- end }}
+
+{{- /* ===================== Node Exporter (DaemonSet) ===================== */ -}}
+{{- if .Values.nodeExporter.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.nodeExporter.port }}
+      targetPort: 9100
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 8 }}
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: node-exporter
+          image: {{ .Values.nodeExporter.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          args:
+            - '--path.procfs=/host/proc'
+            - '--path.sysfs=/host/sys'
+            - '--path.rootfs=/host/root'
+            - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+          ports:
+            - containerPort: 9100
+              name: metrics
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /
+{{- end }}

--- a/helm/fuzeinfra/templates/secrets.yaml
+++ b/helm/fuzeinfra/templates/secrets.yaml
@@ -1,0 +1,24 @@
+{{- if not .Values.credentials.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fuzeinfra.secretName" . }}
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.credentials.postgres.user | quote }}
+  POSTGRES_PASSWORD: {{ .Values.credentials.postgres.password | quote }}
+  POSTGRES_DB: {{ .Values.credentials.postgres.db | quote }}
+  MONGODB_USER: {{ .Values.credentials.mongodb.user | quote }}
+  MONGODB_PASSWORD: {{ .Values.credentials.mongodb.password | quote }}
+  NEO4J_USER: {{ .Values.credentials.neo4j.user | quote }}
+  NEO4J_PASSWORD: {{ .Values.credentials.neo4j.password | quote }}
+  NEO4J_AUTH: {{ printf "%s/%s" .Values.credentials.neo4j.user .Values.credentials.neo4j.password | quote }}
+  RABBITMQ_USER: {{ .Values.credentials.rabbitmq.user | quote }}
+  RABBITMQ_PASSWORD: {{ .Values.credentials.rabbitmq.password | quote }}
+  GRAFANA_ADMIN_PASSWORD: {{ .Values.credentials.grafana.adminPassword | quote }}
+  AIRFLOW_ADMIN_USER: {{ .Values.credentials.airflow.adminUser | quote }}
+  AIRFLOW_ADMIN_PASSWORD: {{ .Values.credentials.airflow.adminPassword | quote }}
+  AIRFLOW_FERNET_KEY: {{ .Values.credentials.airflow.fernetKey | quote }}
+{{- end }}

--- a/helm/fuzeinfra/values-aws.yaml
+++ b/helm/fuzeinfra/values-aws.yaml
@@ -1,0 +1,50 @@
+# =============================================================================
+# AWS (EKS) overlay.
+#   helm upgrade --install fuzeinfra helm/fuzeinfra \
+#     -n fuzeinfra --create-namespace -f helm/fuzeinfra/values-aws.yaml
+#
+# Prereqs on the cluster (see terraform/eks + docs/kubernetes-migration.md):
+#   - aws-ebs-csi-driver with a "gp3" StorageClass
+#   - ingress-nginx controller (creates an AWS NLB)
+# =============================================================================
+global:
+  storageClass: "gp3"
+  # Replace with your real domain; point a wildcard *.infra.<domain> at the
+  # ingress-nginx load balancer (Route53 / Cloudflare).
+  domain: infra.fuzefront.com
+  imagePullPolicy: IfNotPresent
+
+ingress:
+  enabled: true
+  className: nginx
+  tls:
+    # Set up cert-manager + a ClusterIssuer, then enable.
+    enabled: false
+
+# Production-leaning sizing. Tune to your node group.
+postgres:
+  storage: 20Gi
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits:   { cpu: "2",  memory: 2Gi }
+
+elasticsearch:
+  storage: 30Gi
+  javaOpts: "-Xms1g -Xmx1g"
+  resources:
+    requests: { cpu: 500m, memory: 2Gi }
+    limits:   { cpu: "2",  memory: 3Gi }
+
+kafka:
+  storage: 20Gi
+
+prometheus:
+  storage: 30Gi
+
+airflow:
+  workerReplicas: 2
+
+# NOTE: The "managed services later" path - when you are ready to move
+# stateful services to RDS/ElastiCache/MSK/OpenSearch, disable them here
+# (e.g. postgres.enabled: false) and point apps/airflow at the managed
+# endpoints via the credentials/secret. See docs/kubernetes-migration.md.

--- a/helm/fuzeinfra/values-local.yaml
+++ b/helm/fuzeinfra/values-local.yaml
@@ -1,0 +1,25 @@
+# =============================================================================
+# Local (kind) overlay.
+#   helm upgrade --install fuzeinfra helm/fuzeinfra \
+#     -n fuzeinfra --create-namespace -f helm/fuzeinfra/values-local.yaml
+# =============================================================================
+global:
+  storageClass: "standard"   # kind's default dynamic provisioner
+  domain: dev.local
+  imagePullPolicy: IfNotPresent
+
+ingress:
+  enabled: true
+  className: nginx
+  tls:
+    enabled: false
+
+# Smaller footprint for laptops.
+elasticsearch:
+  javaOpts: "-Xms256m -Xmx256m"
+  resources:
+    requests: { cpu: 100m, memory: 512Mi }
+    limits:   { cpu: 500m, memory: 1Gi }
+
+airflow:
+  workerReplicas: 1

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -1,0 +1,200 @@
+# =============================================================================
+# FuzeInfra Helm chart - default values (in-cluster everything)
+#
+# These defaults run the full stack with StatefulSets for stateful services.
+# Override per environment with values-local.yaml (kind) or values-aws.yaml (EKS).
+# =============================================================================
+
+global:
+  # Namespace is taken from the Helm release namespace (`helm -n fuzeinfra`).
+  # Storage class for PersistentVolumeClaims:
+  #   - kind:  "standard" (default kind storage class)
+  #   - EKS:   "gp3" (provided by the aws-ebs-csi-driver / values-aws.yaml)
+  storageClass: "standard"
+
+  # Base domain used to build Ingress hostnames, e.g. grafana.dev.local.
+  # Local:  dev.local   (resolve via /etc/hosts or dnsmasq -> 127.0.0.1)
+  # AWS:    set to your real domain in values-aws.yaml
+  domain: dev.local
+
+  # imagePullPolicy applied to every workload.
+  imagePullPolicy: IfNotPresent
+
+# -----------------------------------------------------------------------------
+# Credentials. For real environments, override these or supply an existing
+# Secret via `existingSecret`. Defaults mirror the docker-compose dev values.
+# -----------------------------------------------------------------------------
+credentials:
+  # If set, the chart will NOT create a Secret and instead reads keys from this one.
+  existingSecret: ""
+  postgres:
+    user: fuzeinfra
+    password: fuzeinfra_secure_password
+    db: fuzeinfra_db
+  mongodb:
+    user: admin
+    password: admin123
+  neo4j:
+    user: neo4j
+    password: password123
+  rabbitmq:
+    user: admin
+    password: admin123
+  grafana:
+    adminPassword: admin
+  airflow:
+    adminUser: admin
+    adminPassword: admin
+    # Fernet key for Airflow connection encryption. Generate a real one with:
+    #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    fernetKey: "Zp9p8x0Q3y0sJpQ8m2nq3l4F6tH9wXyZ1aB2cD3eF4="
+
+# -----------------------------------------------------------------------------
+# Ingress (replaces the docker-compose nginx reverse proxy). Web UIs are exposed
+# at <service>.<global.domain>. Requires an ingress controller (ingress-nginx),
+# installed by the bootstrap scripts for kind and as an EKS addon path.
+# -----------------------------------------------------------------------------
+ingress:
+  enabled: true
+  className: nginx
+  # TLS via cert-manager / secrets is left to the environment overlay.
+  tls:
+    enabled: false
+
+# =============================================================================
+# Service definitions. Each block: enabled, image, resources, storage size.
+# =============================================================================
+
+postgres:
+  enabled: true
+  image: postgres:15
+  port: 5432
+  storage: 5Gi
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: "1",  memory: 1Gi }
+
+mongodb:
+  enabled: true
+  image: mongo:7
+  port: 27017
+  storage: 5Gi
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: "1",  memory: 1Gi }
+
+mongoExpress:
+  enabled: true
+  image: mongo-express:latest
+  port: 8081
+
+redis:
+  enabled: true
+  image: redis:7-alpine
+  port: 6379
+  storage: 2Gi
+  resources:
+    requests: { cpu: 50m,  memory: 64Mi }
+    limits:   { cpu: 500m, memory: 512Mi }
+
+neo4j:
+  enabled: true
+  image: neo4j:5
+  httpPort: 7474
+  boltPort: 7687
+  storage: 5Gi
+  resources:
+    requests: { cpu: 200m, memory: 512Mi }
+    limits:   { cpu: "1",  memory: 2Gi }
+
+elasticsearch:
+  enabled: true
+  image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
+  port: 9200
+  storage: 10Gi
+  javaOpts: "-Xms512m -Xmx512m"
+  resources:
+    requests: { cpu: 250m, memory: 1Gi }
+    limits:   { cpu: "1",  memory: 2Gi }
+
+chromadb:
+  enabled: true
+  image: chromadb/chroma:latest
+  port: 8000
+  storage: 5Gi
+
+# Kafka in KRaft mode (no ZooKeeper) - fixes the ZooKeeper startup races and
+# deprecation warnings from the docker-compose ZooKeeper-based setup.
+kafka:
+  enabled: true
+  image: confluentinc/cp-kafka:7.6.1
+  port: 9092
+  storage: 5Gi
+  # Fixed cluster id so the StatefulSet can re-format storage deterministically.
+  clusterId: "fuzeinfra-kafka-cluster01"
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits:   { cpu: "1",  memory: 1Gi }
+
+kafkaUi:
+  enabled: true
+  image: provectuslabs/kafka-ui:latest
+  port: 8080
+
+rabbitmq:
+  enabled: true
+  image: rabbitmq:3-management
+  amqpPort: 5672
+  managementPort: 15672
+  storage: 2Gi
+
+# -----------------------------------------------------------------------------
+# Monitoring & logging
+# -----------------------------------------------------------------------------
+prometheus:
+  enabled: true
+  image: prom/prometheus:latest
+  port: 9090
+  storage: 10Gi
+
+grafana:
+  enabled: true
+  image: grafana/grafana:latest
+  port: 3000
+  storage: 2Gi
+
+alertmanager:
+  enabled: true
+  image: prom/alertmanager:latest
+  port: 9093
+  storage: 1Gi
+
+loki:
+  enabled: true
+  image: grafana/loki:2.9.0
+  port: 3100
+  storage: 5Gi
+
+promtail:
+  enabled: true
+  image: grafana/promtail:2.9.0
+
+nodeExporter:
+  enabled: true
+  image: prom/node-exporter:latest
+  port: 9100
+
+# -----------------------------------------------------------------------------
+# Airflow (CeleryExecutor) - workflow orchestration for data pipelines.
+# Reuses the in-cluster Postgres (metadata DB) and Redis (Celery broker).
+# -----------------------------------------------------------------------------
+airflow:
+  enabled: true
+  image: apache/airflow:2.7.0
+  webPort: 8080
+  flowerPort: 5555
+  # Number of Celery workers (scale data pipeline throughput here).
+  workerReplicas: 1
+  # Mount DAGs from a ConfigMap built from airflow-shared/dags? For real use,
+  # prefer git-sync or a baked image. Default: empty dir + example DAG ConfigMap.
+  loadExamples: false

--- a/k8s/aws/gp3-storageclass.yaml
+++ b/k8s/aws/gp3-storageclass.yaml
@@ -1,0 +1,15 @@
+# gp3 StorageClass for EKS (backed by the aws-ebs-csi-driver addon).
+# Apply after the cluster is up:  kubectl apply -f k8s/aws/gp3-storageclass.yaml
+# This becomes the default class so the chart's PVCs (storageClass: gp3) bind.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: gp3
+  encrypted: "true"

--- a/k8s/kind/kind-cluster.yaml
+++ b/k8s/kind/kind-cluster.yaml
@@ -1,0 +1,23 @@
+# kind cluster for FuzeInfra local development.
+# Maps host ports 80/443 to the ingress-nginx controller so *.dev.local works.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: fuzeinfra
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      # Ingress controller HTTP/HTTPS exposed on localhost.
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+  - role: worker
+  - role: worker

--- a/k8s/kind/setup-kind.sh
+++ b/k8s/kind/setup-kind.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Bring up a local FuzeInfra Kubernetes cluster on kind, install the
+# ingress-nginx controller, and deploy the FuzeInfra Helm chart.
+#
+# Prereqs: docker, kind, kubectl, helm.
+# Usage:   ./k8s/kind/setup-kind.sh
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLUSTER_NAME="fuzeinfra"
+NAMESPACE="fuzeinfra"
+
+command -v kind   >/dev/null || { echo "kind not found - https://kind.sigs.k8s.io"; exit 1; }
+command -v kubectl>/dev/null || { echo "kubectl not found"; exit 1; }
+command -v helm   >/dev/null || { echo "helm not found"; exit 1; }
+
+echo "==> Creating kind cluster '$CLUSTER_NAME' (if missing)"
+if ! kind get clusters | grep -qx "$CLUSTER_NAME"; then
+  kind create cluster --config "$SCRIPT_DIR/kind-cluster.yaml"
+else
+  echo "    cluster already exists, reusing"
+fi
+kubectl cluster-info --context "kind-${CLUSTER_NAME}"
+
+echo "==> Installing ingress-nginx (kind provider)"
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+echo "==> Waiting for ingress-nginx controller to be ready"
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=180s
+
+echo "==> Deploying FuzeInfra Helm chart"
+helm upgrade --install fuzeinfra "$REPO_ROOT/helm/fuzeinfra" \
+  --namespace "$NAMESPACE" --create-namespace \
+  -f "$REPO_ROOT/helm/fuzeinfra/values-local.yaml" \
+  --wait --timeout 10m || {
+    echo "Helm install reported a timeout; some heavy images (elasticsearch, kafka)"
+    echo "may still be pulling. Check: kubectl -n $NAMESPACE get pods"
+  }
+
+cat <<EOF
+
+==> Done.
+Add these hostnames to your /etc/hosts (all -> 127.0.0.1) or use the dnsmasq
+wildcard for *.dev.local:
+
+  127.0.0.1 grafana.dev.local prometheus.dev.local airflow.dev.local \\
+            flower.dev.local kafka-ui.dev.local mongo-express.dev.local \\
+            rabbitmq.dev.local neo4j.dev.local alertmanager.dev.local
+
+Then open:  http://grafana.dev.local  (admin / admin)
+Check pods: kubectl -n $NAMESPACE get pods
+EOF

--- a/k8s/kind/teardown-kind.sh
+++ b/k8s/kind/teardown-kind.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Delete the local FuzeInfra kind cluster.
+set -euo pipefail
+CLUSTER_NAME="fuzeinfra"
+echo "==> Deleting kind cluster '$CLUSTER_NAME'"
+kind delete cluster --name "$CLUSTER_NAME"
+echo "==> Done."

--- a/terraform/eks/.terraform/modules/modules.json
+++ b/terraform/eks/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."}]}

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -1,0 +1,109 @@
+# -----------------------------------------------------------------------------
+# FuzeInfra EKS cluster.
+#
+# Builds a VPC, an EKS control plane, a managed node group, and the core addons
+# (CoreDNS, kube-proxy, VPC-CNI, EBS CSI driver) needed to run the FuzeInfra
+# Helm chart with gp3-backed PersistentVolumes.
+#
+# Uses the well-maintained terraform-aws-modules for VPC and EKS.
+# -----------------------------------------------------------------------------
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 3)
+  tags = merge(var.tags, {
+    Cluster = var.cluster_name
+  })
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${var.cluster_name}-vpc"
+  cidr = var.vpc_cidr
+
+  azs             = local.azs
+  private_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k + 8)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Tags required for EKS to discover subnets for load balancers.
+  public_subnet_tags = {
+    "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb"           = "1"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+
+  tags = local.tags
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_public_access_cidrs = var.admin_access_cidrs
+
+  # Give the identity running terraform cluster-admin via an access entry.
+  enable_cluster_creator_admin_permissions = true
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # Core addons. EBS CSI driver gets an IRSA role so gp3 PVCs can be provisioned.
+  cluster_addons = {
+    coredns    = {}
+    kube-proxy = {}
+    vpc-cni    = {}
+    aws-ebs-csi-driver = {
+      service_account_role_arn = module.ebs_csi_irsa.iam_role_arn
+    }
+  }
+
+  eks_managed_node_groups = {
+    default = {
+      instance_types = var.node_instance_types
+      min_size       = var.node_min_size
+      max_size       = var.node_max_size
+      desired_size   = var.node_desired_size
+      disk_size      = var.node_disk_size
+      capacity_type  = "ON_DEMAND"
+      labels = {
+        "fuzeinfra/node" = "shared"
+      }
+    }
+  }
+
+  tags = local.tags
+}
+
+# IRSA role for the EBS CSI driver.
+module "ebs_csi_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+
+  role_name             = "${var.cluster_name}-ebs-csi"
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = local.tags
+}

--- a/terraform/eks/outputs.tf
+++ b/terraform/eks/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_name" {
+  description = "EKS cluster name."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS API server endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_region" {
+  description = "AWS region of the cluster."
+  value       = var.aws_region
+}
+
+output "configure_kubectl" {
+  description = "Command to update your local kubeconfig for this cluster."
+  value       = "aws eks update-kubeconfig --region ${var.aws_region} --name ${module.eks.cluster_name}"
+}
+
+output "vpc_id" {
+  description = "VPC ID hosting the cluster."
+  value       = module.vpc.vpc_id
+}

--- a/terraform/eks/terraform.tfvars.example
+++ b/terraform/eks/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# Copy to terraform.tfvars and adjust.
+aws_region      = "us-east-1"
+cluster_name    = "fuzeinfra"
+cluster_version = "1.29"
+
+# Worker node group sizing.
+node_instance_types = ["t3.large"]
+node_desired_size   = 2
+node_min_size       = 2
+node_max_size       = 4
+node_disk_size      = 50
+
+# IMPORTANT: restrict this to your IP/office CIDR in production.
+admin_access_cidrs = ["0.0.0.0/0"]

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -1,0 +1,65 @@
+variable "aws_region" {
+  description = "AWS region for the EKS cluster."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster."
+  type        = string
+  default     = "fuzeinfra"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version for the EKS control plane."
+  type        = string
+  default     = "1.29"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC created for the cluster."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "node_instance_types" {
+  description = "Instance types for the managed node group."
+  type        = list(string)
+  default     = ["t3.large"]
+}
+
+variable "node_desired_size" {
+  description = "Desired number of worker nodes."
+  type        = number
+  default     = 2
+}
+
+variable "node_min_size" {
+  description = "Minimum number of worker nodes."
+  type        = number
+  default     = 2
+}
+
+variable "node_max_size" {
+  description = "Maximum number of worker nodes."
+  type        = number
+  default     = 4
+}
+
+variable "node_disk_size" {
+  description = "EBS volume size (GiB) per worker node."
+  type        = number
+  default     = 50
+}
+
+variable "admin_access_cidrs" {
+  description = "CIDRs allowed to reach the public EKS API endpoint. Restrict in production."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Additional tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/eks/versions.tf
+++ b/terraform/eks/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Reuse the same remote-state bucket pattern as the EC2 deployment.
+  # Configure via `terraform init -backend-config=...` or edit here.
+  backend "s3" {
+    bucket = "fuzefront-terraform-state"
+    key    = "fuzeinfra/eks/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "FuzeInfra"
+      Component = "eks"
+      ManagedBy = "Terraform"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of migrating FuzeInfra from Docker Compose to **Kubernetes** — the same Helm chart runs locally on **kind** and on AWS via **Amazon EKS**, with **in-cluster StatefulSets** for stateful services (managed-services path documented for later). Also fixes the **Kafka errors** in the Compose stack by moving to KRaft mode.

These were the decisions confirmed up front: kind (local) · EKS (AWS) · Helm (packaging) · in-cluster data now.

## What's included

**Helm chart — `helm/fuzeinfra/`**
- Databases as StatefulSets + PVCs: Postgres, MongoDB, Redis, Neo4j, Elasticsearch, ChromaDB
- Messaging: **Kafka in KRaft mode** (no ZooKeeper), RabbitMQ, Kafka UI, Mongo Express
- Monitoring/logging: Prometheus, Grafana, Alertmanager, Loki (StatefulSets) + Promtail & node-exporter (DaemonSets) with RBAC for service discovery
- **Airflow (CeleryExecutor)**: db-init Job (Helm hook), webserver, scheduler, scalable workers, Flower — reusing in-cluster Postgres + Redis
- Ingress for all web UIs at `<service>.<domain>`; credentials in a Secret; per-environment overlays (`values-local.yaml`, `values-aws.yaml`)
- In-cluster service names match the Compose hostnames (`postgres`, `redis`, `kafka`…), so **app connection strings are unchanged**

**Local cluster — `k8s/kind/`**: one-command bring-up (`make kind-up`) — creates the cluster, installs ingress-nginx, deploys the chart.

**AWS — `terraform/eks/`**: VPC, EKS control plane, managed node group, core addons (CoreDNS, kube-proxy, VPC-CNI, EBS CSI with IRSA); `k8s/aws/gp3-storageclass.yaml` for the chart's PVCs.

**Kafka fix — `docker-compose.FuzeInfra.yml`**: converted Kafka to single-node KRaft (ZooKeeper removed), added a healthcheck, and updated Kafka UI to bootstrap-only. This removes the ZooKeeper startup-race / deprecation errors seen in `docker logs fuzeinfra-kafka`.

**Also**: `Makefile`, `docs/kubernetes-migration.md`, and a `helm-validate.yml` CI workflow (lint + kubeconform).

## Validation

| Check | Result |
|-------|--------|
| `helm lint` (3 overlays) | ✅ pass |
| `helm template` + `kubeconform -strict` (k8s 1.29) | ✅ 49/49 valid |
| `docker compose config` | ✅ valid |
| `terraform fmt` | ✅ clean |

## ⚠️ Not validated in the build environment
- **Live deploys** (`kind`, EKS) and **`terraform plan/apply`** were not run — the sandbox has no running Docker daemon and blocks `registry.terraform.io` (the community VPC/EKS modules can't be fetched there). HCL is `fmt`-clean and uses standard module usage; run `terraform init && plan` where the registry is reachable.
- ⚠️ **Kafka KRaft is an on-disk format change.** Existing local volumes must be removed before `infra-up`: `docker volume rm fuzeinfra_kafka_data fuzeinfra_zookeeper_data fuzeinfra_zookeeper_logs`

## Notes / open items for review
- Airflow DAGs ship as an example ConfigMap for an out-of-the-box demo; production should use git-sync or a baked image (tracked in the roadmap).
- dnsmasq and the cloudflare-tunnel services are intentionally **not** ported to the chart yet (CoreDNS/Ingress replace dnsmasq; tunnel can be added if external access is needed).

See `docs/kubernetes-migration.md` for full run instructions and the next-phase roadmap.

https://claude.ai/code/session_01PY2gV4J2QcXi8fAUh3oN5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01PY2gV4J2QcXi8fAUh3oN5M)_