### PR TITLE
fix(infra-request): AWS backend creds on plan/apply steps (unblocks node provisioning)

### DIFF
--- a/.github/workflows/infra-request-handler.yml
+++ b/.github/workflows/infra-request-handler.yml
@@ -53,6 +53,13 @@ concurrency:
 jobs:
   reconcile:
     runs-on: ubuntu-latest
+    # AWS creds for the S3 remote backend — needed by EVERY terraform step
+    # (init/plan/apply), not just init. Without these on the plan/apply steps the
+    # S3 backend can't refresh state ("No valid credential sources found"), which
+    # made every node-provisioning request's plan fail (so no VPS was ever created).
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_SECRET_ACCESS_KEY }}
     steps:
       - name: Check out FuzeInfra (module + whitelist + scripts)
         uses: actions/checkout@v4


### PR DESCRIPTION
**Why no 2nd VPS got created.** The infra-request handler's `plan`/`apply` steps had no AWS creds in env, so the S3 backend failed with `No valid credential sources found` → every node request's plan failed (gated PRs #64/#68 carry failed plans).

**Fix:** move `AWS_ACCESS_KEY_ID/SECRET` (from `TF_STATE_*`) to **job-level** env so init/plan/apply all reach the backend. Provider (Contabo) creds still come from `handler.auto.tfvars.json`.

Combined with landing the **V92/V76 whitelist** (#67 / issue #65), FuzeFront's `fuzefront-worker-2` (product V92) request will auto-apply and provision the node.

Refs #47, #65.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>