### PR TITLE
Port dnsmasq and cloudflare-tunnel to the Helm chart

### DIFF
--- a/docs/kubernetes-migration.md
+++ b/docs/kubernetes-migration.md
@@ -50,8 +50,8 @@ self-heal, and diverge between "local" and "cloud". Kubernetes gives us:
 | prometheus, grafana, alertmanager, loki | StatefulSet + PVC | Configs as ConfigMaps |
 | promtail, node-exporter | DaemonSet | Per-node log/metric collection |
 | nginx (reverse proxy) | **Ingress** (ingress-nginx) | `*.dev.local` / `*.infra.<domain>` |
-| dnsmasq | **CoreDNS** (built-in) + host DNS | Not deployed by the chart |
-| cloudflare-tunnel | (optional, not in chart yet) | Add later if external access needed |
+| dnsmasq | Deployment + Service (optional) | CoreDNS handles in-cluster DNS; dnsmasq serves the wildcard dev domain. Off by default, on in `values-local`. |
+| cloudflare-tunnel | Deployment (optional, token from Secret) | Off by default; enable + set `credentials.cloudflare.tunnelToken` |
 | airflow-* (init/webserver/scheduler/worker/flower) | Job (Helm hook) + Deployments | CeleryExecutor, Redis broker, Postgres backend |
 
 Stateful data services run **in-cluster** for now (StatefulSets), with a

--- a/helm/fuzeinfra/templates/dns-tunnel.yaml
+++ b/helm/fuzeinfra/templates/dns-tunnel.yaml
@@ -1,0 +1,159 @@
+{{- /* ===================== dnsmasq (optional local DNS) ===================== */ -}}
+{{- if .Values.dnsmasq.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnsmasq-config
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+data:
+  dnsmasq.conf: |
+    # dnsmasq for FuzeInfra - resolves the wildcard dev domain.
+    # In-cluster service discovery is handled by CoreDNS; this serves
+    # *.{{ .Values.global.domain }} for host-side / external resolution.
+    port=53
+    no-resolv
+    server=8.8.8.8
+    server=8.8.4.4
+    # Wildcard: *.{{ .Values.global.domain }} -> configured target
+    address=/{{ .Values.global.domain }}/{{ .Values.dnsmasq.wildcardTarget }}
+    cache-size=1000
+    no-hosts
+    bind-interfaces
+    listen-address=0.0.0.0
+    domain={{ .Values.global.domain }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dnsmasq
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 4 }}
+spec:
+  type: {{ .Values.dnsmasq.serviceType }}
+  selector:
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 4 }}
+  ports:
+    - name: dns-udp
+      port: {{ .Values.dnsmasq.dnsPort }}
+      targetPort: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: {{ .Values.dnsmasq.dnsPort }}
+      targetPort: 53
+      protocol: TCP
+    - name: http
+      port: {{ .Values.dnsmasq.webPort }}
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dnsmasq
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll the pod when the config changes.
+        checksum/config: {{ .Values.global.domain | printf "%s-%s" .Values.dnsmasq.wildcardTarget | sha256sum }}
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 8 }}
+    spec:
+      containers:
+        - name: dnsmasq
+          image: {{ .Values.dnsmasq.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          env:
+            - name: HTTP_USER
+              value: "admin"
+            - name: HTTP_PASS
+              value: {{ .Values.dnsmasq.adminPassword | quote }}
+          ports:
+            - containerPort: 53
+              protocol: UDP
+            - containerPort: 53
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dnsmasq.conf
+              subPath: dnsmasq.conf
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: dnsmasq-config
+{{- end }}
+
+{{- /* ===================== cloudflare-tunnel (optional) ===================== */ -}}
+{{- if .Values.cloudflareTunnel.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflare-tunnel
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.cloudflareTunnel.replicas }}
+  selector:
+    matchLabels:
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "cloudflare-tunnel") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" . | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "cloudflare-tunnel") | nindent 8 }}
+    spec:
+      containers:
+        - name: cloudflared
+          image: {{ .Values.cloudflareTunnel.image }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+          # Token-based tunnel: ingress routes are managed in the Cloudflare
+          # Zero Trust dashboard (mirrors the docker-compose `tunnel run --token`).
+          args:
+            - tunnel
+            - --no-autoupdate
+            - --metrics
+            - 0.0.0.0:{{ .Values.cloudflareTunnel.metricsPort }}
+            - run
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzeinfra.secretName" . }}
+                  key: CLOUDFLARE_TUNNEL_TOKEN
+          ports:
+            - containerPort: {{ .Values.cloudflareTunnel.metricsPort }}
+              name: metrics
+          # cloudflared exposes a readiness endpoint on the metrics port.
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+{{- end }}

--- a/helm/fuzeinfra/templates/secrets.yaml
+++ b/helm/fuzeinfra/templates/secrets.yaml
@@ -21,4 +21,5 @@ stringData:
   AIRFLOW_ADMIN_USER: {{ .Values.credentials.airflow.adminUser | quote }}
   AIRFLOW_ADMIN_PASSWORD: {{ .Values.credentials.airflow.adminPassword | quote }}
   AIRFLOW_FERNET_KEY: {{ .Values.credentials.airflow.fernetKey | quote }}
+  CLOUDFLARE_TUNNEL_TOKEN: {{ .Values.credentials.cloudflare.tunnelToken | quote }}
 {{- end }}

--- a/helm/fuzeinfra/values-aws.yaml
+++ b/helm/fuzeinfra/values-aws.yaml
@@ -44,6 +44,19 @@ prometheus:
 airflow:
   workerReplicas: 2
 
+# DNS & external access on EKS:
+# - dnsmasq is usually unnecessary on AWS (use Route53 / Cloudflare for the real
+#   domain). Leave it off. Enable only if you want an in-cluster resolver.
+dnsmasq:
+  enabled: false
+
+# - cloudflare-tunnel gives secure external access without a public LB. To enable,
+#   set cloudflareTunnel.enabled=true and provide the token (prefer an existing
+#   Secret via credentials.existingSecret).
+cloudflareTunnel:
+  enabled: false
+  # replicas: 2   # run multiple replicas for HA once enabled
+
 # NOTE: The "managed services later" path - when you are ready to move
 # stateful services to RDS/ElastiCache/MSK/OpenSearch, disable them here
 # (e.g. postgres.enabled: false) and point apps/airflow at the managed

--- a/helm/fuzeinfra/values-local.yaml
+++ b/helm/fuzeinfra/values-local.yaml
@@ -23,3 +23,15 @@ elasticsearch:
 
 airflow:
   workerReplicas: 1
+
+# Optional local DNS server for *.dev.local. Exposed in-cluster; query it via the
+# dnsmasq Service. CoreDNS still handles in-cluster service names.
+dnsmasq:
+  enabled: true
+  wildcardTarget: "127.0.0.1"
+  serviceType: ClusterIP
+
+# cloudflare-tunnel stays off locally (needs a real tunnel token). To enable:
+#   cloudflareTunnel.enabled=true and set credentials.cloudflare.tunnelToken
+cloudflareTunnel:
+  enabled: false

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -48,6 +48,10 @@ credentials:
     # Fernet key for Airflow connection encryption. Generate a real one with:
     #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
     fernetKey: "Zp9p8x0Q3y0sJpQ8m2nq3l4F6tH9wXyZ1aB2cD3eF4="
+  cloudflare:
+    # Tunnel token from the Cloudflare Zero Trust dashboard. Required only when
+    # cloudflareTunnel.enabled=true. Prefer supplying via an existing Secret.
+    tunnelToken: ""
 
 # -----------------------------------------------------------------------------
 # Ingress (replaces the docker-compose nginx reverse proxy). Web UIs are exposed
@@ -198,3 +202,33 @@ airflow:
   # Mount DAGs from a ConfigMap built from airflow-shared/dags? For real use,
   # prefer git-sync or a baked image. Default: empty dir + example DAG ConfigMap.
   loadExamples: false
+
+# -----------------------------------------------------------------------------
+# DNS & external access
+# -----------------------------------------------------------------------------
+# dnsmasq: optional in-cluster DNS server that resolves the wildcard dev domain
+# (*.<global.domain>) to a single target. In-cluster service discovery is already
+# handled by CoreDNS, so this is OFF by default and mainly useful for kind where
+# you want *.dev.local resolution served from the cluster.
+dnsmasq:
+  enabled: false
+  image: jpillora/dnsmasq:latest
+  dnsPort: 53
+  webPort: 8080
+  # Where *.<global.domain> resolves to. For host-side resolution keep 127.0.0.1;
+  # set to the ingress controller address to route into the cluster.
+  wildcardTarget: "127.0.0.1"
+  adminPassword: admin123
+  # ClusterIP | NodePort | LoadBalancer. Use LoadBalancer/NodePort to use this as
+  # an actual DNS server from outside the cluster.
+  serviceType: ClusterIP
+
+# cloudflare-tunnel: optional cloudflared Deployment for secure external access /
+# webhook endpoints. OFF by default; requires credentials.cloudflare.tunnelToken
+# (or an existing Secret). Ingress routing is configured in the Cloudflare
+# Zero Trust dashboard (token-based tunnel), mirroring the docker-compose setup.
+cloudflareTunnel:
+  enabled: false
+  image: cloudflare/cloudflared:latest
+  metricsPort: 2000
+  replicas: 1


### PR DESCRIPTION
## Summary

Follow-up to the Phase 1 Kubernetes migration (#4). Ports the two remaining Docker Compose services — **dnsmasq** and **cloudflare-tunnel** — into the Helm chart as **optional, flag-gated** components, so the chart now covers the full original stack.

Kept deliberately small and additive (per the "don't do too much in one PR" guidance): no changes to existing workloads, only new templates + values/secret wiring.

## What's included

**dnsmasq — `helm/fuzeinfra/templates/dns-tunnel.yaml`**
- ConfigMap + Service + Deployment serving the wildcard dev domain (`*.<global.domain>` → `dnsmasq.wildcardTarget`).
- In-cluster service discovery is already handled by CoreDNS, so this is **off by default** and **enabled in `values-local`** (kind), where `*.dev.local` resolution is useful.
- `serviceType` supports `ClusterIP` / `NodePort` / `LoadBalancer` to use it as a real resolver from outside the cluster; runs with `NET_ADMIN` (matching the compose `cap_add`).

**cloudflare-tunnel — same template**
- `cloudflared` Deployment using a **token-based tunnel** (mirrors the compose `tunnel run --token`), token sourced from the chart Secret (`credentials.cloudflare.tunnelToken`, key `CLOUDFLARE_TUNNEL_TOKEN`).
- **Off by default** everywhere; ingress routing is managed in the Cloudflare Zero Trust dashboard. Readiness/liveness via the cloudflared `/ready` metrics endpoint.

**Wiring**: `values.yaml` (new `dnsmasq` + `cloudflareTunnel` blocks, `credentials.cloudflare.tunnelToken`), `secrets.yaml` (adds the token key), `values-local.yaml` / `values-aws.yaml` overlays, and `docs/kubernetes-migration.md` updated.

## Validation

| Check | Result |
|-------|--------|
| `helm lint` (base / local / aws) | ✅ pass |
| `kubeconform -strict` (k8s 1.29), local overlay | ✅ 52/52 valid (incl. dnsmasq) |
| `kubeconform -strict`, tunnel enabled | ✅ 53/53 valid |

## Not validated in the build environment
Same constraints as #4: no running Docker daemon / no live cluster here, so an actual kind/EKS deploy of these two components wasn't exercised. The token-based tunnel additionally needs a real `CLOUDFLARE_TUNNEL_TOKEN` to come up.

## Note on CI
The `infrastructure-tests.yml` check is **red on `main` and every historical run** (pre-existing: missing nginx cert + cloudflare token in CI; never emits `test-results.xml`) — unrelated to this change. The Helm validation workflow added in #4 is the relevant gate here.

https://claude.ai/code/session_01PY2gV4J2QcXi8fAUh3oN5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01PY2gV4J2QcXi8fAUh3oN5M)_