### PR TITLE
Add Argo CD GitOps layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,28 @@ eks-plan:
 .PHONY: eks-apply
 eks-apply:
 	cd terraform/eks && terraform apply
+
+# ----------------------------------------------------------------------------
+# Argo CD (GitOps) - see docs/gitops.md
+# ----------------------------------------------------------------------------
+# ENV selects which Application to bootstrap: local (kind) or aws (EKS).
+ENV ?= local
+
+.PHONY: argocd-install
+argocd-install:
+	./argocd/install/setup-argocd.sh $(ENV)
+
+.PHONY: argocd-password
+argocd-password:
+	@kubectl -n argocd get secret argocd-initial-admin-secret \
+	  -o jsonpath="{.data.password}" | base64 -d; echo
+
+.PHONY: argocd-ui
+argocd-ui:
+	@echo "Argo CD UI at https://localhost:8080 (user: admin)"
+	kubectl -n argocd port-forward svc/argocd-server 8080:443
+
+.PHONY: argocd-status
+argocd-status:
+	kubectl -n argocd get applications
+

--- a/argocd/applications/fuzeinfra-aws.yaml
+++ b/argocd/applications/fuzeinfra-aws.yaml
@@ -1,0 +1,40 @@
+# Argo CD Application for AWS (EKS).
+# Deploys helm/fuzeinfra with the aws overlay into the fuzeinfra namespace.
+# Apply on the EKS cluster only:  kubectl apply -f argocd/applications/fuzeinfra-aws.yaml
+#
+# Prereqs on the cluster (see terraform/eks + docs/kubernetes-migration.md):
+#   - gp3 default StorageClass, ingress-nginx controller.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzeinfra-aws
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: fuzeinfra
+  source:
+    repoURL: https://github.com/izzywdev/FuzeInfra.git
+    targetRevision: main
+    path: helm/fuzeinfra
+    helm:
+      valueFiles:
+        - values-aws.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzeinfra
+  syncPolicy:
+    # selfHeal keeps the cluster matching git; prune removes deleted resources.
+    # For a more conservative prod posture, remove `automated` and sync manually.
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m

--- a/argocd/applications/fuzeinfra-local.yaml
+++ b/argocd/applications/fuzeinfra-local.yaml
@@ -1,0 +1,35 @@
+# Argo CD Application for a LOCAL (kind) cluster.
+# Deploys helm/fuzeinfra with the local overlay into the fuzeinfra namespace.
+# Apply on the kind cluster only:  kubectl apply -f argocd/applications/fuzeinfra-local.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzeinfra-local
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: fuzeinfra
+  source:
+    repoURL: https://github.com/izzywdev/FuzeInfra.git
+    targetRevision: main
+    path: helm/fuzeinfra
+    helm:
+      valueFiles:
+        - values-local.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzeinfra
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/install/setup-argocd.sh
+++ b/argocd/install/setup-argocd.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Install Argo CD into the current kube-context and bootstrap the FuzeInfra
+# GitOps Application (App points at helm/fuzeinfra in this repo).
+#
+# Prereqs: kubectl, helm not required (Argo renders Helm itself).
+# Usage:
+#   ./argocd/install/setup-argocd.sh local   # bootstrap fuzeinfra-local (kind)
+#   ./argocd/install/setup-argocd.sh aws     # bootstrap fuzeinfra-aws  (EKS)
+#   ./argocd/install/setup-argocd.sh none    # install Argo CD only, no app
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARGOCD_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENVIRONMENT="${1:-local}"
+# Pin Argo CD for reproducibility; bump deliberately.
+ARGOCD_VERSION="${ARGOCD_VERSION:-v2.13.3}"
+
+command -v kubectl >/dev/null || { echo "kubectl not found"; exit 1; }
+
+echo "==> Installing Argo CD ${ARGOCD_VERSION} into namespace 'argocd'"
+kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n argocd \
+  -f "https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml"
+
+echo "==> Waiting for Argo CD server to be ready"
+kubectl -n argocd rollout status deploy/argocd-server --timeout=300s
+
+echo "==> Applying FuzeInfra AppProject"
+kubectl apply -f "$ARGOCD_DIR/projects/fuzeinfra.yaml"
+
+case "$ENVIRONMENT" in
+  local)
+    echo "==> Bootstrapping Application fuzeinfra-local"
+    kubectl apply -f "$ARGOCD_DIR/applications/fuzeinfra-local.yaml"
+    ;;
+  aws)
+    echo "==> Bootstrapping Application fuzeinfra-aws"
+    kubectl apply -f "$ARGOCD_DIR/applications/fuzeinfra-aws.yaml"
+    ;;
+  none)
+    echo "==> Skipping Application bootstrap (env=none)"
+    ;;
+  *)
+    echo "Unknown environment '$ENVIRONMENT' (use: local | aws | none)"; exit 1
+    ;;
+esac
+
+echo
+echo "==> Argo CD admin password:"
+kubectl -n argocd get secret argocd-initial-admin-secret \
+  -o jsonpath="{.data.password}" 2>/dev/null | base64 -d || \
+  echo "(secret not found - it may have been rotated/deleted after first login)"
+echo
+cat <<'EOF'
+
+==> Open the Argo CD UI:
+  kubectl -n argocd port-forward svc/argocd-server 8080:443
+  then browse https://localhost:8080  (user: admin)
+
+NOTE: if this repo is PRIVATE, register repo credentials so Argo CD can read it:
+  argocd repo add https://github.com/izzywdev/FuzeInfra.git \
+    --username <user> --password <token>
+  (or create a repository Secret labeled argocd.argoproj.io/secret-type=repository)
+EOF

--- a/argocd/projects/fuzeinfra.yaml
+++ b/argocd/projects/fuzeinfra.yaml
@@ -1,0 +1,23 @@
+# Argo CD AppProject scoping FuzeInfra: which repo it may deploy from and where.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: fuzeinfra
+  namespace: argocd
+spec:
+  description: FuzeInfra shared infrastructure platform
+  sourceRepos:
+    - https://github.com/izzywdev/FuzeInfra.git
+  destinations:
+    - namespace: fuzeinfra
+      server: https://kubernetes.default.svc
+    - namespace: argocd
+      server: https://kubernetes.default.svc
+  # The chart creates cluster-scoped objects (monitoring ClusterRole/Binding),
+  # so cluster resources must be allowed for this project.
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -1,0 +1,143 @@
+# GitOps with Argo CD
+
+FuzeInfra is delivered to Kubernetes via **Argo CD**: Argo CD watches this repo
+and continuously syncs the `helm/fuzeinfra` chart into the cluster. Push to
+`main` → Argo CD reconciles the cluster to match. The same model works on a
+local `kind` cluster and on EKS — only the values overlay differs.
+
+## Layout
+
+```
+argocd/
+  projects/fuzeinfra.yaml            # AppProject: allowed repo + destinations
+  applications/fuzeinfra-local.yaml  # App -> helm/fuzeinfra (values-local.yaml)
+  applications/fuzeinfra-aws.yaml    # App -> helm/fuzeinfra (values-aws.yaml)
+  install/setup-argocd.sh            # install Argo CD + bootstrap an App
+```
+
+Argo CD itself is **bootstrapped separately** from the app it manages (it must
+not be part of the chart it deploys). Once installed, the `Application` is the
+only thing you apply by hand; everything else flows through git.
+
+## Quick start (local / kind)
+
+```bash
+# 0) bring up the local cluster (ingress etc.)
+make kind-up                      # or ./k8s/kind/setup-kind.sh
+
+# 1) install Argo CD and bootstrap the local Application
+make argocd-install ENV=local     # or ./argocd/install/setup-argocd.sh local
+
+# 2) get the admin password and open the UI
+make argocd-password
+make argocd-ui                    # port-forward https://localhost:8080 (user: admin)
+```
+
+Argo CD will sync `helm/fuzeinfra` (values-local.yaml) into the `fuzeinfra`
+namespace and self-heal it. Check status:
+
+```bash
+kubectl -n argocd get applications
+kubectl -n fuzeinfra get pods
+```
+
+> If you used `make kind-up`, the chart is already installed via Helm. Let Argo
+> CD adopt it (it will reconcile the same resources), or skip the Helm install
+> and let Argo CD own it from the start — pick one owner to avoid drift.
+
+## AWS (EKS)
+
+```bash
+aws eks update-kubeconfig --region us-east-1 --name fuzeinfra
+kubectl apply -f k8s/aws/gp3-storageclass.yaml      # default storage
+# install ingress-nginx (see docs/kubernetes-migration.md)
+make argocd-install ENV=aws                          # bootstraps fuzeinfra-aws
+```
+
+## Private repository
+
+If `izzywdev/FuzeInfra` is private, Argo CD needs read credentials:
+
+```bash
+argocd repo add https://github.com/izzywdev/FuzeInfra.git \
+  --username <user> --password <personal-access-token>
+```
+
+or create a `Secret` in `argocd` labeled
+`argocd.argoproj.io/secret-type=repository`.
+
+## How Helm hooks behave
+
+Argo CD renders the chart with `helm template` and converts Helm hooks to Argo
+resource hooks. The chart's `airflow-init` Job (`helm.sh/hook: post-install,
+post-upgrade`) runs as an Argo **PostSync** hook — DB migration/bootstrap still
+happens automatically on each sync.
+
+## Sync policy
+
+Both Applications use `automated` sync with `prune` + `selfHeal`, plus
+`CreateNamespace=true` and `ServerSideApply=true`. For a more conservative
+production posture on EKS, drop the `automated` block in
+`applications/fuzeinfra-aws.yaml` and sync deliberately (`argocd app sync
+fuzeinfra-aws`).
+
+---
+
+# Branch protection for `main`
+
+To make CI a real gate (and to let GitHub **auto-merge** queue PRs until checks
+pass), protect `main` and require the CI check. `test-infrastructure` runs on
+every PR to `main`, so it's the right required check. (Don't require
+`Lint & schema-validate chart` as mandatory — it only runs on `helm/**` changes,
+so requiring it would block PRs that don't touch the chart, since the check would
+never report.)
+
+## Option A — GitHub UI
+
+**Settings → Branches → Add branch ruleset (or Add rule)** for `main`:
+
+- **Require a pull request before merging**: on
+  - Required approvals: `0` (or `1` if you want review gating)
+- **Require status checks to pass before merging**: on
+  - **Require branches to be up to date before merging**: on
+  - Search and add the check: **`test-infrastructure`**
+- **Do not allow bypassing the above settings**: optional
+- Leave force-pushes and deletions disabled.
+
+Then **Settings → General → Pull Requests → Allow auto-merge** (already enabled).
+
+## Option B — `gh` CLI (exact config)
+
+```bash
+gh api -X PUT repos/izzywdev/FuzeInfra/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["test-infrastructure"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": true
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+```
+
+Notes:
+- `strict: true` = PRs must be up to date with `main` before merging.
+- `required_approving_review_count: 0` keeps a solo workflow unblocked; set to
+  `1` to require a review.
+- To also gate on the Helm chart, change `.github/workflows/helm-validate.yml` to
+  run on all PRs (remove the `paths:` filter) and add
+  `"Lint & schema-validate chart"` to `contexts`.
+
+With this in place, enabling auto-merge on a PR makes GitHub merge it
+automatically once `test-infrastructure` is green.


### PR DESCRIPTION
## Summary

Brings **Argo CD** in as the GitOps delivery layer for FuzeInfra. Argo CD watches this repo and continuously syncs the `helm/fuzeinfra` chart into the cluster — push to `main` → the cluster reconciles. Same model on local `kind` and on EKS; only the values overlay differs.

Argo CD is bootstrapped **separately** from the chart it manages (it must not be part of the chart it deploys). After install, the `Application` is the only thing applied by hand; everything else flows through git.

## What's included

```
argocd/
  projects/fuzeinfra.yaml            # AppProject: allowed source repo + destinations
  applications/fuzeinfra-local.yaml  # App -> helm/fuzeinfra (values-local.yaml)  [kind]
  applications/fuzeinfra-aws.yaml    # App -> helm/fuzeinfra (values-aws.yaml)    [EKS]
  install/setup-argocd.sh            # install Argo CD (pinned) + bootstrap an App
```

- **AppProject** scopes the repo and destinations, and whitelists cluster resources (the chart creates the monitoring `ClusterRole`/`ClusterRoleBinding`).
- **Applications** use `automated` sync with `prune` + `selfHeal`, plus `CreateNamespace=true` and `ServerSideApply=true`. The chart's `airflow-init` Helm hook becomes an Argo **PostSync** hook, so DB migration/bootstrap still runs on each sync.
- **Makefile**: `argocd-install` (`ENV=local|aws`), `argocd-password`, `argocd-ui`, `argocd-status`.
- **docs/gitops.md**: full GitOps workflow, private-repo credential setup, Helm-hook behavior — **and the exact branch-protection config** (both GitHub UI steps and a ready-to-run `gh api` command) to gate `main` on the `test-infrastructure` check so auto-merge can queue PRs to green.

## Usage

```bash
make kind-up                 # local cluster
make argocd-install ENV=local
make argocd-password && make argocd-ui   # https://localhost:8080 (admin)
```

## Validation here
- All Argo CD manifests YAML-parse; `kubeconform -ignore-missing-schemas` passes (the Argo CRD kinds are skipped — expected without the CRD schemas).
- Makefile parses (`make -n` dry-runs the new targets).

## Caveats (can't be checked in this sandbox)
- No running cluster here, so an actual Argo CD install/sync wasn't exercised; the manifests follow standard Argo CD `Application`/`AppProject` shape.
- If `izzywdev/FuzeInfra` is **private**, Argo CD needs repo read credentials (documented in `docs/gitops.md`).
- This PR only touches `argocd/`, `Makefile`, and `docs/` — it doesn't change the chart or workflows, so the heavy `test-infrastructure` CI won't run on it (no app changes); that's expected.

https://claude.ai/code/session_01PY2gV4J2QcXi8fAUh3oN5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01PY2gV4J2QcXi8fAUh3oN5M)_