### PR TITLE
ci(auto-pr): open @claude PRs ready, not draft (autonomous merge)

### DIFF
--- a/.github/workflows/claude-auto-pr.yml
+++ b/.github/workflows/claude-auto-pr.yml
@@ -34,7 +34,7 @@ jobs:
             exit 0
           fi
           if git rev-list --count "origin/${BASE}..origin/${BRANCH}" | grep -qvE '^0$'; then
-            url=$(gh pr create --draft --base "$BASE" --head "$BRANCH" --fill) \
+            url=$(gh pr create --base "$BASE" --head "$BRANCH" --fill) \
               || { echo "gh pr create failed (no diff or transient) — skipping."; exit 0; }
             echo "Opened $url"
             # Auto-close the source issue on merge: derive N from claude/issue-<N>-...


### PR DESCRIPTION
Autonomy policy: reviews dropped to 0 (CI remains the gate). `claude-auto-pr.yml` opened **draft** PRs and `auto-merge.yml` skips drafts → the @claude issue→merge flow stalled at draft (e.g. #67 for issue #65). Open ready so auto-merge completes on green CI.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>