### PR TITLE
feat(k8s): consumer-agnostic k8s contract, staging CI, and runner manifest

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,72 @@
+name: Deploy FuzeInfra – Production
+
+# Triggers on every push to `main`.
+# Production credentials live in the repo secret KUBE_CONFIG (base64-encoded).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'helm/**'
+      - '.github/workflows/deploy-prod.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the rendered manifests without applying (helm upgrade --dry-run)"
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    name: Helm upgrade – production
+    runs-on: ubuntu-latest
+
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Configure kubeconfig
+        run: |
+          if [ -z "${KUBE_CONFIG:-}" ]; then
+            echo "::warning::KUBE_CONFIG secret is not set. Deploy skipped."
+            echo "SKIP=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          mkdir -p ~/.kube
+          printf '%s' "$KUBE_CONFIG" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Helm lint
+        if: env.SKIP != 'true'
+        run: |
+          helm lint helm/fuzeinfra
+
+      - name: Deploy FuzeInfra
+        if: env.SKIP != 'true'
+        run: |
+          FLAGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            FLAGS="--dry-run"
+          fi
+          helm upgrade --install fuzeinfra helm/fuzeinfra \
+            --namespace fuzeinfra \
+            --create-namespace \
+            --atomic \
+            --timeout 15m \
+            $FLAGS
+
+      - name: Verify rollout
+        if: env.SKIP != 'true' && inputs.dry_run != 'true'
+        run: |
+          echo "=== Pods ==="
+          kubectl -n fuzeinfra get pods
+          echo "=== Services ==="
+          kubectl -n fuzeinfra get svc

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,97 @@
+name: Deploy FuzeInfra – Staging
+
+# Triggers on every push to the `staging` branch.
+# The `staging` branch is the stable deploy target for the local k8s cluster.
+# Merge main -> staging to kick off a staging rollout.
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the rendered manifests without applying (helm upgrade --dry-run)"
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    name: Helm upgrade – staging
+    # -----------------------------------------------------------------------
+    # Preferred runner: a self-hosted pod inside the local cluster labelled
+    # `self-hosted` + `staging` (see k8s/runner/ for the manifest).
+    # That pod uses its in-cluster ServiceAccount kubeconfig automatically.
+    #
+    # Fallback: if no such runner is registered, set the repo secret
+    # KUBE_CONFIG_STAGING (base64-encoded kubeconfig) and re-run on any
+    # runner – the configure-kubeconfig step will pick it up.
+    #
+    # No-op behaviour: if neither in-cluster access nor the secret is
+    # available the deploy step is skipped and the job exits successfully
+    # with a warning notice.
+    # -----------------------------------------------------------------------
+    runs-on: [self-hosted, staging]
+
+    environment: staging
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      # When running on the in-cluster runner pod there is already an
+      # ambient kubeconfig via the pod's ServiceAccount projection.
+      # When KUBE_CONFIG_STAGING is set (e.g. a remote runner), write it out.
+      - name: Configure kubeconfig
+        run: |
+          if [ -n "${KUBE_CONFIG_STAGING:-}" ]; then
+            mkdir -p ~/.kube
+            printf '%s' "$KUBE_CONFIG_STAGING" | base64 -d > ~/.kube/config
+            chmod 600 ~/.kube/config
+            echo "Kubeconfig written from KUBE_CONFIG_STAGING secret."
+          else
+            echo "KUBE_CONFIG_STAGING not set – relying on in-cluster / ambient config."
+          fi
+        env:
+          KUBE_CONFIG_STAGING: ${{ secrets.KUBE_CONFIG_STAGING }}
+
+      - name: Verify cluster access
+        id: check
+        run: |
+          if kubectl cluster-info --request-timeout=10s 2>/dev/null; then
+            echo "connected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "connected=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No cluster access (neither in-cluster ServiceAccount nor KUBE_CONFIG_STAGING resolved). Deploy skipped."
+          fi
+
+      - name: Helm lint
+        if: steps.check.outputs.connected == 'true'
+        run: |
+          helm lint helm/fuzeinfra -f helm/fuzeinfra/values-local.yaml
+
+      - name: Deploy FuzeInfra
+        if: steps.check.outputs.connected == 'true'
+        run: |
+          FLAGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            FLAGS="--dry-run"
+          fi
+          helm upgrade --install fuzeinfra helm/fuzeinfra \
+            --namespace fuzeinfra \
+            --create-namespace \
+            -f helm/fuzeinfra/values-local.yaml \
+            --atomic \
+            --timeout 10m \
+            $FLAGS
+
+      - name: Verify rollout
+        if: steps.check.outputs.connected == 'true' && inputs.dry_run != 'true'
+        run: |
+          echo "=== Pods ==="
+          kubectl -n fuzeinfra get pods
+          echo "=== Services ==="
+          kubectl -n fuzeinfra get svc

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -2,7 +2,7 @@ name: Helm Chart Validation
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, staging]
     paths:
       - 'helm/**'
       - '.github/workflows/helm-validate.yml'

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,0 +1,174 @@
+# FuzeInfra Service Contract
+
+This document is FuzeInfra's **public interface**. It describes the stable, consumer-agnostic service endpoints that any workload in the cluster can rely on. FuzeInfra does not know about, reference, or adapt to any specific consumer.
+
+---
+
+## Namespace
+
+All FuzeInfra services run in the **`fuzeinfra`** namespace.
+
+```
+kubectl -n fuzeinfra get svc
+```
+
+---
+
+## Stable Service DNS
+
+Every service is named `fuzeinfra-<svc>`. The full in-cluster FQDN is:
+
+```
+fuzeinfra-<svc>.fuzeinfra.svc.cluster.local
+```
+
+Short-form (works from within any namespace in the same cluster):
+
+```
+fuzeinfra-<svc>.fuzeinfra
+```
+
+### Datastores
+
+| Service | Short DNS | Port | Protocol | Notes |
+|---------|-----------|------|----------|-------|
+| PostgreSQL | `fuzeinfra-postgres.fuzeinfra` | **5432** | TCP | Headless StatefulSet; connect via JDBC/psycopg2 |
+| MongoDB | `fuzeinfra-mongodb.fuzeinfra` | **27017** | TCP | Headless StatefulSet; auth required |
+| Redis | `fuzeinfra-redis.fuzeinfra` | **6379** | TCP | Headless StatefulSet; AOF persistence enabled |
+| Neo4j Bolt | `fuzeinfra-neo4j.fuzeinfra` | **7687** | TCP (Bolt) | APOC plugins loaded |
+| Neo4j HTTP | `fuzeinfra-neo4j.fuzeinfra` | **7474** | HTTP | Browser / REST API |
+| Elasticsearch | `fuzeinfra-elasticsearch.fuzeinfra` | **9200** | HTTP | Single-node, security disabled |
+| ChromaDB | `fuzeinfra-chromadb.fuzeinfra` | **8000** | HTTP | Vector store; REST API |
+
+### Message Queues
+
+| Service | Short DNS | Port | Protocol | Notes |
+|---------|-----------|------|----------|-------|
+| Kafka (broker) | `fuzeinfra-kafka.fuzeinfra` | **9092** | PLAINTEXT | KRaft mode, no ZooKeeper |
+| RabbitMQ (AMQP) | `fuzeinfra-rabbitmq.fuzeinfra` | **5672** | AMQP | Auth required |
+| RabbitMQ (Management) | `fuzeinfra-rabbitmq.fuzeinfra` | **15672** | HTTP | Web UI / API |
+
+### Observability (internal use / dashboards)
+
+| Service | Short DNS | Port |
+|---------|-----------|------|
+| Prometheus | `fuzeinfra-prometheus.fuzeinfra` | **9090** |
+| Grafana | `fuzeinfra-grafana.fuzeinfra` | **3000** |
+| Alertmanager | `fuzeinfra-alertmanager.fuzeinfra` | **9093** |
+| Loki | `fuzeinfra-loki.fuzeinfra` | **3100** |
+
+---
+
+## Credentials
+
+FuzeInfra manages its own credentials in the `fuzeinfra-secrets` Secret (or an existing Secret supplied via `credentials.existingSecret` in the Helm values).
+
+**Consumers must NOT read from this Secret.** Instead:
+
+1. Create your own Secret in your own namespace with the connection string(s) you need.
+2. Reference the stable DNS above to construct URLs at deploy time.
+
+Example — consumer Secret in namespace `my-app`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-app-infra-config
+  namespace: my-app
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql://my_user:my_password@fuzeinfra-postgres.fuzeinfra:5432/my_db"
+  REDIS_URL: "redis://fuzeinfra-redis.fuzeinfra:6379/0"
+  KAFKA_BOOTSTRAP_SERVERS: "fuzeinfra-kafka.fuzeinfra:9092"
+```
+
+The consumer is responsible for:
+- Creating any application-specific databases/keyspaces on the shared datastore.
+- Managing its own credentials (the FuzeInfra admin credentials are for platform ops only).
+
+---
+
+## How to Reference FuzeInfra from a Consumer Service
+
+### Docker Compose (local dev)
+
+Join the `FuzeInfra` Docker network and use the container hostnames:
+
+```yaml
+networks:
+  FuzeInfra:
+    external: true
+
+services:
+  my-service:
+    image: my-image
+    networks: [FuzeInfra]
+    environment:
+      DATABASE_URL: postgresql://user:pass@postgres:5432/mydb
+      REDIS_URL: redis://redis:6379/0
+```
+
+> Note: Docker Compose container names (`postgres`, `redis`, …) differ from the k8s service names (`fuzeinfra-postgres`, `fuzeinfra-redis`, …). Use environment variables so the same application image works in both environments.
+
+### Kubernetes (staging / production)
+
+Reference services by their FQDN or short form. No special network attachment or label is required — standard in-cluster DNS resolution is enough:
+
+```yaml
+env:
+  - name: DATABASE_URL
+    value: "postgresql://user:pass@fuzeinfra-postgres.fuzeinfra:5432/mydb"
+  - name: REDIS_URL
+    value: "redis://fuzeinfra-redis.fuzeinfra:6379/0"
+  - name: KAFKA_BOOTSTRAP_SERVERS
+    value: "fuzeinfra-kafka.fuzeinfra:9092"
+  - name: MONGODB_URL
+    value: "mongodb://user:pass@fuzeinfra-mongodb.fuzeinfra:27017"
+  - name: ELASTICSEARCH_URL
+    value: "http://fuzeinfra-elasticsearch.fuzeinfra:9200"
+  - name: NEO4J_BOLT_URL
+    value: "bolt://fuzeinfra-neo4j.fuzeinfra:7687"
+  - name: CHROMADB_URL
+    value: "http://fuzeinfra-chromadb.fuzeinfra:8000"
+  - name: RABBITMQ_URL
+    value: "amqp://user:pass@fuzeinfra-rabbitmq.fuzeinfra:5672"
+```
+
+---
+
+## Network Policy note
+
+If your cluster enforces NetworkPolicy, consumers must allow egress to namespace `fuzeinfra` on the ports listed above. FuzeInfra itself runs no NetworkPolicy that restricts ingress from other namespaces.
+
+---
+
+## Versioning
+
+The service contract (namespace, service names, and ports) follows semantic versioning in `version.json`. Breaking changes (service renames, port changes) increment the **major** version and are announced in the changelog before taking effect.
+
+Current version: see `version.json`.
+
+---
+
+## Deployment
+
+FuzeInfra is deployed via Helm:
+
+```bash
+# Local (kind) — staging
+helm upgrade --install fuzeinfra helm/fuzeinfra \
+  -n fuzeinfra --create-namespace \
+  -f helm/fuzeinfra/values-local.yaml
+
+# Production
+helm upgrade --install fuzeinfra helm/fuzeinfra \
+  -n fuzeinfra --create-namespace
+
+# Local development — Docker Compose
+./infra-up.sh
+```
+
+CI deploys automatically:
+- **`staging` branch** → local k8s cluster via the `deploy-staging` workflow.
+- **`main` branch** → production cluster via the `deploy-prod` workflow (requires `KUBE_CONFIG` secret).

--- a/helm/fuzeinfra/templates/NOTES.txt
+++ b/helm/fuzeinfra/templates/NOTES.txt
@@ -19,9 +19,18 @@ Web UIs (via Ingress, class "{{ .Values.ingress.className }}"):
 For local (kind), ensure these hostnames resolve to 127.0.0.1, e.g. add to
 /etc/hosts or use the dnsmasq wildcard for *.{{ .Values.global.domain }}.
 
-In-cluster service DNS (use these from your apps):
-  postgres:5432  redis:6379  mongodb:27017  kafka:9092  rabbitmq:5672
-  elasticsearch:9200  neo4j:7687  chromadb:8000
+In-cluster service contract (stable DNS — use these from consumer workloads):
+  fuzeinfra-postgres.{{ .Release.Namespace }}.svc.cluster.local:5432
+  fuzeinfra-mongodb.{{ .Release.Namespace }}.svc.cluster.local:27017
+  fuzeinfra-redis.{{ .Release.Namespace }}.svc.cluster.local:6379
+  fuzeinfra-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092
+  fuzeinfra-rabbitmq.{{ .Release.Namespace }}.svc.cluster.local:5672
+  fuzeinfra-elasticsearch.{{ .Release.Namespace }}.svc.cluster.local:9200
+  fuzeinfra-neo4j.{{ .Release.Namespace }}.svc.cluster.local:7687   (Bolt)
+  fuzeinfra-neo4j.{{ .Release.Namespace }}.svc.cluster.local:7474   (HTTP)
+  fuzeinfra-chromadb.{{ .Release.Namespace }}.svc.cluster.local:8000
+
+See CONTRACT.md in the repository root for the full consumer API reference.
 
 Check status:
   kubectl -n {{ .Release.Namespace }} get pods

--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -16,11 +16,11 @@ referenced via $(VAR) interpolation to build the SQLAlchemy/Celery URLs.
 - name: AIRFLOW__CORE__EXECUTOR
   value: CeleryExecutor
 - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-  value: "postgresql+psycopg2://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/airflow"
+  value: "postgresql+psycopg2://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@fuzeinfra-postgres:5432/airflow"
 - name: AIRFLOW__CELERY__RESULT_BACKEND
-  value: "db+postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/airflow"
+  value: "db+postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@fuzeinfra-postgres:5432/airflow"
 - name: AIRFLOW__CELERY__BROKER_URL
-  value: "redis://redis:6379/0"
+  value: "redis://fuzeinfra-redis:6379/0"
 - name: AIRFLOW__CORE__FERNET_KEY
   valueFrom:
     secretKeyRef:
@@ -40,7 +40,7 @@ referenced via $(VAR) interpolation to build the SQLAlchemy/Celery URLs.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: airflow-dags
+  name: fuzeinfra-airflow-dags
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -65,7 +65,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: airflow-init
+  name: fuzeinfra-airflow-init
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
   annotations:
@@ -103,13 +103,13 @@ spec:
             - |
               set -e
               echo "Waiting for PostgreSQL..."
-              until PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do
+              until PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do
                 sleep 2
               done
               echo "Ensuring 'airflow' database exists..."
-              PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U "$POSTGRES_USER" -d postgres -tc \
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -tc \
                 "SELECT 1 FROM pg_database WHERE datname = 'airflow'" | grep -q 1 || \
-                PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE airflow"
+                PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE airflow"
               echo "Running airflow db migrate..."
               airflow db migrate
               echo "Creating admin user (idempotent)..."
@@ -121,7 +121,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: airflow-webserver
+  name: fuzeinfra-airflow-webserver
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 4 }}
@@ -136,7 +136,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: airflow-webserver
+  name: fuzeinfra-airflow-webserver
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -175,13 +175,13 @@ spec:
       volumes:
         - name: dags
           configMap:
-            name: airflow-dags
+            name: fuzeinfra-airflow-dags
 ---
 {{- /* ===================== Airflow Scheduler ===================== */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: airflow-scheduler
+  name: fuzeinfra-airflow-scheduler
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -208,13 +208,13 @@ spec:
       volumes:
         - name: dags
           configMap:
-            name: airflow-dags
+            name: fuzeinfra-airflow-dags
 ---
 {{- /* ===================== Airflow Celery Worker ===================== */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: airflow-worker
+  name: fuzeinfra-airflow-worker
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -241,13 +241,13 @@ spec:
       volumes:
         - name: dags
           configMap:
-            name: airflow-dags
+            name: fuzeinfra-airflow-dags
 ---
 {{- /* ===================== Airflow Flower (Celery monitoring) ===================== */}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: airflow-flower
+  name: fuzeinfra-airflow-flower
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 4 }}
@@ -262,7 +262,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: airflow-flower
+  name: fuzeinfra-airflow-flower
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:

--- a/helm/fuzeinfra/templates/configmaps-monitoring.yaml
+++ b/helm/fuzeinfra/templates/configmaps-monitoring.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-config
+  name: fuzeinfra-prometheus-config
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -17,7 +17,7 @@ data:
         - static_configs:
             - targets:
               {{- if .Values.alertmanager.enabled }}
-                - alertmanager:{{ .Values.alertmanager.port }}
+                - fuzeinfra-alertmanager:{{ .Values.alertmanager.port }}
               {{- end }}
     scrape_configs:
       - job_name: prometheus
@@ -30,7 +30,7 @@ data:
         relabel_configs:
           - source_labels: [__meta_kubernetes_service_name]
             action: keep
-            regex: node-exporter
+            regex: fuzeinfra-node-exporter
       {{- end }}
       # Scrape any pod annotated with prometheus.io/scrape: "true".
       - job_name: kubernetes-pods
@@ -59,7 +59,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: alertmanager-config
+  name: fuzeinfra-alertmanager-config
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -80,7 +80,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: loki-config
+  name: fuzeinfra-loki-config
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -116,7 +116,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: promtail-config
+  name: fuzeinfra-promtail-config
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -126,7 +126,7 @@ data:
     positions:
       filename: /run/promtail/positions.yaml
     clients:
-      - url: http://loki:{{ .Values.loki.port }}/loki/api/v1/push
+      - url: http://fuzeinfra-loki:{{ .Values.loki.port }}/loki/api/v1/push
     scrape_configs:
       - job_name: kubernetes-pods
         kubernetes_sd_configs:
@@ -150,7 +150,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-datasources
+  name: fuzeinfra-grafana-datasources
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -161,13 +161,13 @@ data:
       - name: Prometheus
         type: prometheus
         access: proxy
-        url: http://prometheus:{{ .Values.prometheus.port }}
+        url: http://fuzeinfra-prometheus:{{ .Values.prometheus.port }}
         isDefault: true
       {{- end }}
       {{- if .Values.loki.enabled }}
       - name: Loki
         type: loki
         access: proxy
-        url: http://loki:{{ .Values.loki.port }}
+        url: http://fuzeinfra-loki:{{ .Values.loki.port }}
       {{- end }}
 {{- end }}

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres
+  name: fuzeinfra-postgres
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 4 }}
@@ -19,11 +19,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: postgres
+  name: fuzeinfra-postgres
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: postgres
+  serviceName: fuzeinfra-postgres
   replicas: 1
   selector:
     matchLabels:
@@ -81,7 +81,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: mongodb
+  name: fuzeinfra-mongodb
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 4 }}
@@ -97,11 +97,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: mongodb
+  name: fuzeinfra-mongodb
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: mongodb
+  serviceName: fuzeinfra-mongodb
   replicas: 1
   selector:
     matchLabels:
@@ -159,7 +159,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis
+  name: fuzeinfra-redis
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 4 }}
@@ -175,11 +175,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: redis
+  name: fuzeinfra-redis
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: redis
+  serviceName: fuzeinfra-redis
   replicas: 1
   selector:
     matchLabels:
@@ -227,7 +227,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: neo4j
+  name: fuzeinfra-neo4j
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 4 }}
@@ -245,11 +245,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: neo4j
+  name: fuzeinfra-neo4j
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: neo4j
+  serviceName: fuzeinfra-neo4j
   replicas: 1
   selector:
     matchLabels:
@@ -315,7 +315,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: elasticsearch
+  name: fuzeinfra-elasticsearch
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 4 }}
@@ -330,11 +330,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: elasticsearch
+  name: fuzeinfra-elasticsearch
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: elasticsearch
+  serviceName: fuzeinfra-elasticsearch
   replicas: 1
   selector:
     matchLabels:
@@ -397,7 +397,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: chromadb
+  name: fuzeinfra-chromadb
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 4 }}
@@ -412,11 +412,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: chromadb
+  name: fuzeinfra-chromadb
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: chromadb
+  serviceName: fuzeinfra-chromadb
   replicas: 1
   selector:
     matchLabels:

--- a/helm/fuzeinfra/templates/dns-tunnel.yaml
+++ b/helm/fuzeinfra/templates/dns-tunnel.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dnsmasq-config
+  name: fuzeinfra-dnsmasq-config
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 data:
@@ -26,7 +26,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: dnsmasq
+  name: fuzeinfra-dnsmasq
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 4 }}
@@ -51,7 +51,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dnsmasq
+  name: fuzeinfra-dnsmasq
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -99,7 +99,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: dnsmasq-config
+            name: fuzeinfra-dnsmasq-config
 {{- end }}
 
 {{- /* ===================== cloudflare-tunnel (optional) ===================== */ -}}
@@ -108,7 +108,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cloudflare-tunnel
+  name: fuzeinfra-cloudflare-tunnel
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:

--- a/helm/fuzeinfra/templates/ingress.yaml
+++ b/helm/fuzeinfra/templates/ingress.yaml
@@ -1,16 +1,16 @@
 {{- if .Values.ingress.enabled }}
 {{- $root := . -}}
-{{- /* service name -> service port for each web UI we expose */ -}}
+{{- /* hostname-subdomain -> { svc: fuzeinfra-<svc>, port, enabled } */ -}}
 {{- $routes := dict
-  "grafana"           (dict "svc" "grafana"           "port" $root.Values.grafana.port           "enabled" $root.Values.grafana.enabled)
-  "prometheus"        (dict "svc" "prometheus"        "port" $root.Values.prometheus.port        "enabled" $root.Values.prometheus.enabled)
-  "alertmanager"      (dict "svc" "alertmanager"      "port" $root.Values.alertmanager.port      "enabled" $root.Values.alertmanager.enabled)
-  "airflow"           (dict "svc" "airflow-webserver" "port" $root.Values.airflow.webPort        "enabled" $root.Values.airflow.enabled)
-  "flower"            (dict "svc" "airflow-flower"    "port" $root.Values.airflow.flowerPort     "enabled" $root.Values.airflow.enabled)
-  "kafka-ui"          (dict "svc" "kafka-ui"          "port" $root.Values.kafkaUi.port           "enabled" (and $root.Values.kafkaUi.enabled $root.Values.kafka.enabled))
-  "mongo-express"     (dict "svc" "mongo-express"     "port" $root.Values.mongoExpress.port      "enabled" (and $root.Values.mongoExpress.enabled $root.Values.mongodb.enabled))
-  "rabbitmq"          (dict "svc" "rabbitmq"          "port" $root.Values.rabbitmq.managementPort "enabled" $root.Values.rabbitmq.enabled)
-  "neo4j"             (dict "svc" "neo4j"             "port" $root.Values.neo4j.httpPort         "enabled" $root.Values.neo4j.enabled)
+  "grafana"           (dict "svc" "fuzeinfra-grafana"           "port" $root.Values.grafana.port           "enabled" $root.Values.grafana.enabled)
+  "prometheus"        (dict "svc" "fuzeinfra-prometheus"        "port" $root.Values.prometheus.port        "enabled" $root.Values.prometheus.enabled)
+  "alertmanager"      (dict "svc" "fuzeinfra-alertmanager"      "port" $root.Values.alertmanager.port      "enabled" $root.Values.alertmanager.enabled)
+  "airflow"           (dict "svc" "fuzeinfra-airflow-webserver" "port" $root.Values.airflow.webPort        "enabled" $root.Values.airflow.enabled)
+  "flower"            (dict "svc" "fuzeinfra-airflow-flower"    "port" $root.Values.airflow.flowerPort     "enabled" $root.Values.airflow.enabled)
+  "kafka-ui"          (dict "svc" "fuzeinfra-kafka-ui"          "port" $root.Values.kafkaUi.port           "enabled" (and $root.Values.kafkaUi.enabled $root.Values.kafka.enabled))
+  "mongo-express"     (dict "svc" "fuzeinfra-mongo-express"     "port" $root.Values.mongoExpress.port      "enabled" (and $root.Values.mongoExpress.enabled $root.Values.mongodb.enabled))
+  "rabbitmq"          (dict "svc" "fuzeinfra-rabbitmq"          "port" $root.Values.rabbitmq.managementPort "enabled" $root.Values.rabbitmq.enabled)
+  "neo4j"             (dict "svc" "fuzeinfra-neo4j"             "port" $root.Values.neo4j.httpPort         "enabled" $root.Values.neo4j.enabled)
 -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm/fuzeinfra/templates/messaging.yaml
+++ b/helm/fuzeinfra/templates/messaging.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kafka
+  name: fuzeinfra-kafka
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 4 }}
@@ -22,11 +22,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kafka
+  name: fuzeinfra-kafka
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: kafka
+  serviceName: fuzeinfra-kafka
   replicas: 1
   selector:
     matchLabels:
@@ -47,12 +47,13 @@ spec:
               value: "1"
             - name: KAFKA_PROCESS_ROLES
               value: "broker,controller"
+            # Pod DNS: <pod>.<headless-svc>.<namespace>.svc.cluster.local
             - name: KAFKA_CONTROLLER_QUORUM_VOTERS
-              value: "1@kafka-0.kafka:9093"
+              value: "1@fuzeinfra-kafka-0.fuzeinfra-kafka:9093"
             - name: KAFKA_LISTENERS
               value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: "PLAINTEXT://kafka:9092"
+              value: "PLAINTEXT://fuzeinfra-kafka:9092"
             - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
               value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
             - name: KAFKA_CONTROLLER_LISTENER_NAMES
@@ -106,7 +107,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kafka-ui
+  name: fuzeinfra-kafka-ui
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 4 }}
@@ -121,7 +122,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kafka-ui
+  name: fuzeinfra-kafka-ui
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -144,7 +145,7 @@ spec:
               value: "local"
             # KRaft mode: bootstrap servers only, no ZooKeeper.
             - name: KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS
-              value: "kafka:9092"
+              value: "fuzeinfra-kafka:9092"
             - name: DYNAMIC_CONFIG_ENABLED
               value: "true"
           ports:
@@ -165,7 +166,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: rabbitmq
+  name: fuzeinfra-rabbitmq
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 4 }}
@@ -183,11 +184,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: rabbitmq
+  name: fuzeinfra-rabbitmq
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: rabbitmq
+  serviceName: fuzeinfra-rabbitmq
   replicas: 1
   selector:
     matchLabels:
@@ -247,7 +248,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: mongo-express
+  name: fuzeinfra-mongo-express
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 4 }}
@@ -262,7 +263,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mongo-express
+  name: fuzeinfra-mongo-express
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -292,7 +293,7 @@ spec:
                   name: {{ include "fuzeinfra.secretName" . }}
                   key: MONGODB_PASSWORD
             - name: ME_CONFIG_MONGODB_URL
-              value: "mongodb://$(ME_CONFIG_MONGODB_ADMINUSERNAME):$(ME_CONFIG_MONGODB_ADMINPASSWORD)@mongodb:27017/"
+              value: "mongodb://$(ME_CONFIG_MONGODB_ADMINUSERNAME):$(ME_CONFIG_MONGODB_ADMINPASSWORD)@fuzeinfra-mongodb:27017/"
             - name: ME_CONFIG_BASICAUTH_USERNAME
               value: "admin"
             - name: ME_CONFIG_BASICAUTH_PASSWORD

--- a/helm/fuzeinfra/templates/monitoring.yaml
+++ b/helm/fuzeinfra/templates/monitoring.yaml
@@ -45,7 +45,7 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus
+  name: fuzeinfra-prometheus
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 4 }}
@@ -60,11 +60,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: prometheus
+  name: fuzeinfra-prometheus
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: prometheus
+  serviceName: fuzeinfra-prometheus
   replicas: 1
   selector:
     matchLabels:
@@ -103,7 +103,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: prometheus-config
+            name: fuzeinfra-prometheus-config
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -121,7 +121,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: alertmanager
+  name: fuzeinfra-alertmanager
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 4 }}
@@ -136,11 +136,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: alertmanager
+  name: fuzeinfra-alertmanager
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: alertmanager
+  serviceName: fuzeinfra-alertmanager
   replicas: 1
   selector:
     matchLabels:
@@ -169,7 +169,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: alertmanager-config
+            name: fuzeinfra-alertmanager-config
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -187,7 +187,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
+  name: fuzeinfra-grafana
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 4 }}
@@ -202,11 +202,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: grafana
+  name: fuzeinfra-grafana
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: grafana
+  serviceName: fuzeinfra-grafana
   replicas: 1
   selector:
     matchLabels:
@@ -248,7 +248,7 @@ spec:
       volumes:
         - name: datasources
           configMap:
-            name: grafana-datasources
+            name: fuzeinfra-grafana-datasources
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -266,7 +266,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: loki
+  name: fuzeinfra-loki
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 4 }}
@@ -281,11 +281,11 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: loki
+  name: fuzeinfra-loki
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  serviceName: loki
+  serviceName: fuzeinfra-loki
   replicas: 1
   selector:
     matchLabels:
@@ -320,7 +320,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: loki-config
+            name: fuzeinfra-loki-config
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -338,7 +338,7 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: promtail
+  name: fuzeinfra-promtail
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
@@ -376,7 +376,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: promtail-config
+            name: fuzeinfra-promtail-config
         - name: run
           hostPath:
             path: /run/promtail
@@ -394,7 +394,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: node-exporter
+  name: fuzeinfra-node-exporter
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
     {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 4 }}
@@ -410,7 +410,7 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: node-exporter
+  name: fuzeinfra-node-exporter
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:

--- a/k8s/runner/runner.yaml
+++ b/k8s/runner/runner.yaml
@@ -1,0 +1,191 @@
+# =============================================================================
+# Generic GitHub Actions self-hosted runner for the FuzeInfra staging cluster.
+#
+# This manifest is CONSUMER-AGNOSTIC: it deploys a runner that can execute
+# any workflow routed to labels [self-hosted, staging]. No knowledge of any
+# specific application or consumer is encoded here.
+#
+# Prerequisites:
+#   1. Create repo/org secret RUNNER_TOKEN containing a GitHub Actions runner
+#      registration token (Settings → Actions → Runners → New self-hosted runner
+#      → copy the token value).
+#   2. Set RUNNER_REPO_URL to the GitHub repo or org URL, e.g.:
+#        https://github.com/my-org  (org-level)
+#        https://github.com/my-org/my-repo  (repo-level)
+#
+# Apply:
+#   kubectl apply -f k8s/runner/runner.yaml
+#
+# The runner registers itself on startup and deregisters gracefully on shutdown.
+# =============================================================================
+
+# ---- Namespace ---------------------------------------------------------------
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fuzeinfra-runners
+  labels:
+    app.kubernetes.io/part-of: fuzeinfra
+---
+# ---- Secret (placeholder – owner must patch with real values) ----------------
+# kubectl create secret generic fuzeinfra-runner-secret \
+#   --namespace fuzeinfra-runners \
+#   --from-literal=RUNNER_TOKEN=<registration-token> \
+#   --from-literal=RUNNER_REPO_URL=https://github.com/my-org
+#
+# OR apply this manifest and patch:
+#   kubectl -n fuzeinfra-runners patch secret fuzeinfra-runner-secret \
+#     -p '{"stringData":{"RUNNER_TOKEN":"<token>","RUNNER_REPO_URL":"<url>"}}'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fuzeinfra-runner-secret
+  namespace: fuzeinfra-runners
+  labels:
+    app.kubernetes.io/part-of: fuzeinfra
+type: Opaque
+stringData:
+  RUNNER_TOKEN: "REPLACE_ME"
+  RUNNER_REPO_URL: "REPLACE_ME"
+---
+# ---- ServiceAccount ----------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fuzeinfra-runner
+  namespace: fuzeinfra-runners
+  labels:
+    app.kubernetes.io/part-of: fuzeinfra
+---
+# ---- ClusterRole: deploy access for the fuzeinfra namespace ------------------
+# Grants the runner enough rights to run `helm upgrade` and `kubectl` against
+# the fuzeinfra namespace. Extend verbs/resources as needed for other namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fuzeinfra-runner-deploy
+  labels:
+    app.kubernetes.io/part-of: fuzeinfra
+rules:
+  # Core workload types
+  - apiGroups: ["", "apps", "batch"]
+    resources:
+      - pods
+      - services
+      - endpoints
+      - configmaps
+      - secrets
+      - persistentvolumeclaims
+      - serviceaccounts
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Namespace management (create fuzeinfra if it doesn't exist)
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create"]
+  # Networking
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # RBAC (for Helm charts that create ServiceAccounts / Roles)
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Storage
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fuzeinfra-runner-deploy
+  labels:
+    app.kubernetes.io/part-of: fuzeinfra
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fuzeinfra-runner-deploy
+subjects:
+  - kind: ServiceAccount
+    name: fuzeinfra-runner
+    namespace: fuzeinfra-runners
+---
+# ---- Runner Deployment -------------------------------------------------------
+# Image: myoung34/github-runner is a well-maintained ephemeral runner image.
+# See https://github.com/myoung34/docker-github-actions-runner for options.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuzeinfra-runner
+  namespace: fuzeinfra-runners
+  labels:
+    app.kubernetes.io/name: fuzeinfra-runner
+    app.kubernetes.io/part-of: fuzeinfra
+spec:
+  # Scale up for parallelism; each pod registers as a separate ephemeral runner.
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fuzeinfra-runner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fuzeinfra-runner
+        app.kubernetes.io/part-of: fuzeinfra
+    spec:
+      serviceAccountName: fuzeinfra-runner
+      # Graceful shutdown: runner deregisters before pod is killed.
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: runner
+          # Pin to a specific tag in production to avoid unexpected upgrades.
+          image: myoung34/github-runner:latest
+          imagePullPolicy: Always
+          env:
+            - name: RUNNER_NAME_PREFIX
+              value: "fuzeinfra-staging"
+            # Labels used to route jobs: must include self-hosted + staging
+            - name: LABELS
+              value: "self-hosted,staging"
+            - name: EPHEMERAL
+              value: "true"
+            - name: RUNNER_WORKDIR
+              value: /tmp/runner
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fuzeinfra-runner-secret
+                  key: RUNNER_TOKEN
+            - name: REPO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: fuzeinfra-runner-secret
+                  key: RUNNER_REPO_URL
+          # Mount the in-cluster ServiceAccount token so kubectl/helm work
+          # without an explicit kubeconfig inside workflow steps.
+          volumeMounts:
+            - name: work
+              mountPath: /tmp/runner
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          # Liveness: runner process must be alive
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "Runner.Listener"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+      volumes:
+        - name: work
+          emptyDir: {}


### PR DESCRIPTION
## Summary

Makes FuzeInfra deployable to a local k8s cluster as a **standalone, shared infrastructure layer** with a stable, consumer-agnostic service contract.

### What changed

- **Helm services renamed** to `fuzeinfra-<svc>` across all templates (databases, messaging, monitoring, airflow, DNS/tunnel, ingress). The stable in-cluster contract is now `fuzeinfra-<svc>.fuzeinfra.svc.cluster.local`. All internal DNS cross-references updated consistently (Kafka KRaft quorum voters, Airflow PostgreSQL/Redis URLs, Grafana datasource URLs, Promtail push URL, Ingress backends).
- **`CONTRACT.md`** added — consumer-facing API reference: namespace, FQDNs, ports, credential pattern, Docker Compose vs k8s connection examples.
- **`.github/workflows/deploy-staging.yml`** — triggers on push to the `staging` branch; runs on `[self-hosted, staging]` runner (in-cluster pod); falls back to `KUBE_CONFIG_STAGING` secret; no-ops cleanly with a warning if neither is available.
- **`.github/workflows/deploy-prod.yml`** — triggers on push to `main` (helm/** changes); runs on GitHub-hosted `ubuntu-latest` + `KUBE_CONFIG` secret; no-ops if secret is absent.
- **`k8s/runner/runner.yaml`** — generic in-cluster self-hosted runner (Namespace `fuzeinfra-runners`, Secret placeholder, ServiceAccount, ClusterRole + ClusterRoleBinding, Deployment). Labels `[self-hosted, staging]`. No consumer-specific content.
- **`staging` branch** created from this feature branch so the staging CI workflow is immediately live once the runner is registered.
- **`.github/workflows/helm-validate.yml`** updated to also validate on `staging` branch pushes.

### Consumer-specific content

**Zero.** This repository contains no application names, no consumer namespaces, no references to other repos' charts or PRs, and no RBAC scoped to a named application. FuzeInfra exposes a stable interface; it does not adapt to who calls it.

### Prerequisites (owner provides)

- `KUBE_CONFIG_STAGING` repo/environment secret (base64-encoded kubeconfig for the local cluster) — only needed if the in-cluster runner isn't registered yet.
- `KUBE_CONFIG` repo/environment secret — for production deploys from `main`.
- Patch `k8s/runner/runner.yaml` with a real `RUNNER_TOKEN` and `RUNNER_REPO_URL` before applying the runner manifest.

### Deployment model

```
feature/* → PR → main  →  deploy-prod workflow  →  production cluster
                         ↘ merge main → staging  →  deploy-staging workflow  →  local cluster
```

### Not deployed

No cluster deployment has been made from CI. The workflows exist; they will deploy only after the secrets and/or runner are wired up and the `staging` branch receives a push.

## Test plan

- [ ] `helm lint helm/fuzeinfra` passes (covered by `helm-validate` CI on this PR)
- [ ] `helm lint helm/fuzeinfra -f helm/fuzeinfra/values-local.yaml` passes
- [ ] `helm template … | kubeconform` passes (covered by `helm-validate` CI)
- [ ] Owner registers a `[self-hosted, staging]` runner pod (`kubectl apply -f k8s/runner/runner.yaml` after patching the Secret) and pushes to `staging` to trigger a real deploy
- [ ] Owner confirms `kubectl -n fuzeinfra get svc` shows all `fuzeinfra-*` names
- [ ] Consumer team confirms their connection strings work against the new FQDNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm7ET5FW5msKx2CYGzqVJk)_