### PR TITLE
fix(tf): clean plan + working merge-to-apply (#55 gate)

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -252,6 +252,13 @@ jobs:
           # The plan was produced by a different workflow run (the PR check).
           workflow: terraform-plan-apply.yml
           commit: ${{ steps.pr.outputs.head_sha }}
+          # CRITICAL: the plan job INTENTIONALLY fails (exit 1) when the plan is
+          # non-empty (the drift gate) — which is exactly the case where we DO want
+          # to apply on merge. dawidd6 defaults to workflow_conclusion=success and
+          # would skip that failed run, so the saved plan artifact is "not found"
+          # and merge-to-apply only ever worked for empty plans. Match ANY
+          # conclusion (pinned by commit) so the reviewed plan is recoverable.
+          workflow_conclusion: ""
           path: ${{ env.TF_ROOT }}
           if_no_artifact_found: fail
 

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -59,7 +59,10 @@ permissions:
 
 env:
   TF_ROOT: ${{ vars.TF_ROOT || 'terraform/contabo' }}
-  TERRAFORM_VERSION: "1.6.6"
+  # Must be >= the version that wrote the live state. The state was applied with
+  # 1.15.x, so an older CLI (1.6.6) mis-plans random_bytes/tunnel as a phantom
+  # secret rotation. Keep this in lockstep with whatever applies the state.
+  TERRAFORM_VERSION: "1.15.6"
   # AWS creds for the S3/DynamoDB backend (used by every `terraform init`).
   AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_SECRET_ACCESS_KEY }}

--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -153,8 +153,15 @@ resource "cloudflare_zero_trust_access_application" "app_launcher" {
   name             = "App Launcher"
   type             = "app_launcher"
   session_duration = var.access_session_duration
-  # Show the App Launcher portal (drifted to false via ClickOps; pin true).
-  app_launcher_visible = true
+
+  # NOTE: app_launcher_visible is INERT on a type=app_launcher resource —
+  # Cloudflare's API always stores it false and ignores writes, so the provider's
+  # computed default (true) vs the API (false) is a perpetual no-op diff. Ignore it
+  # (the API owns this field). The portal's TILES are the `launcher_bookmark`
+  # bookmark apps below — those carry app_launcher_visible=true and it sticks there.
+  lifecycle {
+    ignore_changes = [app_launcher_visible]
+  }
 }
 
 resource "cloudflare_zero_trust_access_policy" "app_launcher" {


### PR DESCRIPTION
Makes #55's Terraform-CD actually functional. Two fixes:

## 1. Clean plan — `app_launcher_visible` is API-inert
On a `type=app_launcher` resource, Cloudflare **ignores** `app_launcher_visible` (always stores `false`), so the provider's computed-`true` default was a **perpetual no-op diff** (PR #84's `= true` reverted on the very next refresh). `ignore_changes` it — the API owns that field. **Plan is now clean (0 changes).**
- The launcher's **12 tiles** come from the `launcher_bookmark` (type=`bookmark`) apps — those carry `app_launcher_visible=true` and it **persists**. Untouched. Your launcher/Grafana tile are unaffected.

## 2. merge-to-apply was broken for non-empty plans
The drift gate (#73) intentionally **fails** the plan job on a non-empty plan — exactly when you want to apply on merge. But the apply job's `dawidd6` download defaulted to `workflow_conclusion: success`, so it skipped the (intentionally) failed plan run → 'no artifact found' (this is why PR #84's apply failed). Set `workflow_conclusion: ''` to recover the reviewed plan from any conclusion. **Now merging a terraform PR with real changes applies the reviewed plan.**

## #55 status after this
Backend (S3+DynamoDB), state migration, ~13 CI secrets, and a **clean plan** are all in place; merge-to-apply works. Remaining: add `terraform-plan / plan` as a required check (Task 4) — the deadlock-safe pattern is already in the workflow.