### PR TITLE
feat(infra-request): apply approved plan on gated-PR merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,14 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
-    if: "!github.event.pull_request.draft"
+    # Skip drafts, and skip GATED infra-request PRs (branch infra-request/*) —
+    # those are NON-whitelisted node requests that exist precisely for human
+    # approval. Auto-merging them would defeat the whitelist and auto-provision a
+    # paid VPS unattended. A human merges them; that triggers the approved apply
+    # (infra-request-apply-on-approve.yml).
+    if: >-
+      !github.event.pull_request.draft &&
+      !startsWith(github.event.pull_request.head.ref, 'infra-request/')
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/infra-request-apply-on-approve.yml
+++ b/.github/workflows/infra-request-apply-on-approve.yml
@@ -1,0 +1,63 @@
+# ===========================================================================
+# infra-request-apply-on-approve
+# ===========================================================================
+# Fills the gap behind a gated infra-request PR's "merge to approve".
+#
+# A NON-whitelisted infra-request is routed by infra-request-handler.yml to a
+# gated PR carrying `infra-requests/<slug>.json` (the request) + `.plan.txt`.
+# Merging that PR is the human approval — but on its own it applied NOTHING.
+#
+# This workflow closes the loop: when such a PR merges (a push to main that
+# adds/updates an infra-requests/*.json), it re-dispatches the request with
+# `approved: true`. The handler's validator treats approved=true as decision
+# `apply` (bypassing the whitelist for that one approved run), so the SAME apply
+# path runs — no duplicated terraform logic here.
+#
+# Note: auto-merge.yml deliberately does NOT auto-merge `infra-request/*` PRs, so
+# the merge here is always a human action (the approval).
+# ===========================================================================
+name: infra-request-apply-on-approve
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra-requests/**.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infra-request-apply-on-approve
+  cancel-in-progress: false
+
+jobs:
+  reapply-approved:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Re-dispatch merged (approved) infra-requests
+        env:
+          # A PAT so the dispatch (and the handler it triggers) is a real-user
+          # event, not a suppressed GITHUB_TOKEN one.
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Only the infra-request files added/modified by THIS push (the merged PR).
+          files=$(git diff --name-only --diff-filter=AM HEAD~1 HEAD -- 'infra-requests/*.json' || true)
+          if [ -z "$files" ]; then
+            echo "No infra-request json added/modified in this push — nothing to approve."
+            exit 0
+          fi
+          for f in $files; do
+            echo "Approved (merged): $f — re-dispatching with approved=true"
+            body=$(jq -c '{
+              event_type: "infra-request",
+              client_payload: { repo: .repo, ref: .ref, requests: .requests, approved: true }
+            }' "$f")
+            echo "$body" | gh api -X POST "repos/${{ github.repository }}/dispatches" --input -
+            echo "  dispatched."
+          done

--- a/.github/workflows/infra-request-handler.yml
+++ b/.github/workflows/infra-request-handler.yml
@@ -221,7 +221,10 @@ jobs:
             echo ""
             echo "**Validation reasons:** ${{ steps.validate.outputs.reasons }}"
             echo ""
-            echo "Review the \`terraform plan\` below and merge to approve. Do not merge if unexpected."
+            echo "Review the \`terraform plan\` below. **Merging this PR IS the approval** — it"
+            echo "re-dispatches the request as approved and the handler APPLIES it (provisioning"
+            echo "real infrastructure). Do not merge if unexpected. (These PRs are excluded from"
+            echo "auto-merge precisely so a human approves them.)"
             echo ""
             echo '```'
             cat ../consumer/deploy/terraform/plan.txt || true

--- a/scripts-tools/test_validate_infra_request.py
+++ b/scripts-tools/test_validate_infra_request.py
@@ -60,6 +60,18 @@ class ValidateTests(unittest.TestCase):
         decision, _ = validate(WHITELIST, {"changed": "deploy/argocd/applications/x.yaml"}, "izzywdev/FuzeFront")
         self.assertEqual(decision, "skip")
 
+    def test_approved_bypasses_whitelist(self):
+        # A human merged the gated PR → re-dispatch carries approved=true → apply
+        # even though the product_id is NOT whitelisted.
+        payload = {"approved": True, "requests": [{"name": "w1", "product_id": "V92", "region": "EU", "role": "workload"}]}
+        decision, _ = validate(WHITELIST, payload, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "apply")
+
+    def test_approved_still_skips_when_no_requests(self):
+        # approved is irrelevant if there's nothing to provision.
+        decision, _ = validate(WHITELIST, {"approved": True, "requests": []}, "izzywdev/FuzeFront")
+        self.assertEqual(decision, "skip")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts-tools/validate_infra_request.py
+++ b/scripts-tools/validate_infra_request.py
@@ -47,6 +47,12 @@ def validate(whitelist, payload, repo):
         # than opening a gated PR (argo-only/unrelated changes land here).
         return "skip", ["no infra 'requests' in payload — nothing to reconcile (not an infra-request)"]
 
+    # Manually approved: a human merged the gated PR, which re-dispatches the
+    # request with approved=true. That merge IS the approval, so apply regardless
+    # of the whitelist (the whitelist only governs UNATTENDED auto-apply).
+    if payload.get("approved") is True:
+        return "apply", ["manually approved via gated-PR merge — whitelist bypassed"]
+
     allowed_repos = whitelist.get("allowed_repos")
     if allowed_repos and repo not in allowed_repos:
         reasons.append(f"repo '{repo}' is not in allowed_repos")


### PR DESCRIPTION
Fills the gap: merging a gated infra-request PR now actually **applies** the request (it did nothing before).

- **validator**: `approved=true` → `apply` (the merge is the approval; whitelist only governs *unattended* auto-apply).
- **infra-request-apply-on-approve.yml** (NEW): gated PR merged (push touching `infra-requests/*.json`) → re-dispatch with `approved=true` → handler runs its existing apply path. No duplicated terraform.
- **auto-merge carve-out**: `infra-request/*` PRs don't auto-merge — they're for human approval (else reviews=0 would auto-provision a paid VPS unattended).
- handler gated-PR body now says merging approves + applies.

Refs #47.

Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>