### PR TITLE
fix(contabo): open Flannel VXLAN 8472/udp on control-plane firewall

### DIFF
--- a/terraform/contabo/provisioning.tf
+++ b/terraform/contabo/provisioning.tf
@@ -67,7 +67,17 @@ resource "null_resource" "provision" {
       # All HTTP(S) traffic enters exclusively through the Cloudflare Named Tunnel,
       # which cloudflared initiates as outbound-only connections — no inbound port needed.
       # Blocking 80/443 externally prevents direct VPS access bypassing WAF + Access.
-      "ufw allow 22/tcp && ufw allow 6443/tcp && ufw --force enable 2>/dev/null || true",
+      #
+      # 8472/udp = Flannel VXLAN overlay. REQUIRED once worker nodes join: without it
+      # the control-plane DROPs inbound VXLAN from agents, so pods on worker nodes
+      # can't reach control-plane services (CoreDNS/Postgres/Traefik) — symptom is
+      # cross-node DNS timeouts / EAI_AGAIN. (The worker module already opens 8472;
+      # the server never did, which broke the first worker that joined.)
+      # 10250/tcp = kubelet (parity with the worker module). NOTE: 8472 is opened
+      # Anywhere here, matching the worker cloud-init + the public-IP VXLAN design;
+      # the overlay is unauthenticated, so moving to flannel wireguard-native or a
+      # Contabo private VLAN is tracked as a hardening follow-up.
+      "ufw allow 22/tcp && ufw allow 6443/tcp && ufw allow 8472/udp && ufw allow 10250/tcp && ufw --force enable 2>/dev/null || true",
       "ufw delete allow 80/tcp 2>/dev/null || true",
       "ufw delete allow 443/tcp 2>/dev/null || true",
 

--- a/terraform/contabo/vps.tf
+++ b/terraform/contabo/vps.tf
@@ -22,8 +22,13 @@ resource "contabo_instance" "prod" {
     runcmd:
       # Ports 80/443 are intentionally omitted — all HTTP(S) traffic flows through
       # the Cloudflare Named Tunnel (outbound-only from cloudflared).
+      # 8472/udp = Flannel VXLAN overlay, 10250/tcp = kubelet — required for
+      # cross-node pod networking once worker nodes join (the server must accept
+      # inbound VXLAN from agents, or worker pods can't reach control-plane services).
       - ufw allow 22/tcp
       - ufw allow 6443/tcp
+      - ufw allow 8472/udp
+      - ufw allow 10250/tcp
       - ufw --force enable
   EOT
 


### PR DESCRIPTION
## Why
A 2nd k3s node joined prod but its pods couldn't reach control-plane services (CoreDNS/Postgres) — cross-node DNS `EAI_AGAIN`. Root cause: the **control-plane VPS ufw allowed only 22+6443, never 8472/udp** (Flannel VXLAN). Single-node hid it; the first worker exposed it. The worker module already opens 8472 — the server didn't.

## Change
Add `8472/udp` + `10250/tcp` to the control-plane firewall in both `vps.tf` (cloud-init) and `provisioning.tf` (remote-exec).

## Apply note
Neither path re-applies to the **live** server (cloud-init = first-boot only; `user_data` is in `ignore_changes`; remote-exec = create-only). The live control-plane was **already fixed manually** (scoped ufw 8472 between the two node IPs), restoring cross-node networking (verified: a worker pod now resolves CoreDNS + reaches Postgres). This PR makes the IaC correct for any rebuild and documents the change.

## Follow-up
8472 is opened Anywhere (matches the worker cloud-init + the existing public-IP VXLAN design). Hardening to flannel `wireguard-native` or a Contabo private VLAN is a separate tracked item.