### PR TITLE
chore(tf): apply pending cloudflare vanity routes + sealed-secrets (DRAFT — review plan first)

### DIFF
--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -533,3 +533,6 @@ resource "null_resource" "tunnel_secrets" {
     EOT
   }
 }
+
+# Trigger CD plan/apply of the already-reviewed pending changes (vanity
+# routes app/auth.fuzefront.com + sealed-secrets CF Access). See #59 plan.


### PR DESCRIPTION
DRAFT on purpose — triggers the CD `plan` so I can confirm it matches the #59-reviewed plan before it applies to prod. Marking ready merges it → applies → creates app/auth.fuzefront.com.

Refs #42, #46, #59.