### PR TITLE
ci(security): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/harden-gate.yml
+++ b/.github/workflows/harden-gate.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - name: gitleaks (gates new secrets)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Trivy filesystem scan (report-only, SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -95,7 +95,7 @@ jobs:
       # actually changed.
       - name: Detect terraform/** changes
         id: detect
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             tf:
@@ -228,7 +228,7 @@ jobs:
           echo "Merged PR #$PR, reviewed plan keyed by head SHA $HEAD_SHA"
 
       - name: Download the reviewed plan
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           name: tfplan-${{ steps.pr.outputs.head_sha }}
           # The plan was produced by a different workflow run (the PR check).


### PR DESCRIPTION
Resolves the automated security review's **GitHub Actions Third-Party Unpinned** findings (HIGH + 2× MEDIUM).

Mutable action tags can be silently re-pointed to malicious code; pinning to immutable commit SHAs closes that supply-chain vector. The version tag is retained in a trailing comment for readability and future upgrades.

| File | Action | Was | Pinned SHA |
|---|---|---|---|
| terraform-plan-apply.yml | dorny/paths-filter | @v3 | d1c1ffe… # v3 |
| terraform-plan-apply.yml | dawidd6/action-download-artifact | @v6 | bf251b5… # v6 |
| harden-gate.yml | gitleaks/gitleaks-action | @v2 | ff98106… # v2 |
| harden-gate.yml | aquasecurity/trivy-action | **@master** | ed142fd… # v0.36.0 |

`@master` (trivy) was the highest-risk — fully floating. `gitleaks-action` additionally receives `GITHUB_TOKEN`. `dorny/paths-filter` wasn't flagged but is the same risk class, pinned for completeness.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>