### PR TITLE
fix(tf/contabo): align prod-drifting variable defaults (CD safety, #55)

### DIFF
--- a/terraform/contabo/variables.tf
+++ b/terraform/contabo/variables.tf
@@ -136,7 +136,10 @@ variable "cloudflare_zone_id" {
 variable "tunnel_name" {
   description = "Name of the Named Tunnel in Cloudflare Zero Trust dashboard"
   type        = string
-  default     = "fuzeinfra"
+  # MUST match the deployed tunnel name. The production tunnel is named
+  # "FuzeInfra" (confirmed in state); a mismatch makes terraform rename — and if
+  # `name` is ForceNew, recreate — the tunnel, which would break all prod access.
+  default = "FuzeInfra"
 }
 
 variable "prod_subdomain" {

--- a/terraform/contabo/vps.tf
+++ b/terraform/contabo/vps.tf
@@ -32,7 +32,11 @@ resource "contabo_instance" "prod" {
     # Changing comments or whitespace here would otherwise trigger a Contabo API
     # update (no VPS effect) AND cause null_resource.provision to re-run because
     # it depends on the instance. Ignore it to prevent spurious re-provisions.
-    ignore_changes = [user_data]
+    #
+    # display_name: Contabo ignores the requested name and keeps its auto-assigned
+    # value (e.g. "vmi3383846"), so terraform would otherwise show a perpetual
+    # (no-op) diff trying to set it. Ignore to keep plans clean.
+    ignore_changes = [user_data, display_name]
   }
 }
 


### PR DESCRIPTION
## Variable audit result (issue #55)
Audited all 11 `terraform/contabo` variables the CD does **not** wire, comparing each `variables.tf` default to what prod was actually applied with. **9 are SAFE** (default == deployed). **2 differed** and are fixed here so a CD `plan` (which runs with CI defaults, no local `terraform.tfvars`) doesn't try to mutate prod:

| variable | was | now | why |
|---|---|---|---|
| `tunnel_name` | `"fuzeinfra"` | **`"FuzeInfra"`** | 🔴 live CF tunnel is `"FuzeInfra"` (state-confirmed). Mismatch → terraform renames, and if `name` is ForceNew, **destroy+recreate the prod tunnel → all access breaks.** |
| `instance_display_name` → `display_name` | — | `ignore_changes` | 🟡 Contabo ignores the input and keeps its auto-name (`vmi3383846`); added to the existing `lifecycle.ignore_changes` to stop a perpetual no-op diff. |

## ⚠️ Important caveat — ClickOps origin
Prod was substantially built via **ClickOps and not cleanly `terraform import`-ed**. So this PR closes the *input-variable* gap only — the CD's **first `terraform plan` may surface additional resource-level drift** (clickops resources not matching the HCL). That plan **must be reviewed and reconciled/imported before the CD is allowed to apply.** This is the real gate; the var audit is necessary but not sufficient.

## Remaining #55 items before the CD can apply
- Add secrets: `TF_STATE_*` (backend) + `CRIT_BRIDGE_TOKEN`.
- Run `terraform plan` on a Linux runner (local is blocked by an Application Control policy on the Contabo provider binary), review drift, import where needed.
- Only then make `plan` a required check and let apply run.

Refs #55.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>