### PR TITLE
fix(infra-request): Terraform-only handler; decouple ArgoCD registration

### DIFF
--- a/.github/workflows/argocd-register.yml
+++ b/.github/workflows/argocd-register.yml
@@ -1,0 +1,79 @@
+# ===========================================================================
+# argocd-register
+# ===========================================================================
+# ONE-TIME registration of a consumer repo into the FuzeInfra cluster's ArgoCD.
+#
+# This is deliberately a manual workflow_dispatch, fully decoupled from the
+# Terraform-only infra-request-handler. You run it once when onboarding a repo
+# (or when adding a brand-new Argo Application/AppProject for it). After that,
+# ArgoCD polls and self-syncs the consumer's deploy/argocd manifests — ongoing
+# edits to those files are NOT an infra-request and must never trigger the
+# handler. Re-running this is safe (kubectl apply is idempotent) but normally
+# unnecessary; let ArgoCD own the steady state.
+#
+# Required repo secrets (FuzeInfra CI only):
+#   KUBE_CONFIG   # base64 kubeconfig for the k3s server
+#
+# Example:
+#   gh workflow run argocd-register.yml \
+#     -f repo=izzywdev/FuzeFront -f ref=main -f path=deploy/argocd
+
+name: argocd-register
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Consumer repo to register (owner/name)"
+        required: true
+        type: string
+      ref:
+        description: "Ref to read the argo manifests from"
+        required: false
+        default: main
+        type: string
+      path:
+        description: "Path in the consumer repo holding the Argo Application/AppProject manifests"
+        required: false
+        default: deploy/argocd
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # One registration at a time per repo.
+  group: argocd-register-${{ inputs.repo }}
+  cancel-in-progress: false
+
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out consumer argo manifests
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref }}
+          path: consumer
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sparse-checkout: |
+            ${{ inputs.path }}
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+
+      - name: Register Argo Applications (one-time)
+        run: |
+          DIR="consumer/${{ inputs.path }}"
+          if [ ! -d "$DIR" ]; then
+            echo "::error::No '${{ inputs.path }}' directory in ${{ inputs.repo }}@${{ inputs.ref }} — nothing to register."
+            exit 1
+          fi
+          echo "Registering Argo manifests from $DIR ..."
+          kubectl apply -f "$DIR/"
+          echo ""
+          echo "Done. ArgoCD now owns these Applications and will self-sync future"
+          echo "changes to ${{ inputs.path }} — do not re-run this for ordinary edits."

--- a/.github/workflows/infra-request-handler.yml
+++ b/.github/workflows/infra-request-handler.yml
@@ -5,26 +5,29 @@
 # *declare* infra needs in git and dispatch `repository_dispatch
 # (event_type: infra-request)` at this repo; this workflow reconciles them.
 #
+# This handler is TERRAFORM-ONLY. It reconciles infra (node) provisioning
+# requests from newly-added repos/microservices and nothing else. ArgoCD owns
+# the consumer's argo manifests after the one-time initial registration (see
+# argocd-register.yml), so an ongoing argo-manifest edit must never reach this
+# handler — and if one does dispatch (no `requests` payload) it is a clean
+# no-op, never a gated PR.
+#
 # Flow:
 #   1. Check out THIS repo (module + whitelist + scripts) and the REQUESTING
-#      repo's deploy/terraform/ + deploy/argocd/.
-#   2. Validate the request against config/infra-request-whitelist.json.
-#   3. Whitelisted  -> terraform apply (FuzeInfra creds + k3s token + remote
-#      backend), then label the node and argocd-sync the changed Applications.
-#   4. Not whitelisted -> open a gated PR carrying `terraform plan` for manual
-#      approval. Never auto-apply.
-#
-# ---------------------------------------------------------------------------
-# NOTE: This file lives in docs/workflows/ because the bot that authored it
-# cannot write under .github/workflows/. To activate it, a maintainer must:
-#     git mv docs/workflows/infra-request-handler.yml .github/workflows/
-# ---------------------------------------------------------------------------
+#      repo's deploy/terraform/.
+#   2. Validate the request against config/infra-request-whitelist.json, which
+#      yields a decision: skip | apply | gate.
+#   3. skip   -> no infra `requests` in the payload; do nothing and exit.
+#   4. apply  -> request is whitelisted: terraform apply (FuzeInfra creds + k3s
+#      token + remote backend), then label the joined nodes.
+#   5. gate   -> valid request, not whitelisted: open a PR carrying `terraform
+#      plan` for manual approval. Never auto-apply.
 #
 # Required repo secrets (FuzeInfra CI only):
 #   CONTABO_CLIENT_ID, CONTABO_CLIENT_SECRET, CONTABO_API_USER, CONTABO_API_PASSWORD
 #   K3S_SERVER_URL, K3S_NODE_TOKEN
 #   CONTABO_IMAGE_ID, NODE_SSH_PUBLIC_KEY
-#   KUBE_CONFIG                  # base64 kubeconfig for the k3s server (label + argocd sync)
+#   KUBE_CONFIG                  # base64 kubeconfig for the k3s server (node labeling backstop)
 #   TF_STATE_* backend creds     # for the FuzeInfra-owned remote TF state backend
 #
 # Dispatch client_payload shape (sent by the consumer's infra-dispatch.yml):
@@ -56,7 +59,7 @@ jobs:
         with:
           path: fuzeinfra
 
-      - name: Check out requesting repo (deploy/ only)
+      - name: Check out requesting repo (deploy/terraform only)
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.client_payload.repo }}
@@ -65,7 +68,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sparse-checkout: |
             deploy/terraform
-            deploy/argocd
 
       - name: Write dispatch payload to file
         id: payload
@@ -85,13 +87,24 @@ jobs:
             --repo "${{ github.event.client_payload.repo }}" \
             --github-output "$GITHUB_OUTPUT"
 
+      # Not an infra-request (no `requests` payload) -> clean no-op. This is the
+      # backstop that keeps argo-only/unrelated dispatches from manufacturing a
+      # gated PR. Every terraform step below is gated on decision != 'skip'.
+      - name: No-op (not an infra-request)
+        if: steps.validate.outputs.decision == 'skip'
+        run: |
+          echo "Decision: skip — ${{ steps.validate.outputs.reasons }}"
+          echo "Nothing to reconcile. ArgoCD owns argo manifests; this handler is Terraform-only."
+
       - name: Set up Terraform
+        if: steps.validate.outputs.decision != 'skip'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.6.6"
 
       # --- Pass the node requests + injected secrets to Terraform -------------
       - name: Generate handler tfvars
+        if: steps.validate.outputs.decision != 'skip'
         working-directory: consumer/deploy/terraform
         env:
           REQUESTS_JSON: ${{ toJSON(github.event.client_payload.requests) }}
@@ -113,6 +126,7 @@ jobs:
           JSON
 
       - name: Terraform init (FuzeInfra-owned remote backend)
+        if: steps.validate.outputs.decision != 'skip'
         working-directory: consumer/deploy/terraform
         env:
           # Configure the FuzeInfra-owned remote state backend here. Example for S3:
@@ -131,18 +145,18 @@ jobs:
       # WHITELISTED -> auto-apply
       # =====================================================================
       - name: Terraform apply (auto)
-        if: steps.validate.outputs.whitelisted == 'true'
+        if: steps.validate.outputs.decision == 'apply'
         working-directory: consumer/deploy/terraform
         run: terraform apply -auto-approve -input=false
 
       - name: Configure kubectl
-        if: steps.validate.outputs.whitelisted == 'true'
+        if: steps.validate.outputs.decision == 'apply'
         run: |
           mkdir -p "$HOME/.kube"
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
 
       - name: Label joined nodes
-        if: steps.validate.outputs.whitelisted == 'true'
+        if: steps.validate.outputs.decision == 'apply'
         env:
           REQUESTS_JSON: ${{ toJSON(github.event.client_payload.requests) }}
         run: |
@@ -162,29 +176,23 @@ jobs:
               subprocess.run(["kubectl","label","node",name,*labels,"--overwrite"],check=True)
           '
 
-      - name: Apply & sync changed Argo Applications
-        if: steps.validate.outputs.whitelisted == 'true'
-        run: |
-          if [ -d consumer/deploy/argocd ]; then
-            kubectl apply -f consumer/deploy/argocd/
-            # If argocd CLI/login is configured, trigger an immediate sync:
-            #   argocd app sync -l app.kubernetes.io/instance=${{ github.event.client_payload.repo }}
-          else
-            echo "No deploy/argocd/ in the consumer repo — skipping Argo sync."
-          fi
+      # NOTE: ArgoCD registration is intentionally NOT done here. A repo is
+      # registered into the cluster's ArgoCD exactly once via the separate
+      # argocd-register.yml (workflow_dispatch); thereafter ArgoCD self-syncs
+      # the consumer's deploy/argocd manifests. This handler stays Terraform-only.
 
       # =====================================================================
-      # NOT WHITELISTED -> gated PR with terraform plan (manual approval)
+      # GATE -> PR with terraform plan (manual approval)
       # =====================================================================
       - name: Terraform plan (gated)
-        if: steps.validate.outputs.whitelisted != 'true'
+        if: steps.validate.outputs.decision == 'gate'
         working-directory: consumer/deploy/terraform
         run: |
           terraform plan -input=false -no-color -out=tfplan | tee plan.txt
           terraform show -no-color tfplan > plan-show.txt || true
 
       - name: Open gated PR for manual approval
-        if: steps.validate.outputs.whitelisted != 'true'
+        if: steps.validate.outputs.decision == 'gate'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/INFRA_REQUEST_DISPATCH.md
+++ b/docs/INFRA_REQUEST_DISPATCH.md
@@ -5,17 +5,25 @@ needs in git and **dispatch** to FuzeInfra to reconcile them. **FuzeInfra is the
 sole credential holder** — consumers never see Contabo creds, the k3s node-token,
 or the Terraform state backend.
 
+The handler is **Terraform-only**: it reconciles node-provisioning requests and
+nothing else. ArgoCD registration is a separate one-time `workflow_dispatch`
+(`argocd-register.yml`); after it, ArgoCD self-syncs the consumer's argo
+manifests and they never touch this handler.
+
 ```
 ┌────────────────────┐   repository_dispatch        ┌──────────────────────────┐
 │ Consumer repo      │   (event_type:               │ FuzeInfra                │
 │ (e.g. FuzeFront)   │    infra-request)            │                          │
 │                    │ ───────────────────────────► │ infra-request-handler.yml│
-│ deploy/terraform/  │   client_payload =           │  • validate vs whitelist │
+│ deploy/terraform/  │   client_payload =           │  • no requests → skip    │
 │   node-request.tf  │   { repo, ref, requests[] }  │  • whitelisted → apply   │
-│ deploy/argocd/     │                              │  • else → gated PR (plan)│
+│   requests.json    │   (TF changes only)          │  • else → gated PR (plan)│
 │ .github/workflows/ │                              │                          │
 │   infra-dispatch.yml                              │ creds: FuzeInfra CI only │
 └────────────────────┘                              └──────────────────────────┘
+
+  deploy/argocd/  ──(one-time)──► argocd-register.yml ──► ArgoCD self-syncs after
+                                  (workflow_dispatch)      registration; no handler
 ```
 
 ## Components in this repo
@@ -23,18 +31,10 @@ or the Terraform state backend.
 | Path | Role |
 |------|------|
 | [`modules/contabo-k3s-node`](../modules/contabo-k3s-node/) | TF module: VPS + cloud-init k3s agent join + labels (consumers reference this) |
-| `.github/workflows/infra-request-handler.yml` | Handler (see activation note below) |
+| `.github/workflows/infra-request-handler.yml` | Terraform-only handler (skip / apply / gated-PR) |
+| `.github/workflows/argocd-register.yml` | One-time ArgoCD registration of a repo (`workflow_dispatch`) |
 | [`config/infra-request-whitelist.json`](../config/infra-request-whitelist.json) | Auto-apply rules |
-| [`scripts-tools/validate_infra_request.py`](../scripts-tools/validate_infra_request.py) | Whitelist validator used by the handler |
-
-> **Activation note:** the handler workflow ships at
-> [`docs/workflows/infra-request-handler.yml`](workflows/infra-request-handler.yml)
-> because the bot that authored it cannot write under `.github/workflows/`. A
-> maintainer must move it into place:
-> ```bash
-> git mv docs/workflows/infra-request-handler.yml .github/workflows/
-> git commit -m "ci: activate infra-request-handler" && git push
-> ```
+| [`scripts-tools/validate_infra_request.py`](../scripts-tools/validate_infra_request.py) | Whitelist validator (returns skip / apply / gate) used by the handler |
 
 ## The auto-apply whitelist
 
@@ -93,14 +93,24 @@ gh secret set FUZEINFRA_DISPATCH_TOKEN --repo izzywdev/FuzeFront
 
 ### Consumer side — example `infra-dispatch.yml`
 
-The consumer's workflow fires the dispatch (for reference; lives in the consumer repo):
+The consumer's workflow fires the dispatch (for reference; lives in the consumer repo).
+
+**The handler is Terraform-only.** It reconciles infra (node) provisioning
+requests and nothing else, so the dispatch must:
+
+1. Trigger **only** on `deploy/terraform/**` — **never** on `deploy/argocd/**`.
+   ArgoCD self-syncs argo manifests after the one-time registration (below), so
+   argo-manifest edits are not infra-requests and must not dispatch.
+2. Dispatch **only when there is a non-empty `requests` payload** to send. A push
+   that changes terraform scaffolding but carries no node requests should send
+   nothing (the handler would no-op anyway, but don't dispatch noise).
 
 ```yaml
 name: infra-dispatch
 on:
   push:
     branches: [main]
-    paths: ["deploy/terraform/**", "deploy/argocd/**"]
+    paths: ["deploy/terraform/**"]      # NOT deploy/argocd/** — Argo owns those
 jobs:
   dispatch:
     runs-on: ubuntu-latest
@@ -110,14 +120,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FUZEINFRA_DISPATCH_TOKEN }}
         run: |
-          # Build the requests[] payload from deploy/terraform (e.g. a committed
-          # requests.json) and dispatch it.
+          # Only dispatch if there is a non-empty requests[] payload to send.
+          if [ ! -s deploy/terraform/requests.json ] \
+             || [ "$(jq '(.requests // []) | length' deploy/terraform/requests.json)" -eq 0 ]; then
+            echo "No non-empty 'requests' in deploy/terraform/requests.json — nothing to dispatch."
+            exit 0
+          fi
           gh api repos/izzywdev/FuzeInfra/dispatches \
             -f event_type=infra-request \
             -F client_payload[repo]="${{ github.repository }}" \
             -F client_payload[ref]="${{ github.sha }}" \
             --input deploy/terraform/requests.json
 ```
+
+> `requests.json` must have the shape `{ "requests": [ {name, product_id, region, role, labels}, ... ] }`.
+> The consumer's `deploy/terraform/` root module must also **declare** the variables the
+> handler injects (`requests`, `contabo_client_id`, `contabo_client_secret`,
+> `contabo_api_user`, `contabo_api_password`, `k3s_server_url`, `k3s_node_token`,
+> `image_id`, `ssh_public_key`) — otherwise `terraform plan` fails with
+> "undeclared variable". Declare them and forward into the `contabo-k3s-node` module.
+
+### One-time ArgoCD registration (separate from infra-requests)
+
+Registering a repo into the cluster's ArgoCD is a **one-time, manual** action,
+decoupled from the Terraform handler. Run FuzeInfra's `argocd-register.yml`:
+
+```bash
+gh workflow run argocd-register.yml --repo izzywdev/FuzeInfra \
+  -f repo=izzywdev/FuzeFront -f ref=main -f path=deploy/argocd
+```
+
+After this, ArgoCD polls and self-syncs the consumer's `deploy/argocd` manifests.
+Ongoing edits to those files are **not** infra-requests and trigger nothing.
 
 ## Required FuzeInfra CI secrets (handler side)
 
@@ -127,7 +161,7 @@ jobs:
 | `K3S_SERVER_URL` / `K3S_NODE_TOKEN` | k3s agent join |
 | `CONTABO_IMAGE_ID` | OS image for new nodes |
 | `NODE_SSH_PUBLIC_KEY` | Break-glass SSH key injected via cloud-init |
-| `KUBE_CONFIG` | base64 kubeconfig — node labeling + Argo sync |
+| `KUBE_CONFIG` | base64 kubeconfig — node labeling (handler) + one-time Argo registration (`argocd-register.yml`) |
 | `TF_STATE_BUCKET` / `TF_STATE_REGION` / `TF_STATE_ACCESS_KEY_ID` / `TF_STATE_SECRET_ACCESS_KEY` | FuzeInfra-owned remote TF state backend |
 
 ## Related docs

--- a/scripts-tools/test_validate_infra_request.py
+++ b/scripts-tools/test_validate_infra_request.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Unit tests for validate_infra_request.validate()."""
+"""Unit tests for validate_infra_request.validate().
+
+validate() returns (decision, reasons) where decision is one of:
+  "skip"  -> not an infra-request (no requests); handler no-ops
+  "apply" -> whitelisted; handler auto-applies
+  "gate"  -> valid request, not whitelisted; handler opens a gated PR
+"""
 import json
 import os
 import sys
@@ -20,33 +26,39 @@ WHITELIST = {
 class ValidateTests(unittest.TestCase):
     def test_valid_request_auto_applies(self):
         payload = {"requests": [{"name": "w1", "product_id": "V45", "region": "EU", "role": "workload"}]}
-        ok, reasons = validate(WHITELIST, payload, "izzywdev/FuzeFront")
-        self.assertTrue(ok, reasons)
+        decision, reasons = validate(WHITELIST, payload, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "apply", reasons)
 
     def test_defaults_region_and_role(self):
         payload = {"requests": [{"name": "w1", "product_id": "V46"}]}
-        ok, _ = validate(WHITELIST, payload, "izzywdev/FuzeFront")
-        self.assertTrue(ok)
+        decision, _ = validate(WHITELIST, payload, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "apply")
 
-    def test_bad_product_region_role_rejected(self):
+    def test_bad_product_region_role_gated(self):
         payload = {"requests": [{"name": "w1", "product_id": "V99", "region": "US", "role": "server"}]}
-        ok, reasons = validate(WHITELIST, payload, "izzywdev/FuzeFront")
-        self.assertFalse(ok)
+        decision, reasons = validate(WHITELIST, payload, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "gate")
         self.assertEqual(len(reasons), 3)
 
-    def test_unknown_repo_rejected(self):
+    def test_unknown_repo_gated(self):
         payload = {"requests": [{"name": "w1", "product_id": "V45"}]}
-        ok, reasons = validate(WHITELIST, payload, "stranger/Repo")
-        self.assertFalse(ok)
+        decision, _ = validate(WHITELIST, payload, "stranger/Repo")
+        self.assertEqual(decision, "gate")
 
-    def test_too_many_nodes_rejected(self):
+    def test_too_many_nodes_gated(self):
         payload = {"requests": [{"name": f"w{i}", "product_id": "V45"} for i in range(4)]}
-        ok, _ = validate(WHITELIST, payload, "izzywdev/FuzeFront")
-        self.assertFalse(ok)
+        decision, _ = validate(WHITELIST, payload, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "gate")
 
-    def test_empty_requests_rejected(self):
-        ok, _ = validate(WHITELIST, {"requests": []}, "izzywdev/FuzeFront")
-        self.assertFalse(ok)
+    def test_empty_requests_skipped(self):
+        # No infra requests -> not an infra-request -> skip (NOT a gated PR).
+        decision, _ = validate(WHITELIST, {"requests": []}, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "skip")
+
+    def test_missing_requests_key_skipped(self):
+        # An argo-only / unrelated dispatch carries no `requests` key at all.
+        decision, _ = validate(WHITELIST, {"changed": "deploy/argocd/applications/x.yaml"}, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "skip")
 
 
 if __name__ == "__main__":

--- a/scripts-tools/validate_infra_request.py
+++ b/scripts-tools/validate_infra_request.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
 """Validate a dispatched infra-request against the auto-apply whitelist.
 
-Used by the infra-request-handler workflow to decide auto-apply vs gated-PR.
-A request auto-applies ONLY if it comes from an allowed repo AND every node it
-declares satisfies the whitelist (product_id, region, role, bounded count).
-Any violation routes the whole request to a manual-approval PR.
+Used by the infra-request-handler workflow to decide what to do with a dispatch.
+The handler is Terraform-only: it reconciles infra (node) provisioning requests
+and nothing else. ArgoCD owns the consumer's argo manifests after the one-time
+initial registration, so a dispatch that carries no infra `requests` (e.g. an
+argo-only or unrelated change that wrongly fired the consumer's dispatch) is NOT
+an infra-request at all and must be a clean no-op — never a gated PR.
+
+There are three possible decisions:
+  * "skip"  -> payload has no non-empty `requests` list. Not an infra-request;
+               the handler does nothing (no terraform, no PR).
+  * "apply" -> a real request from an allowed repo where every node satisfies the
+               whitelist (product_id, region, role, bounded count) -> auto-apply.
+  * "gate"  -> a real request that violates the whitelist -> manual-approval PR
+               carrying `terraform plan`.
 
 Usage:
     validate_infra_request.py --whitelist config/infra-request-whitelist.json \
@@ -14,7 +24,8 @@ request.json is the dispatch client_payload, expected to contain a top-level
 "requests" list of {name, product_id, region, role, labels} objects.
 
 Exit code is always 0 (the decision is conveyed via output, not failure).
-Writes `whitelisted=true|false` and `reasons=<text>` to --github-output when given.
+Writes `decision=skip|apply|gate`, `whitelisted=true|false` (true iff apply) and
+`reasons=<text>` to --github-output when given.
 """
 import argparse
 import json
@@ -27,11 +38,14 @@ def load_json(path):
 
 
 def validate(whitelist, payload, repo):
+    """Return (decision, reasons) where decision is 'skip' | 'apply' | 'gate'."""
     reasons = []
 
     requests = payload.get("requests")
     if not isinstance(requests, list) or not requests:
-        return False, ["payload has no non-empty 'requests' list"]
+        # Not an infra-request: nothing to provision. The handler no-ops rather
+        # than opening a gated PR (argo-only/unrelated changes land here).
+        return "skip", ["no infra 'requests' in payload — nothing to reconcile (not an infra-request)"]
 
     allowed_repos = whitelist.get("allowed_repos")
     if allowed_repos and repo not in allowed_repos:
@@ -58,7 +72,7 @@ def validate(whitelist, payload, repo):
         if allowed_roles and role not in allowed_roles:
             reasons.append(f"node '{name}': role '{role}' not in {allowed_roles}")
 
-    return (len(reasons) == 0), reasons
+    return ("apply" if not reasons else "gate"), reasons
 
 
 def main(argv=None):
@@ -72,15 +86,18 @@ def main(argv=None):
     whitelist = load_json(args.whitelist)
     payload = load_json(args.request)
 
-    ok, reasons = validate(whitelist, payload, args.repo)
+    decision, reasons = validate(whitelist, payload, args.repo)
     reason_text = "; ".join(reasons) if reasons else "all nodes satisfy the whitelist"
+    whitelisted = "true" if decision == "apply" else "false"
 
-    print(f"whitelisted={'true' if ok else 'false'}")
+    print(f"decision={decision}")
+    print(f"whitelisted={whitelisted}")
     print(f"reasons={reason_text}")
 
     if args.github_output:
         with open(args.github_output, "a", encoding="utf-8") as fh:
-            fh.write(f"whitelisted={'true' if ok else 'false'}\n")
+            fh.write(f"decision={decision}\n")
+            fh.write(f"whitelisted={whitelisted}\n")
             fh.write(f"reasons={reason_text}\n")
 
     return 0


### PR DESCRIPTION
## Why
PR #39 was a false-positive: an ongoing FuzeFront ArgoCD manifest edit (`deploy/argocd/applications/litellm.yaml`) triggered the infra-request handler, which opened a gated PR carrying an empty `requests` list and a failed `terraform plan`.

By design the handler must reconcile **only Terraform node-provisioning requests** from newly-added repos/microservices. ArgoCD owns the consumer's argo manifests after a **one-time registration**, so post-registration argo edits must be non-events.

## What (FuzeInfra side)
- **`validate_infra_request.py`** → three-way decision `skip | apply | gate`. No non-empty `requests` ⇒ **`skip`** (not an infra-request) instead of collapsing into the gated path.
- **`infra-request-handler.yml`** → all terraform steps gated on `decision != 'skip'`; explicit no-op step for `skip`; dropped `deploy/argocd` from the consumer checkout and removed the argo apply/sync step (**handler is now TF-only**); removed the stale "lives in docs/workflows" activation note.
- **`argocd-register.yml`** (NEW) → one-time `workflow_dispatch` that registers a repo's argo manifests into the cluster's ArgoCD; ArgoCD self-syncs thereafter.
- **`docs/INFRA_REQUEST_DISPATCH.md`** → dispatch only on `deploy/terraform/**` (never `deploy/argocd/**`) and only with a non-empty `requests.json`; documents the 9 root TF variables the consumer must declare + the one-time registration path.
- **tests** → empty/missing `requests` ⇒ `skip` (not `gate`); apply/gate assertions updated. `7 passed`.

## Delegated to FuzeFront (cross-repo, owns `infra-dispatch.yml` + `deploy/terraform/`)
- Remove `deploy/argocd/**` from the dispatch `paths`.
- Declare the 9 root TF variables (`requests`, `contabo_*`, `k3s_*`, `image_id`, `ssh_public_key`) so `terraform plan` runs clean.

Closes the root cause behind #39 (already closed).

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>