### PR TITLE
fix(helm): stabilize prod node — probe timeouts, worker limits, MongoDB probe

### DIFF
--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -32,6 +32,10 @@ referenced via $(VAR) interpolation to build the SQLAlchemy/Celery URLs.
   value: {{ .Values.airflow.loadExamples | quote }}
 - name: AIRFLOW__API__AUTH_BACKENDS
   value: "airflow.api.auth.backend.basic_auth"
+{{- if .Values.airflow.celeryWorkerConcurrency }}
+- name: AIRFLOW__CELERY__WORKER_CONCURRENCY
+  value: {{ .Values.airflow.celeryWorkerConcurrency | quote }}
+{{- end }}
 {{- end -}}
 
 {{- /*
@@ -268,6 +272,10 @@ spec:
           args: ["celery", "worker"]
           env:
             {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
+          {{- if .Values.airflow.workerResources }}
+          resources:
+            {{- toYaml .Values.airflow.workerResources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: dags
               mountPath: /opt/airflow/dags

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -62,6 +62,8 @@ spec:
               command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
             initialDelaySeconds: 30
             periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
   volumeClaimTemplates:
@@ -134,8 +136,8 @@ spec:
             - name: data
               mountPath: /data/db
           readinessProbe:
-            exec:
-              command: ["mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+            tcpSocket:
+              port: 27017
             initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -101,6 +101,12 @@ grafana:
 
 airflow:
   workerReplicas: 1
+  # 4 vCPU / 8 GB node — cap concurrency and memory to stop the worker from
+  # crowding out CoreDNS/Postgres under memory pressure.
+  celeryWorkerConcurrency: 4
+  workerResources:
+    requests: { cpu: 500m, memory: 512Mi }
+    limits:   { cpu: "2",  memory: 1536Mi }
 
 # Cloudflare tunnel: all traffic enters via the named tunnel; no host-level
 # ports 80/443 need to be open.  The tunnel token lives in fuzeinfra-secrets

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -292,8 +292,16 @@ airflow:
   image: apache/airflow:2.9.1
   webPort: 8080
   flowerPort: 5555
-  # Number of Celery workers (scale data pipeline throughput here).
+  # Number of Celery worker pods (scale data pipeline throughput here).
   workerReplicas: 1
+  # Celery prefork concurrency per worker pod. Default Celery uses nproc (can
+  # be 16+ on a 4-core node), consuming 1.5 GB+ of RAM. Set explicitly.
+  celeryWorkerConcurrency: 4
+  # Resource envelope for the worker pod. Unset = unbounded (dangerous on
+  # single-node clusters). Override per environment in values-<env>.yaml.
+  workerResources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits:   { cpu: "2",  memory: 1Gi }
   # Mount DAGs from a ConfigMap built from airflow-shared/dags? For real use,
   # prefer git-sync or a baked image. Default: empty dir + example DAG ConfigMap.
   loadExamples: false


### PR DESCRIPTION
## Root cause

Node at 87% memory (6927Mi / 7.9GB) after PR #30 sidecars were enabled in prod. The unconstrained Celery worker (16 prefork processes × ~100MB each = **1579Mi actual usage**) crowded out everything else, causing probe timeouts across CoreDNS, Postgres, and MongoDB.

**Cascade:** CoreDNS health probe (1s timeout) timed out under load → CoreDNS restarted (88× in 24h) → in-cluster DNS broke → Argo couldn't resolve `argocd-repo-server` → `OutOfSync/SyncError`.

## Changes

| File | Fix |
|---|---|
| `templates/databases.yaml` | Postgres `livenessProbe`: add `timeoutSeconds: 5` + `failureThreshold: 3` (default was 1s — caused 117 restarts) |
| `templates/databases.yaml` | MongoDB `readinessProbe`: switch `mongosh exec` → `tcpSocket` (mongosh starts a Node.js runtime per probe; times out under memory pressure despite MongoDB being healthy — 5516 consecutive failures over 24h) |
| `templates/airflow.yaml` | Worker container: wire `workerResources` + `AIRFLOW__CELERY__WORKER_CONCURRENCY` env from values |
| `values.yaml` | Add `airflow.celeryWorkerConcurrency: 4` and `airflow.workerResources` defaults |
| `values-contabo.yaml` | Override concurrency=4, memory limit=1536Mi for 4vCPU/8GB prod node |

## Immediate action taken

CoreDNS was already manually restarted (`kubectl rollout restart deployment/coredns -n kube-system`) to unblock Argo while this PR is in review. This PR fixes the underlying probe/resource issues so restarts don't recur.

## Test plan

- [ ] Helm lint passes in CI
- [ ] After merge + Argo sync: `kubectl top pods -n fuzeinfra` shows airflow-worker ≤ 1536Mi
- [ ] No new CoreDNS or Postgres restarts within 1h of sync
- [ ] Argo app health returns `Healthy` / `Synced`
- [ ] MongoDB shows `1/1 Running` within 2m of pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)