### PR TITLE
feat(runners): org-level ARC staging runner for izzywdev

### DIFF
--- a/argocd/applications/arc-runners.yaml
+++ b/argocd/applications/arc-runners.yaml
@@ -1,0 +1,65 @@
+# =============================================================================
+# Optional: ArgoCD Application for the ARC runner scale set (GitOps management).
+#
+# IMPORTANT: The ARC *controller* must be bootstrapped first via install.sh
+# (Helm + CRD install).  Only the runner scale set is managed here by ArgoCD.
+#
+# Apply after bootstrap:
+#   kubectl apply -f argocd/applications/arc-runners.yaml
+# =============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners-staging
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Remind operators not to register against GitHub from CI without approval.
+    platform.izzywdev/registration-note: >
+      GitHub runner registration is triggered automatically when the
+      arc-runner-github-app Secret exists in arc-runners.  Do not apply this
+      Application in a new environment without first creating that Secret.
+spec:
+  project: fuzeinfra
+  source:
+    repoURL: https://github.com/izzywdev/FuzeInfra.git
+    targetRevision: main
+    chart: gha-runner-scale-set
+    # Helm chart pulled directly from OCI registry via ArgoCD's Helm OCI support.
+    # Requires ArgoCD >= 2.8 with HELM_ENABLE_OCI=1 (set in argocd-cm or env).
+    helm:
+      releaseName: staging
+      valueFiles:
+        # ArgoCD resolves this relative path against the source repo root.
+        - runners/arc/runner-scale-set-values.yaml
+  # Alternate source using the OCI chart directly (ArgoCD Helm OCI mode):
+  # source:
+  #   repoURL: ghcr.io/actions/actions-runner-controller-charts
+  #   chart: gha-runner-scale-set
+  #   targetRevision: "0.9.*"
+  #   helm:
+  #     releaseName: staging
+  #     values: |
+  #       githubConfigUrl: "https://github.com/izzywdev"
+  #       githubConfigSecret: arc-runner-github-app
+  #       runnerGroup: staging-runners
+  #       runnerScaleSetName: staging
+  #       minRunners: 0
+  #       maxRunners: 5
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/projects/fuzeinfra.yaml
+++ b/argocd/projects/fuzeinfra.yaml
@@ -13,6 +13,10 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: argocd
       server: https://kubernetes.default.svc
+    - namespace: arc-systems
+      server: https://kubernetes.default.svc
+    - namespace: arc-runners
+      server: https://kubernetes.default.svc
   # The chart creates cluster-scoped objects (monitoring ClusterRole/Binding),
   # so cluster resources must be allowed for this project.
   clusterResourceWhitelist:

--- a/runners/README.md
+++ b/runners/README.md
@@ -1,0 +1,320 @@
+# Shared Staging Runner — org-level GitHub Actions Self-Hosted Runner
+
+This directory provisions a **shared, org-level GitHub Actions self-hosted runner** for the
+`izzywdev` organization.  It lives in the same `fuzeinfra` kind/EKS cluster that hosts the
+shared platform stack, and it is **consumer-agnostic** — no application-specific names,
+namespaces, or logic appear here.
+
+## Contents
+
+```
+runners/
+├── arc/
+│   ├── controller-values.yaml       # Helm values for ARC controller (arc-systems ns)
+│   ├── runner-scale-set-values.yaml # Helm values for the runner scale set (arc-runners ns)
+│   ├── github-secret.yaml           # Secret TEMPLATE — fill before applying
+│   └── install.sh                   # Bootstrap: install controller + scale set
+└── rbac/
+    ├── deployer-role.yaml           # Namespaced Role for deploy operations
+    └── deployer-rolebinding.yaml    # RoleBinding: runner SA → deployer Role
+```
+
+ArgoCD application (optional GitOps management of the scale set):
+
+```
+argocd/applications/arc-runners.yaml
+```
+
+---
+
+## Design decisions
+
+### 1. Registration scope: org-level runner group
+
+The runner registers at the **`izzywdev` organization level**, not at any individual repo.
+It is placed in a **runner group named `staging-runners`** (create it manually in
+[GitHub Settings → Actions → Runner groups](https://github.com/organizations/izzywdev/settings/actions/runner-groups)).
+
+Set that group's "Repository access" to an **explicit repo allowlist**, not "All repositories".
+Every repo that should access this runner must be explicitly added to the group.  This is the
+primary access-control boundary for which repos can schedule jobs on the runner.
+
+### 2. Mechanism: Actions Runner Controller (ARC) scale sets — recommended
+
+ARC v0.9+ "scale set" mode is used (not the legacy `HorizontalRunnerAutoscaler` approach).
+
+| Feature | ARC scale sets | Long-lived Deployment |
+|---|---|---|
+| Freshness | Fresh pod per job (ephemeral) | Shared persistent pod |
+| Security | No cross-job contamination | State may leak between jobs |
+| Idle cost | Scales to 0 when idle | Always-on pod |
+| Complexity | Helm + CRD | Single Deployment |
+
+**ARC is strongly recommended** for a shared privileged runner.  The ephemeral model
+(one pod per job, terminated after) prevents workspace contamination and credential leakage
+between unrelated jobs from different repos.
+
+The lighter long-lived Deployment approach is documented below for reference but should only
+be used for non-sensitive, single-repo scenarios.
+
+### 3. GitHub authentication: GitHub App (recommended) vs PAT
+
+| | GitHub App | Personal Access Token (PAT) |
+|---|---|---|
+| Scope | Org-level, scoped permissions | Often user-level, broad |
+| Rotation | Key rotation without invalidating other tokens | Token must be rotated manually |
+| Audit | Actions logged under App identity | Actions logged under user identity |
+| Setup | Slightly more steps | Simpler |
+
+**Recommendation: GitHub App.**  See [Creating the credential](#creating-the-credential).
+
+### 4. Cluster permissions: least-privilege deployer ServiceAccount
+
+The runner pod runs as **`arc-runner-sa`** in the **`arc-runners`** namespace.
+
+At install time, this SA has **zero permissions** in the cluster.  It only gains access to a
+staging namespace when the platform team applies the `runners/rbac/` templates there — a
+deliberate onboarding step.  The runner can only operate in namespaces where a RoleBinding
+was explicitly created.
+
+The `deployer` Role grants only:
+- `apps`: Deployments, ReplicaSets, StatefulSets, DaemonSets (CRUD)
+- `core`: Services, ConfigMaps, Pods (read-only), Secrets (write-only, no read)
+- `networking.k8s.io`: Ingresses (CRUD)
+- `autoscaling`: HPAs (CRUD)
+
+No cluster-scoped resources.  No exec, no port-forward, no log access.
+
+### 5. Consumer-agnostic design
+
+Zero references to any specific application, team, or namespace appear in this directory.
+Consumer repos are identified only by their presence in the runner-group allowlist (managed
+in GitHub UI) and by the RoleBinding the platform team applies in their namespace.
+
+---
+
+## Security boundary
+
+> **Read this section before deploying.**
+
+A shared self-hosted runner executes **arbitrary workflow YAML from any allowlisted repo**
+on a Kubernetes identity with in-cluster access.  The mitigations below together define the
+trust boundary:
+
+| Threat | Mitigation |
+|---|---|
+| Cross-job contamination | Ephemeral ARC pods — each job gets a clean pod, terminated after |
+| Privilege escalation via runner | `arc-runner-sa` has zero cluster permissions except explicit RoleBindings; runner container runs non-root with dropped capabilities |
+| Rogue repo in the org gaining runner access | Runner group with explicit allowlist — repos must be added manually |
+| Fork PRs executing privileged jobs | Do NOT set `pull_request_target` without careful review; use `pull_request` (no write token) for untrusted forks |
+| Long-lived credentials in runner environment | GitHub App private key lives in a Kubernetes Secret in `arc-runners`; not exposed to job environment |
+| Lateral movement to other namespaces | Namespaced RoleBindings only — the runner cannot reach any namespace without an explicit grant |
+
+**Trust boundary:** any workflow in an allowlisted repo that runs on `[self-hosted, staging]`
+executes code with the ability to deploy workloads into staging namespaces where the RBAC
+has been granted.  Treat the runner-group allowlist as a security boundary equivalent to
+org membership for the staging cluster.
+
+---
+
+## Prerequisites
+
+- `kubectl` configured against the target cluster
+- `helm` >= 3.10
+- ArgoCD running in the cluster (for GitOps mode; optional otherwise)
+- The `fuzeinfra` kind cluster (`k8s/kind/kind-cluster.yaml`) or the EKS cluster
+
+---
+
+## Creating the credential
+
+### Option A — GitHub App (recommended)
+
+1. Go to [New GitHub App](https://github.com/organizations/izzywdev/settings/apps/new)
+2. Fill in:
+   - **Name**: `izzywdev-arc-runner`
+   - **Homepage URL**: `https://github.com/izzywdev`
+   - **Webhook**: disabled
+3. Under **Permissions → Organization permissions**, set:
+   - **Self-hosted runners**: Read & Write
+4. Under **Where can this GitHub App be installed?**: select **Only on this account**
+5. Click **Create GitHub App**; note the **App ID**
+6. Scroll to **Private keys** → **Generate a private key**; download the `.pem` file
+7. Click **Install App** → Install on `izzywdev`; note the **Installation ID** from the URL
+   (`/installations/<INSTALLATION_ID>`)
+8. Create the Kubernetes Secret:
+
+```bash
+kubectl -n arc-runners create secret generic arc-runner-github-app \
+  --from-literal=github_app_id=<APP_ID> \
+  --from-literal=github_app_installation_id=<INSTALLATION_ID> \
+  --from-literal=github_app_private_key="$(cat /path/to/private-key.pem)"
+```
+
+### Option B — PAT (simpler, not recommended for shared runners)
+
+1. Create a Classic PAT with scopes: `repo` (full), `admin:org` → `manage_runners:org`
+2. Create the Secret:
+
+```bash
+kubectl -n arc-runners create secret generic arc-runner-github-app \
+  --from-literal=github_token=<YOUR_PAT>
+```
+
+---
+
+## Installing the runner
+
+```bash
+# 1. Create the GitHub credential Secret FIRST (see above)
+
+# 2. Create the org runner group in GitHub UI (if it doesn't exist):
+#    https://github.com/organizations/izzywdev/settings/actions/runner-groups
+#    Name: staging-runners
+#    Access: selected repositories only (add your allowlist)
+
+# 3. Bootstrap ARC controller + scale set
+cd /path/to/FuzeInfra
+chmod +x runners/arc/install.sh
+./runners/arc/install.sh
+
+# Verify
+kubectl -n arc-runners get pods
+kubectl -n arc-systems get pods
+
+# 4. (Optional) Enable GitOps management for the scale set via ArgoCD:
+kubectl apply -f argocd/applications/arc-runners.yaml
+```
+
+To upgrade after values changes:
+
+```bash
+./runners/arc/install.sh --upgrade
+```
+
+To remove everything:
+
+```bash
+./runners/arc/install.sh --uninstall
+```
+
+---
+
+## Consumer onboarding
+
+A consumer repo needs two things to use the shared runner:
+
+### Step 1 — Add the repo to the runner group allowlist
+
+In GitHub: **Organization Settings → Actions → Runner groups → staging-runners → Repository access**  
+Add the consumer repo.  This is the platform team's gate.
+
+### Step 2 — Grant deployer RBAC in the staging namespace
+
+The platform team applies the Role + RoleBinding in the consumer's staging namespace:
+
+```bash
+NAMESPACE=<consumer-staging-namespace>   # e.g. myapp-staging
+
+# Apply the deployer Role
+kubectl apply -f runners/rbac/deployer-role.yaml -n "$NAMESPACE"
+
+# Apply the RoleBinding (binds arc-runner-sa in arc-runners to the deployer Role)
+kubectl apply -f runners/rbac/deployer-rolebinding.yaml -n "$NAMESPACE"
+```
+
+That's the entire onboarding.  The runner can now deploy to `$NAMESPACE`.
+
+### Step 3 — Target the runner in workflows
+
+```yaml
+# .github/workflows/deploy-staging.yml (in the consumer repo)
+jobs:
+  deploy:
+    runs-on: [self-hosted, staging]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install tooling (kubectl/helm are not pre-baked in the base runner image).
+      - uses: azure/setup-kubectl@v4
+      - uses: azure/setup-helm@v4
+
+      # The runner pod's SA (arc-runner-sa) has in-cluster access; no kubeconfig needed.
+      - name: Deploy to staging
+        run: |
+          helm upgrade --install my-app ./chart \
+            --namespace ${{ vars.STAGING_NAMESPACE }} \
+            --set image.tag=${{ github.sha }} \
+            --atomic --timeout 5m
+```
+
+> The runner pod uses **in-cluster service account auth** — consumers need neither a kubeconfig
+> nor any cluster credentials in their workflow secrets.
+
+---
+
+## Alternative: long-lived runner Deployment
+
+For lightweight, non-sensitive use cases a simple Deployment can host a runner:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-runner
+  namespace: arc-runners
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: staging-runner }
+  template:
+    metadata:
+      labels: { app: staging-runner }
+    spec:
+      serviceAccountName: arc-runner-sa
+      containers:
+        - name: runner
+          image: ghcr.io/actions/actions-runner:latest
+          env:
+            - name: GITHUB_RUNNER_LABELS
+              value: "self-hosted,staging"
+            - name: GITHUB_RUNNER_GROUP
+              value: "staging-runners"
+            - name: GITHUB_URL
+              value: "https://github.com/izzywdev"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: arc-runner-github-app
+                  key: github_token
+```
+
+**Not recommended for shared use** — the pod is not ephemeral, so jobs from different repos
+share the same environment.
+
+---
+
+## Cluster-level bootstrap note (ArgoCD project)
+
+The `arc-runners` and `arc-systems` namespaces are created by `install.sh`.  If you want
+ArgoCD to manage them, add them to the `fuzeinfra` AppProject destinations:
+
+```yaml
+# argocd/projects/fuzeinfra.yaml  — add to spec.destinations:
+- namespace: arc-runners
+  server: https://kubernetes.default.svc
+- namespace: arc-systems
+  server: https://kubernetes.default.svc
+```
+
+---
+
+## Checklist before going live
+
+- [ ] GitHub App created, private key stored in `arc-runner-github-app` Secret
+- [ ] `staging-runners` runner group created in GitHub org, repos allowlisted
+- [ ] `arc-runner-sa` ServiceAccount exists in `arc-runners`
+- [ ] ARC controller running in `arc-systems`
+- [ ] Runner scale set `staging` registered (visible in GitHub org runner settings)
+- [ ] Deployer Role + RoleBinding applied in each consumer staging namespace
+- [ ] First consumer workflow tested end-to-end

--- a/runners/arc/controller-values.yaml
+++ b/runners/arc/controller-values.yaml
@@ -1,0 +1,28 @@
+# =============================================================================
+# ARC Controller Helm values
+# Chart: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+# Namespace: arc-systems
+#
+# The controller watches for RunnerScaleSets across the cluster and manages
+# ephemeral runner pods on behalf of GitHub Actions.
+# =============================================================================
+
+replicaCount: 1
+
+image:
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 128Mi
+
+# Leader election keeps exactly one controller active when replicaCount > 1.
+leaderElectionEnabled: true
+
+# Restrict the controller to runner namespaces rather than cluster-wide.
+# Set to "" to watch all namespaces (not recommended for least-privilege).
+watchSingleNamespace: "arc-runners"

--- a/runners/arc/github-secret.yaml
+++ b/runners/arc/github-secret.yaml
@@ -1,0 +1,47 @@
+# =============================================================================
+# GitHub App credentials for ARC — TEMPLATE, NOT a real secret.
+#
+# DO NOT commit real values.  This file documents the expected structure;
+# the real Secret is created manually (or via Sealed Secrets / External Secrets)
+# before running install.sh.
+#
+# Option A — GitHub App (recommended, least-privilege):
+#   Required org-level permissions:
+#     - Self-hosted runners: Read & Write
+#   Steps:
+#     1. Create a GitHub App at https://github.com/organizations/izzywdev/settings/apps/new
+#     2. Grant: Organization permissions → Actions → Self-hosted runners: Read & Write
+#     3. Install the App on the izzywdev org, note the installation ID
+#     4. Generate a private key and download it
+#     5. Fill the values below and create the secret:
+#          kubectl -n arc-runners create secret generic arc-runner-github-app \
+#            --from-literal=github_app_id=<APP_ID> \
+#            --from-literal=github_app_installation_id=<INSTALLATION_ID> \
+#            --from-literal=github_app_private_key="$(cat private-key.pem)"
+#
+# Option B — Personal Access Token (simpler, but long-lived credential):
+#   Token scopes: repo (Full control)  + admin:org → manage_runners:org
+#   Steps:
+#     1. Create a Classic PAT or Fine-grained token with the above scopes
+#     2. Create the secret:
+#          kubectl -n arc-runners create secret generic arc-runner-github-app \
+#            --from-literal=github_token=<YOUR_PAT>
+# =============================================================================
+
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: arc-runner-github-app
+#   namespace: arc-runners
+# type: Opaque
+# stringData:
+#   # --- Option A: GitHub App ---
+#   github_app_id: "REPLACE_WITH_APP_ID"
+#   github_app_installation_id: "REPLACE_WITH_INSTALLATION_ID"
+#   github_app_private_key: |
+#     -----BEGIN RSA PRIVATE KEY-----
+#     REPLACE_WITH_PRIVATE_KEY_CONTENT
+#     -----END RSA PRIVATE KEY-----
+#
+#   # --- Option B: PAT (choose one option only) ---
+#   # github_token: "REPLACE_WITH_PAT"

--- a/runners/arc/install.sh
+++ b/runners/arc/install.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Bootstrap the ARC controller and staging runner scale set.
+#
+# Prerequisites:
+#   - kubectl configured against the target cluster (kind fuzeinfra or EKS)
+#   - helm >= 3.10
+#   - The GitHub App / PAT secret created BEFORE this script (see github-secret.yaml)
+#
+# Usage:
+#   ./runners/arc/install.sh            # install (idempotent)
+#   ./runners/arc/install.sh --upgrade  # upgrade in place
+#   ./runners/arc/install.sh --uninstall # remove everything
+#
+# The script does NOT register against GitHub — that happens automatically when
+# the controller starts and reads the Secret.  The owner still needs to:
+#   1. Pre-create the Secret (see github-secret.yaml)
+#   2. Pre-create the org runner group "staging-runners" in GitHub UI
+#   3. Add repos to the runner group allowlist
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ARC_CONTROLLER_CHART="oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller"
+ARC_RUNNER_CHART="oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+
+CONTROLLER_NS="arc-systems"
+RUNNER_NS="arc-runners"
+CONTROLLER_RELEASE="arc-controller"
+RUNNER_RELEASE="staging"        # becomes the runner label → runs-on: [self-hosted, staging]
+
+UNINSTALL=false
+UPGRADE=false
+for arg in "$@"; do
+  case "$arg" in
+    --uninstall) UNINSTALL=true ;;
+    --upgrade)   UPGRADE=true ;;
+  esac
+done
+
+# ---- Uninstall --------------------------------------------------------------
+if $UNINSTALL; then
+  echo "==> Removing runner scale set …"
+  helm uninstall "$RUNNER_RELEASE"    --namespace "$RUNNER_NS"    --ignore-not-found || true
+  echo "==> Removing ARC controller …"
+  helm uninstall "$CONTROLLER_RELEASE" --namespace "$CONTROLLER_NS" --ignore-not-found || true
+  echo "Done. Namespaces preserved; remove manually if desired."
+  exit 0
+fi
+
+# ---- Namespaces -------------------------------------------------------------
+echo "==> Ensuring namespaces …"
+kubectl create namespace "$CONTROLLER_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace "$RUNNER_NS"     --dry-run=client -o yaml | kubectl apply -f -
+
+# ---- Runner ServiceAccount (arc-runner-sa in arc-runners) -------------------
+echo "==> Applying runner ServiceAccount …"
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: arc-runner-sa
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/component: runner
+    app.kubernetes.io/part-of: arc-staging
+EOF
+
+# ---- ARC controller ---------------------------------------------------------
+if $UPGRADE; then
+  echo "==> Upgrading ARC controller …"
+  helm upgrade "$CONTROLLER_RELEASE" "$ARC_CONTROLLER_CHART" \
+    --namespace "$CONTROLLER_NS" \
+    --values "$SCRIPT_DIR/controller-values.yaml" \
+    --wait
+else
+  echo "==> Installing ARC controller …"
+  helm install "$CONTROLLER_RELEASE" "$ARC_CONTROLLER_CHART" \
+    --namespace "$CONTROLLER_NS" \
+    --values "$SCRIPT_DIR/controller-values.yaml" \
+    --wait
+fi
+
+# ---- Runner scale set -------------------------------------------------------
+if $UPGRADE; then
+  echo "==> Upgrading runner scale set ($RUNNER_RELEASE) …"
+  helm upgrade "$RUNNER_RELEASE" "$ARC_RUNNER_CHART" \
+    --namespace "$RUNNER_NS" \
+    --values "$SCRIPT_DIR/runner-scale-set-values.yaml" \
+    --wait
+else
+  echo "==> Installing runner scale set ($RUNNER_RELEASE) …"
+  helm install "$RUNNER_RELEASE" "$ARC_RUNNER_CHART" \
+    --namespace "$RUNNER_NS" \
+    --values "$SCRIPT_DIR/runner-scale-set-values.yaml" \
+    --wait
+fi
+
+echo ""
+echo "✓ ARC controller running in namespace: $CONTROLLER_NS"
+echo "✓ Runner scale set '$RUNNER_RELEASE' registered in namespace: $RUNNER_NS"
+echo ""
+echo "Next steps:"
+echo "  1. Confirm the runner appears in GitHub:"
+echo "     https://github.com/organizations/izzywdev/settings/actions/runners"
+echo "  2. Assign the runner to the 'staging-runners' group with your repo allowlist."
+echo "  3. For each consumer app: apply the deployer RBAC (see runners/rbac/)."

--- a/runners/arc/runner-scale-set-values.yaml
+++ b/runners/arc/runner-scale-set-values.yaml
@@ -1,0 +1,76 @@
+# =============================================================================
+# ARC Runner Scale Set Helm values
+# Chart: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+# Namespace: arc-runners  |  Release name: staging
+#
+# Registers an org-level ephemeral runner with labels [self-hosted, staging].
+# Consumers target it with:
+#   runs-on: [self-hosted, staging]
+# =============================================================================
+
+# ---- GitHub target ----------------------------------------------------------
+# Org-level URL → runner is available to every allowlisted repo in the group.
+githubConfigUrl: "https://github.com/izzywdev"
+
+# Name of the Kubernetes Secret containing GitHub App credentials.
+# Create it from runners/arc/github-secret.yaml before installing.
+githubConfigSecret: arc-runner-github-app
+
+# ---- Runner group -----------------------------------------------------------
+# Org runner group created at: Settings → Actions → Runner groups.
+# Set "Repository access" to the explicit repo allowlist (NOT "All repositories").
+runnerGroup: "staging-runners"
+
+# ---- Scale set label --------------------------------------------------------
+# This value becomes the runner's primary label.  Combined with the automatic
+# "self-hosted" label, workflows can target: runs-on: [self-hosted, staging]
+runnerScaleSetName: staging
+
+# ---- Scaling ----------------------------------------------------------------
+# minRunners=0  → idle costs nothing; runners spin up on demand.
+# maxRunners    → hard cap; tune based on cluster capacity.
+minRunners: 0
+maxRunners: 5
+
+# ---- Runner pod spec --------------------------------------------------------
+template:
+  spec:
+    # deployer ServiceAccount: grants namespaced RBAC in each consumer's
+    # staging namespace via a RoleBinding the platform grants at onboarding.
+    serviceAccountName: arc-runner-sa
+
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        # Runners are ephemeral — no privileged flag, no host mounts.
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: "2"
+            memory: 1Gi
+        env:
+          # Prevent the runner from self-updating (image version is the pin).
+          - name: DISABLE_RUNNER_UPDATE
+            value: "1"
+
+    # No tolerations/nodeSelector by default; add here to pin to staging nodes.
+    # nodeSelector:
+    #   node-role: staging
+    # tolerations:
+    #   - key: staging
+    #     operator: Exists
+    #     effect: NoSchedule
+
+# ---- ARC controller reference -----------------------------------------------
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-gha-runner-scale-set-controller

--- a/runners/rbac/deployer-role.yaml
+++ b/runners/rbac/deployer-role.yaml
@@ -1,0 +1,57 @@
+# =============================================================================
+# Deployer Role — namespaced, reusable template.
+#
+# Apply this in a consumer's STAGING namespace to grant the shared runner's
+# ServiceAccount (arc-runners/arc-runner-sa) the minimum permissions needed
+# to deploy a workload: Deployments, Services, ConfigMaps, Secrets, Ingresses,
+# HorizontalPodAutoscalers, and Pods (read-only, for health checks).
+#
+# Usage:
+#   # Substitute YOUR_NAMESPACE with the consumer staging namespace, then:
+#   kubectl apply -f deployer-role.yaml -n <YOUR_NAMESPACE>
+#
+# Or use the kustomize overlay pattern (see runners/README.md).
+# =============================================================================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deployer
+  # namespace is set by -n flag at apply time (or by the consumer's kustomize overlay)
+  labels:
+    app.kubernetes.io/component: deployer-rbac
+    app.kubernetes.io/part-of: arc-staging
+rules:
+  # Core workload objects
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Secrets: write-only (runner can inject image pull secrets / env secrets).
+  # Do NOT grant "get" or "list" — runner should never be able to read secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "patch", "delete"]
+
+  # Pod read-only (for rollout status checks, not exec/logs).
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+
+  # Ingress management
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Autoscaling
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # PersistentVolumeClaims (optional: enable only if the app manages PVCs)
+  # - apiGroups: [""]
+  #   resources: ["persistentvolumeclaims"]
+  #   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/runners/rbac/deployer-rolebinding.yaml
+++ b/runners/rbac/deployer-rolebinding.yaml
@@ -1,0 +1,33 @@
+# =============================================================================
+# Deployer RoleBinding — binds the shared runner's SA to the deployer Role.
+#
+# This RoleBinding lives in the CONSUMER's staging namespace and grants
+# the runner's ServiceAccount (arc-runners/arc-runner-sa) deploy access
+# scoped entirely to that namespace.
+#
+# The runner's cluster-level identity never changes; only namespaces where this
+# RoleBinding is applied become reachable.  This is the onboarding step.
+#
+# Usage:
+#   kubectl apply -f deployer-rolebinding.yaml -n <YOUR_NAMESPACE>
+#
+# Or with inline substitution:
+#   NAMESPACE=myapp-staging
+#   sed "s/YOUR_NAMESPACE/$NAMESPACE/" deployer-rolebinding.yaml | kubectl apply -f - -n $NAMESPACE
+# =============================================================================
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: arc-runner-deployer
+  # namespace is set by -n flag at apply time
+  labels:
+    app.kubernetes.io/component: deployer-rbac
+    app.kubernetes.io/part-of: arc-staging
+subjects:
+  - kind: ServiceAccount
+    name: arc-runner-sa
+    namespace: arc-runners   # the runner's home namespace — DO NOT change
+roleRef:
+  kind: Role
+  name: deployer
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

Provisions a **shared, org-level, consumer-agnostic** GitHub Actions self-hosted runner that runs inside the `fuzeinfra` k8s cluster. Any repo in the `izzywdev` org that the owner adds to the runner-group allowlist can target it with `runs-on: [self-hosted, staging]`.

### Files added

| Path | Purpose |
|---|---|
| `runners/arc/controller-values.yaml` | Helm values for ARC controller (namespace `arc-systems`) |
| `runners/arc/runner-scale-set-values.yaml` | Helm values for the scale set (namespace `arc-runners`, label `staging`) |
| `runners/arc/github-secret.yaml` | Secret **template** — placeholder only, never real credentials |
| `runners/arc/install.sh` | Bootstrap script: installs controller + scale set, idempotent |
| `runners/rbac/deployer-role.yaml` | Namespaced Role for deploy operations (reusable per consumer namespace) |
| `runners/rbac/deployer-rolebinding.yaml` | Binds `arc-runners/arc-runner-sa` to the deployer Role in a consumer's staging ns |
| `argocd/applications/arc-runners.yaml` | Optional ArgoCD Application for GitOps management of the scale set |
| `argocd/projects/fuzeinfra.yaml` | Added `arc-systems` and `arc-runners` to allowed destinations |
| `runners/README.md` | Full documentation: design decisions, security boundary, install guide, consumer onboarding |

---

## Design decisions (explicit)

### 1. Registration scope = ORG (`izzywdev`)
Runner registers at `https://github.com/izzywdev`, so every allowlisted repo can schedule jobs without per-repo registration. Access is gated by a **runner group (`staging-runners`)** with an explicit repo allowlist — the primary security gate. Owner sets the allowlist in GitHub UI.

### 2. Mechanism = ARC scale sets (recommended)
Actions Runner Controller v0.9+ "scale set" mode:
- **Ephemeral pods** — one pod per job, terminated after. No cross-job contamination.
- **Scales to zero** when idle (no cost).
- Much safer than a long-lived Deployment for a shared privileged runner.

A long-lived Deployment alternative is documented in the README but not recommended for shared use.

### 3. Auth = GitHub App (recommended) / PAT (fallback)
GitHub App is preferred: org-scoped, least-privilege (only `Self-hosted runners: Read & Write`), rotatable private key, auditable identity. PAT option documented for simplicity. Neither is in VCS — the Secret is created out-of-band and referenced by name.

### 4. Cluster permissions = least-privilege namespaced RBAC
- `arc-runner-sa` ServiceAccount in `arc-runners` starts with **zero cluster permissions**
- Access is granted per staging namespace by applying the `deployer-role.yaml` + `deployer-rolebinding.yaml` templates — the platform onboarding step
- `deployer` Role: CRUD for Deployments/Services/ConfigMaps/Ingresses/HPAs; Secrets **write-only** (no read); Pods read-only; no cluster-scoped resources
- Runner container: non-root, `allowPrivilegeEscalation: false`, all capabilities dropped

### 5. Consumer-agnostic
Zero app-specific names, namespaces, or logic in this directory. Consumers are identified only by (a) their repo in the runner-group allowlist and (b) the RoleBinding the platform grants in their namespace.

---

## Security boundary

> A shared self-hosted runner executes workflow code from every allowlisted repo on a privileged in-cluster identity. Mitigations:

| Threat | Mitigation |
|---|---|
| Cross-job contamination | Ephemeral ARC pods — fresh pod per job |
| Privilege escalation | Non-root container, capabilities dropped, namespaced RBAC only |
| Rogue repo gaining access | Runner group explicit allowlist (owner-managed) |
| Fork PRs | Use `pull_request` (not `pull_request_target`) for untrusted forks |
| Credential exposure | GitHub App key in k8s Secret, not in job env |
| Lateral namespace movement | No cluster-scoped permissions; only namespaces with explicit RoleBinding |

---

## Owner checklist (before merging / going live)

- [ ] Create the GitHub App (`izzywdev-arc-runner`) with `Self-hosted runners: Read & Write`
- [ ] Create the `arc-runner-github-app` Secret in `arc-runners` namespace
- [ ] Create the `staging-runners` runner group in GitHub org; add repo allowlist
- [ ] Run `./runners/arc/install.sh` against the target cluster
- [ ] Confirm runner appears in [org runner settings](https://github.com/organizations/izzywdev/settings/actions/runners)
- [ ] Apply deployer RBAC in the first consumer staging namespace
- [ ] Test end-to-end with a consumer workflow using `runs-on: [self-hosted, staging]`

**Do NOT run `install.sh` against the live org cluster without confirming the Secret and runner group are in place first.**

---

## Consumer onboarding (2 steps)

1. Platform team adds the repo to the `staging-runners` runner group in GitHub UI
2. Platform team runs:
```bash
kubectl apply -f runners/rbac/deployer-role.yaml        -n <consumer-staging-namespace>
kubectl apply -f runners/rbac/deployer-rolebinding.yaml -n <consumer-staging-namespace>
```

Consumer workflow:
```yaml
runs-on: [self-hosted, staging]
```

No kubeconfig needed in consumer workflows — the runner pod uses in-cluster SA auth.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9yzWLS9JT2BExo6W44S4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9yzWLS9JT2BExo6W44S4R)_