### PR TITLE
ci: fix CD apply-on-merge trigger (PAT) + auto-PR closes its issue

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,5 +16,11 @@ jobs:
     steps:
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (not GITHUB_TOKEN): a merge performed via GITHUB_TOKEN is attributed
+          # to github-actions[bot], and GitHub SUPPRESSES push/pull_request workflows
+          # for bot-token events — so the terraform CD `apply` job never fired on
+          # auto-merge. Using a PAT attributes the merge to a real user, so the
+          # `push: main` apply trigger runs. Falls back to GITHUB_TOKEN if GH_TOKEN
+          # is unset (auto-merge still works; apply just won't fire — as before).
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"

--- a/.github/workflows/claude-auto-pr.yml
+++ b/.github/workflows/claude-auto-pr.yml
@@ -34,8 +34,19 @@ jobs:
             exit 0
           fi
           if git rev-list --count "origin/${BASE}..origin/${BRANCH}" | grep -qvE '^0$'; then
-            gh pr create --draft --base "$BASE" --head "$BRANCH" --fill \
-              || echo "gh pr create failed (no diff or transient) — skipping."
+            url=$(gh pr create --draft --base "$BASE" --head "$BRANCH" --fill) \
+              || { echo "gh pr create failed (no diff or transient) — skipping."; exit 0; }
+            echo "Opened $url"
+            # Auto-close the source issue on merge: derive N from claude/issue-<N>-...
+            # branch names and append "Closes #N" to the PR body (gh won't add it).
+            ISSUE=$(printf '%s' "$BRANCH" | sed -nE 's#^claude/issue-0*([0-9]+).*#\1#p')
+            num=$(printf '%s' "$url" | sed -nE 's#.*/pull/([0-9]+).*#\1#p')
+            if [ -n "$ISSUE" ] && [ -n "$num" ]; then
+              gh pr view "$num" --json body --jq '.body' > /tmp/prbody.md
+              printf '\n\nCloses #%s\n' "$ISSUE" >> /tmp/prbody.md
+              gh pr edit "$num" --body-file /tmp/prbody.md \
+                && echo "PR #$num will close #$ISSUE on merge."
+            fi
           else
             echo "No commits on $BRANCH ahead of $BASE — no PR opened."
           fi


### PR DESCRIPTION
Two CI plumbing fixes for things found this session.

### 1. Apply-on-merge never fired (the real bug behind #47)
`auto-merge.yml` merged via `GITHUB_TOKEN` → merge attributed to `github-actions[bot]` → **GitHub suppresses push/PR workflows for bot-token events** → the terraform CD `apply` (`on: push: main`) never ran (confirmed on #59: nothing applied).

**Fix:** use a PAT (`secrets.GH_TOKEN`, falls back to GITHUB_TOKEN) so the merge is a real-user push → `apply` fires. **Keeps auto-merge** (your requirement) — a post-merge `push`/`pull_request: closed` workflow would *also* have been suppressed, so the token is the fix, not a new trigger.
> ⚠️ Requires `GH_TOKEN` to be a PAT with `repo` scope (it already exists in secrets). Side effect: main-CI runs post-merge (desirable). Easily reverted.

### 2. Handled issues weren't auto-closing
`claude-auto-pr.yml` opened PRs with `--fill` (no `Closes #N`), so resolved issues stayed open. Now it derives N from `claude/issue-<N>-…` and appends `Closes #N` → issues auto-close on merge.

Refs #32, #47.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>