### PR TITLE
fix(airflow): resolve ConfigMap symlink loop in DAG directory scanner

### DIFF
--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -34,6 +34,35 @@ referenced via $(VAR) interpolation to build the SQLAlchemy/Celery URLs.
   value: "airflow.api.auth.backend.basic_auth"
 {{- end -}}
 
+{{- /*
+  Shared DAG volumes/initContainer block.
+  Kubernetes ConfigMap directory mounts create a timestamped directory (e.g.
+  ..2026_06_21_17_06_42.3303819634) plus a ..data symlink pointing to it.
+  Airflow's list_py_file_paths walks with followlinks=True and tracks
+  os.path.realpath per directory; both entries resolve to the same real path,
+  triggering "Detected recursive loop when walking DAG directory".
+  Fix: copy DAG files from the ConfigMap mount into a plain emptyDir — no
+  symlinks, no loop.
+*/ -}}
+{{- define "fuzeinfra.dagInitContainer" -}}
+- name: dag-sync
+  image: busybox
+  command: ["sh", "-c", "cp /configmap-dags/*.py /dags/ 2>/dev/null || true"]
+  volumeMounts:
+    - name: dags-cm
+      mountPath: /configmap-dags
+    - name: dags
+      mountPath: /dags
+{{- end -}}
+
+{{- define "fuzeinfra.dagVolumes" -}}
+- name: dags
+  emptyDir: {}
+- name: dags-cm
+  configMap:
+    name: fuzeinfra-airflow-dags
+{{- end -}}
+
 {{- if .Values.airflow.enabled }}
 {{- /* Example DAG shipped as a ConfigMap so the stack works out of the box.
      For production, replace with git-sync or a baked image. */ -}}
@@ -119,35 +148,6 @@ spec:
                 --username "$AIRFLOW_ADMIN_USER" --firstname Admin --lastname User \
                 --role Admin --email admin@example.com --password "$AIRFLOW_ADMIN_PASSWORD" || true
 ---
-{{- /*
-  Shared DAG volumes/initContainer block.
-  Kubernetes ConfigMap directory mounts create a timestamped directory (e.g.
-  ..2026_06_21_17_06_42.3303819634) plus a ..data symlink pointing to it.
-  Airflow's list_py_file_paths walks with followlinks=True and tracks
-  os.path.realpath per directory; both entries resolve to the same real path,
-  triggering "Detected recursive loop when walking DAG directory".
-  Fix: copy DAG files from the ConfigMap mount into a plain emptyDir — no
-  symlinks, no loop.
-*/ -}}
-{{- define "fuzeinfra.dagInitContainer" -}}
-- name: dag-sync
-  image: busybox
-  command: ["sh", "-c", "cp /configmap-dags/*.py /dags/ 2>/dev/null || true"]
-  volumeMounts:
-    - name: dags-cm
-      mountPath: /configmap-dags
-    - name: dags
-      mountPath: /dags
-{{- end -}}
-
-{{- define "fuzeinfra.dagVolumes" -}}
-- name: dags
-  emptyDir: {}
-- name: dags-cm
-  configMap:
-    name: fuzeinfra-airflow-dags
-{{- end -}}
-
 {{- /* ===================== Airflow Webserver ===================== */}}
 apiVersion: v1
 kind: Service

--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -119,6 +119,35 @@ spec:
                 --username "$AIRFLOW_ADMIN_USER" --firstname Admin --lastname User \
                 --role Admin --email admin@example.com --password "$AIRFLOW_ADMIN_PASSWORD" || true
 ---
+{{- /*
+  Shared DAG volumes/initContainer block.
+  Kubernetes ConfigMap directory mounts create a timestamped directory (e.g.
+  ..2026_06_21_17_06_42.3303819634) plus a ..data symlink pointing to it.
+  Airflow's list_py_file_paths walks with followlinks=True and tracks
+  os.path.realpath per directory; both entries resolve to the same real path,
+  triggering "Detected recursive loop when walking DAG directory".
+  Fix: copy DAG files from the ConfigMap mount into a plain emptyDir — no
+  symlinks, no loop.
+*/ -}}
+{{- define "fuzeinfra.dagInitContainer" -}}
+- name: dag-sync
+  image: busybox
+  command: ["sh", "-c", "cp /configmap-dags/*.py /dags/ 2>/dev/null || true"]
+  volumeMounts:
+    - name: dags-cm
+      mountPath: /configmap-dags
+    - name: dags
+      mountPath: /dags
+{{- end -}}
+
+{{- define "fuzeinfra.dagVolumes" -}}
+- name: dags
+  emptyDir: {}
+- name: dags-cm
+  configMap:
+    name: fuzeinfra-airflow-dags
+{{- end -}}
+
 {{- /* ===================== Airflow Webserver ===================== */}}
 apiVersion: v1
 kind: Service
@@ -152,6 +181,8 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 8 }}
     spec:
+      initContainers:
+        {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
       containers:
         - name: webserver
           image: {{ .Values.airflow.image }}
@@ -175,9 +206,7 @@ spec:
             periodSeconds: 15
             failureThreshold: 12
       volumes:
-        - name: dags
-          configMap:
-            name: fuzeinfra-airflow-dags
+        {{- include "fuzeinfra.dagVolumes" . | nindent 8 }}
 ---
 {{- /* ===================== Airflow Scheduler ===================== */}}
 apiVersion: apps/v1
@@ -197,6 +226,8 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler") | nindent 8 }}
     spec:
+      initContainers:
+        {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
       containers:
         - name: scheduler
           image: {{ .Values.airflow.image }}
@@ -208,9 +239,7 @@ spec:
             - name: dags
               mountPath: /opt/airflow/dags
       volumes:
-        - name: dags
-          configMap:
-            name: fuzeinfra-airflow-dags
+        {{- include "fuzeinfra.dagVolumes" . | nindent 8 }}
 ---
 {{- /* ===================== Airflow Celery Worker ===================== */}}
 apiVersion: apps/v1
@@ -230,6 +259,8 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker") | nindent 8 }}
     spec:
+      initContainers:
+        {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ .Values.airflow.image }}
@@ -241,9 +272,7 @@ spec:
             - name: dags
               mountPath: /opt/airflow/dags
       volumes:
-        - name: dags
-          configMap:
-            name: fuzeinfra-airflow-dags
+        {{- include "fuzeinfra.dagVolumes" . | nindent 8 }}
 ---
 {{- /* ===================== Airflow Flower (Celery monitoring) ===================== */}}
 apiVersion: v1


### PR DESCRIPTION
## Summary

- Kubernetes ConfigMap directory mounts create a timestamped hidden directory (`..2026_06_21_17_06_42.3303819634`) and a `..data` symlink pointing to it inside the pod
- Airflow's `list_py_file_paths` calls `os.walk(followlinks=True)` and tracks each visited directory by `os.path.realpath()`; both entries resolve to the same real path, triggering `RuntimeError: Detected recursive loop when walking DAG directory`
- Fix: add a `dag-sync` `initContainer` (busybox) to the webserver, scheduler, and worker deployments that copies `*.py` DAG files from the ConfigMap mount into a clean `emptyDir` — no symlinks, no loop

## Changes

- Added two shared Helm template helpers (`fuzeinfra.dagInitContainer`, `fuzeinfra.dagVolumes`) to keep the three deployments DRY
- Webserver, scheduler, and worker deployments now use `emptyDir` for `/opt/airflow/dags` (populated at pod start by the initContainer) instead of a direct ConfigMap mount

## Test plan

- [ ] `helm template` renders without errors for all three deployments
- [ ] Airflow scheduler pod starts without `RuntimeError: Detected recursive loop` in logs
- [ ] Example DAG (`example_fuzeinfra_pipeline`) appears in Airflow webserver UI
- [ ] Grafana Loki no longer shows the preceding stack trace errors from the DAG directory scanner

## Note

DAGs are copied once at pod startup. ConfigMap updates require a pod rollout to take effect (same effective behaviour as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)