### PR TITLE
fix(observability): fix Grafana, Loki, and Promtail startup crashes

### DIFF
--- a/helm/fuzeinfra/templates/configmaps-monitoring.yaml
+++ b/helm/fuzeinfra/templates/configmaps-monitoring.yaml
@@ -271,6 +271,7 @@ data:
     compactor:
       working_directory: /loki/compactor
       retention_enabled: true
+      delete_request_store: filesystem
 
     ruler:
       alertmanager_url: http://fuzeinfra-alertmanager:{{ .Values.alertmanager.port }}
@@ -342,11 +343,6 @@ data:
               - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash
               - __meta_kubernetes_pod_container_name
             target_label: __path__
-        metric_relabel_configs:
-          - source_labels: [__name__]
-            action: keep
-            regex: promtail_.*
-
       # System journal logs from nodes (if systemd available)
       - job_name: journal
         journal:
@@ -398,10 +394,5 @@ data:
         url: http://fuzeinfra-loki:{{ .Values.loki.port }}
         jsonData:
           maxLines: 5000
-          derivedFields:
-            - datasourceUid: fuzeinfra-prometheus
-              matcherRegex: "traceID=(\\w+)"
-              name: TraceID
-              url: ""
       {{- end }}
 {{- end }}


### PR DESCRIPTION
## Root causes & fixes

**Grafana** — `Datasource provisioning error: data source not found`
Removed `derivedFields` from the Loki datasource provisioning config. The field cross-referenced `fuzeinfra-prometheus` by UID during the same provisioning pass before it existed in the DB.

**Loki 3.x** — `compactor.delete-request-store should be configured when retention is enabled`
Added `delete_request_store: filesystem` to the compactor block — mandatory new field in Loki 3 when `retention_enabled: true`.

**Promtail** — `field metric_relabel_configs not found in type scrapeconfig.plain`
Removed `metric_relabel_configs` from the Promtail kubernetes-pods scrape config — this is a Prometheus-only field, invalid in Promtail.

All three found by watching pod logs immediately after the first merge deployed to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)