### PR TITLE
chore(tf): CD plan verification — DO NOT MERGE until drift reviewed

### DIFF
--- a/terraform/contabo/backend.tf
+++ b/terraform/contabo/backend.tf
@@ -24,3 +24,5 @@ terraform {
     encrypt = true
   }
 }
+
+# CD plan verification trigger — no infra change (see PR). Safe to remove.


### PR DESCRIPTION
## Purpose — NOT a real change
Appends a comment to `backend.tf` (no infra change) purely to trigger the now-wired `terraform-plan-apply` **plan** job on a Linux runner. This is the **#55 verification** that couldn't run locally (Application Control policy blocks the Contabo provider binary).

## What to look for in the plan comment (posted by the workflow below)
- **Ideal:** `No changes` → state migration is perfect and the CD is safe to use.
- **Expected, given ClickOps origin:** some drift (resources built via dashboard, not cleanly `terraform import`-ed). For each drift line decide: `terraform import` / adjust HCL / accept.
- 🔴 **Watch for destroys/replaces** — especially the Cloudflare tunnel and Contabo instance.

## ⛔ DO NOT MERGE
Merging triggers `apply` of the saved plan. Keep this open as a **review artifact** until the plan reads clean (≈0 changes) after reconciliation. Then close it (or merge once it's genuinely a no-op).

Refs #55.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>