### PR TITLE
fix(tf): guard argocd_sync provisioner (off in CI) — DRAFT, review plan

### DIFF
--- a/terraform/contabo/provisioning.tf
+++ b/terraform/contabo/provisioning.tf
@@ -135,6 +135,12 @@ resource "null_resource" "provision" {
 # for a fresh cluster on first apply or after VPS replacement.
 # ---------------------------------------------------------------------------
 resource "null_resource" "argocd_sync" {
+  # OFF by default — see var.enable_argocd_provisioner. It SSHes with a local key
+  # file that doesn't exist on CI runners, so it must not run under the CD. With
+  # count = 0 the connection block (and file(var.ssh_private_key_path)) is never
+  # evaluated. Argo selfHeal + argocd-register.yml cover the work it did.
+  count = var.enable_argocd_provisioner ? 1 : 0
+
   depends_on = [null_resource.provision]
 
   triggers = {

--- a/terraform/contabo/variables.tf
+++ b/terraform/contabo/variables.tf
@@ -173,3 +173,17 @@ variable "crit_bridge_token" {
   sensitive   = true
 }
 
+variable "enable_argocd_provisioner" {
+  description = <<-EOT
+    Run null_resource.argocd_sync, which SSHes to the server (using
+    ssh_private_key_path) to re-apply the ArgoCD Application/Project/SealedSecrets
+    manifests. OFF by default: it requires a local SSH private key FILE that does
+    not exist on CI runners (the merge-to-apply CD), so it breaks CI applies.
+    Ongoing reconciliation is handled by ArgoCD selfHeal, and one-time argo
+    registration by the argocd-register.yml workflow. Enable locally (in
+    terraform.tfvars) only if you want terraform to push argo manifests via SSH.
+  EOT
+  type        = bool
+  default     = false
+}
+


### PR DESCRIPTION
Fixes the CD apply failure on `null_resource.argocd_sync` (`file("~/.ssh/id_ed25519")` doesn't exist on CI runners). Gates it behind `enable_argocd_provisioner` (default false). Next apply destroys the orphaned `argocd_sync` (state cleanup, no SSH) and completes green.

Draft → I confirm the plan (destroy the null_resource + finish any pending in-place changes) before it applies. Refs #55.