### PR TITLE
harden(contabo): remove needless kubelet 10250 exposure from control-plane firewall

### DIFF
--- a/terraform/contabo/provisioning.tf
+++ b/terraform/contabo/provisioning.tf
@@ -73,11 +73,15 @@ resource "null_resource" "provision" {
       # can't reach control-plane services (CoreDNS/Postgres/Traefik) — symptom is
       # cross-node DNS timeouts / EAI_AGAIN. (The worker module already opens 8472;
       # the server never did, which broke the first worker that joined.)
-      # 10250/tcp = kubelet (parity with the worker module). NOTE: 8472 is opened
-      # Anywhere here, matching the worker cloud-init + the public-IP VXLAN design;
-      # the overlay is unauthenticated, so moving to flannel wireguard-native or a
-      # Contabo private VLAN is tracked as a hardening follow-up.
-      "ufw allow 22/tcp && ufw allow 6443/tcp && ufw allow 8472/udp && ufw allow 10250/tcp && ufw --force enable 2>/dev/null || true",
+      # NOTE: kubelet (10250) is intentionally NOT opened — k3s reaches agent kubelets
+      # through the agent's outbound tunnel to 6443, so no inbound 10250 is needed,
+      # and exposing the kubelet API is an unnecessary risk.
+      # SECURITY: 8472 is opened Anywhere here only as a rebuild bootstrap default
+      # (static cloud-init can't know future worker IPs). The RUNTIME posture is
+      # scoped — the live rule allows 8472 only from the specific node IPs, and the
+      # node-join path should add a scoped per-worker rule. The durable fix is moving
+      # the overlay onto flannel wireguard-native or a Contabo private VLAN (tracked).
+      "ufw allow 22/tcp && ufw allow 6443/tcp && ufw allow 8472/udp && ufw --force enable 2>/dev/null || true",
       "ufw delete allow 80/tcp 2>/dev/null || true",
       "ufw delete allow 443/tcp 2>/dev/null || true",
 

--- a/terraform/contabo/vps.tf
+++ b/terraform/contabo/vps.tf
@@ -22,13 +22,16 @@ resource "contabo_instance" "prod" {
     runcmd:
       # Ports 80/443 are intentionally omitted — all HTTP(S) traffic flows through
       # the Cloudflare Named Tunnel (outbound-only from cloudflared).
-      # 8472/udp = Flannel VXLAN overlay, 10250/tcp = kubelet — required for
-      # cross-node pod networking once worker nodes join (the server must accept
-      # inbound VXLAN from agents, or worker pods can't reach control-plane services).
+      # 8472/udp = Flannel VXLAN overlay — required for cross-node pod networking
+      # once worker nodes join (the server must accept inbound VXLAN from agents, or
+      # worker pods can't reach control-plane services). kubelet (10250) is NOT
+      # opened: k3s tunnels agent kubelets over the outbound 6443 connection, so no
+      # inbound 10250 is needed and exposing it would be an unnecessary risk.
+      # 8472 Anywhere here is a rebuild bootstrap default; the live runtime rule is
+      # scoped to node IPs (durable fix: wireguard-native overlay / private VLAN).
       - ufw allow 22/tcp
       - ufw allow 6443/tcp
       - ufw allow 8472/udp
-      - ufw allow 10250/tcp
       - ufw --force enable
   EOT
 


### PR DESCRIPTION
Follow-up to #80 (which auto-merged before this security fix landed).

Security review flagged the control-plane opening **kubelet 10250 + VXLAN 8472 Anywhere**. This PR:
- **Removes `ufw allow 10250/tcp`** from the control-plane (both `provisioning.tf` and `vps.tf`). k3s reaches agent kubelets via the agent's **outbound 6443 tunnel**, so the server needs no inbound 10250 — proven by the CP running healthy with only 22+6443. It was unnecessary attack surface I'd added for false 'parity'. (Never applied to the live box, so nothing to revert there.)
- Keeps **`8472/udp`** (the actual overlay fix) and documents that Anywhere is only a rebuild-bootstrap default — the **live** rule is scoped to node IPs, with wireguard-native/private-VLAN + scoped per-worker rules as the tracked durable hardening.

No live cluster change; IaC correctness + reduced rebuild attack surface.