### PR TITLE
fix(alerting): prevent alert-suppression bypass via log injection

### DIFF
--- a/.github/gen-ignore-body.py
+++ b/.github/gen-ignore-body.py
@@ -10,6 +10,12 @@ log_ctx      = os.environ.get('LOG_CTX', '')
 run_url      = os.environ.get('RUN_URL', '')
 workflow_url = os.environ.get('WORKFLOW_URL', '')
 
+# The log excerpt is attacker-influenceable (anyone who can write to the logs).
+# Neutralise HTML-comment markers so it cannot forge the IGNORE-PATTERN trailer
+# that update-ignore-list.py reads. (That reader also anchors the marker to the
+# end of the body; this is belt-and-suspenders.)
+log_ctx = log_ctx.replace('<!--', '<!- -').replace('-->', '- ->')
+
 print(f"""## 🔕 Claude suggests ignoring this error
 
 **Pattern:** `{pattern}`

--- a/.github/update-ignore-list.py
+++ b/.github/update-ignore-list.py
@@ -6,18 +6,35 @@ Env vars (set by the GHA workflow):
   ISSUE_BODY    — raw issue body text
   ISSUE_URL     — URL of the closed issue
   ISSUE_NUMBER  — issue number
+  ISSUE_AUTHOR  — login of the user who opened the issue
   TODAY         — YYYY-MM-DD
 """
 import os, json, re, sys, pathlib
 
 issue_body   = os.environ.get('ISSUE_BODY', '')
 issue_url    = os.environ.get('ISSUE_URL', '')
+issue_author = os.environ.get('ISSUE_AUTHOR', '')
 today        = os.environ.get('TODAY', '')
 
-# Extract pattern from HTML comment: <!-- IGNORE-PATTERN: ... -->
-m = re.search(r'<!--\s*IGNORE-PATTERN:\s*(.+?)\s*-->', issue_body, re.DOTALL)
+# Defense in depth: only honour ignore-candidate issues that the workflow bot
+# opened itself. Without this, anyone who can open (or get auto-opened) an issue
+# carrying the ignore-candidate label could have a suppression pattern approved
+# on close. The candidate issues are created with the default GITHUB_TOKEN, so
+# their author is github-actions[bot].
+ALLOWED_AUTHORS = {'github-actions[bot]'}
+if issue_author not in ALLOWED_AUTHORS:
+    print(f'Issue author {issue_author!r} is not an approved bot author '
+          f'(expected one of {sorted(ALLOWED_AUTHORS)}); refusing to update ignore list.')
+    sys.exit(0)
+
+# Extract the pattern from the trailing HTML comment: <!-- IGNORE-PATTERN: ... -->
+# The marker MUST be the last non-whitespace content in the body (anchored to \Z)
+# and may not span newlines. The rendered log excerpt is attacker-influenceable and
+# appears earlier in the body; anchoring + dropping re.DOTALL stops an injected
+# marker there from being matched instead of the real bot-written trailer.
+m = re.search(r'<!--\s*IGNORE-PATTERN:\s*([^\n]+?)\s*-->\s*\Z', issue_body)
 if not m:
-    print('No IGNORE-PATTERN comment found in issue body. Nothing to do.')
+    print('No trailing IGNORE-PATTERN comment found in issue body. Nothing to do.')
     sys.exit(0)
 
 pattern = m.group(1).strip()

--- a/.github/workflows/update-ignore-list.yml
+++ b/.github/workflows/update-ignore-list.yml
@@ -23,6 +23,7 @@ jobs:
           ISSUE_BODY:   ${{ github.event.issue.body }}
           ISSUE_URL:    ${{ github.event.issue.html_url }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           TODAY:        ${{ github.event.issue.closed_at }}
         run: |
           TODAY=$(echo "$TODAY" | cut -c1-10)


### PR DESCRIPTION
## Problem
The `ignore-candidate` issue body renders an attacker-influenceable log excerpt (`LOG_CTX`) **above** the machine-read `<!-- IGNORE-PATTERN: … -->` trailer. `update-ignore-list.py` matched the **first** marker with `re.DOTALL`, so an attacker who can write to the logs could inject a forged marker (e.g. `.*`) that gets approved as a suppression pattern when a maintainer closes the issue — silently suppressing real alerts.

Flagged MEDIUM by automated security review.

## Fix (defense in depth)
- **`update-ignore-list.py`** — anchor the marker to end-of-body (`\Z`), drop `re.DOTALL`, and restrict the capture to a single line, so an injected marker earlier in the body can't be matched. Also verify the issue was opened by `github-actions[bot]` before honouring it.
- **`gen-ignore-body.py`** — neutralise `<!--`/`-->` sequences in `LOG_CTX` so it can't forge the trailer.
- **`update-ignore-list.yml`** — pass `ISSUE_AUTHOR` for the bot-author check.

## Verification
Local simulation confirms the new anchored regex extracts the legitimate trailer while the old regex extracted the injected `.*`; the author gate and the `LOG_CTX` sanitiser both behave as expected. Fail-closed: if no valid trailing marker is found, nothing is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)