### PR TITLE
fix(helm): VCT apiVersion/kind so ArgoCD reaches Synced (11 StatefulSets)

### DIFF
--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -67,7 +67,9 @@ spec:
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -145,7 +147,9 @@ spec:
           resources:
             {{- toYaml .Values.mongodb.resources | nindent 12 }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -213,7 +217,9 @@ spec:
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -297,7 +303,9 @@ spec:
           resources:
             {{- toYaml .Values.neo4j.resources | nindent 12 }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -387,7 +395,9 @@ spec:
           resources:
             {{- toYaml .Values.elasticsearch.resources | nindent 12 }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -458,7 +468,9 @@ spec:
             periodSeconds: 10
             failureThreshold: 6
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]

--- a/helm/fuzeinfra/templates/messaging.yaml
+++ b/helm/fuzeinfra/templates/messaging.yaml
@@ -91,7 +91,9 @@ spec:
           resources:
             {{- toYaml .Values.kafka.resources | nindent 12 }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -233,7 +235,9 @@ spec:
             requests: { cpu: 100m, memory: 256Mi }
             limits:   { cpu: "1",  memory: 1Gi }
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]

--- a/helm/fuzeinfra/templates/monitoring.yaml
+++ b/helm/fuzeinfra/templates/monitoring.yaml
@@ -150,7 +150,9 @@ spec:
           emptyDir: {}
         {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -216,7 +218,9 @@ spec:
           configMap:
             name: fuzeinfra-alertmanager-config
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -390,7 +394,9 @@ spec:
         {{- end }}
   {{- if .Values.grafana.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
@@ -480,7 +486,9 @@ spec:
           configMap:
             name: fuzeinfra-loki-config
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
## Why
`fuzeinfra-prod` was perpetually **OutOfSync** on 11 StatefulSets — but every sync `serverside-applied` them and they were **Healthy**. Cosmetic, not broken.

**Root cause (verified via render-vs-live diff):** the API server adds `apiVersion: v1` + `kind: PersistentVolumeClaim` to each `volumeClaimTemplates[]` entry; the chart omitted them. Argo normalizes other defaults but not VCT apiVersion/kind → diff never converges.

## Fix
Add `apiVersion`/`kind` to all **12** VCT entries (databases ×6, messaging ×2, monitoring ×4). Live already has these exact values → **no change to running resources**, it only lets Argo reach Synced.

## Note
The **Grafana** OutOfSync was a *different*, real issue (#29 removed `volumeClaimTemplates` → immutable-field patch forbidden) — already fixed live via an orphan-recreate; Grafana is now Synced/stateless.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>