### PR TITLE
fix(helm): neo4j 'logs' VCT apiVersion/kind (last OutOfSync StatefulSet)

### DIFF
--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -313,7 +313,9 @@ spec:
         resources:
           requests:
             storage: {{ .Values.neo4j.storage }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: logs
       spec:
         accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
Follow-up to #63. That fixed the first VCT entry per StatefulSet (10/11 converged). **neo4j has two VCTs (`data` + `logs`)** — only `data` was patched, so neo4j stayed OutOfSync on `logs`. This patches the `logs` entry too.

Verified live: after #63, out-of-sync dropped 12→1 (neo4j). This clears the last one.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>