### PR TITLE
fix(argo): sealed-secrets dead chart-repo URL + recur-proof registration (#88)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'helm/**'
       - 'argocd/applications/fuzeinfra-prod.yaml'
+      - 'argocd/applications/sealed-secrets.yaml'
       - '.github/workflows/deploy-prod.yml'
   workflow_dispatch:
 
@@ -41,7 +42,7 @@ jobs:
       # Trigger an immediate ArgoCD sync via kubectl patch.
       # Requires KUBE_CONFIG secret (set by `terraform apply` in terraform/contabo/).
       # If the secret is absent the deploy is skipped with a warning.
-      - name: Trigger ArgoCD sync
+      - name: Register standalone Argo apps + trigger sync
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: |
@@ -52,9 +53,22 @@ jobs:
           fi
           echo "$KUBE_CONFIG" | base64 -d > /tmp/kubeconfig
           chmod 600 /tmp/kubeconfig
-          kubectl --kubeconfig /tmp/kubeconfig \
-            -n argocd patch application fuzeinfra-prod \
-            --type merge \
-            -p '{"operation":{"initiatedBy":{"username":"ci"},"sync":{"revision":"HEAD"}}}' \
-            && echo "ArgoCD sync triggered for fuzeinfra-prod" \
-            || echo "::warning::ArgoCD patch failed — check that ArgoCD is running on the cluster"
+          export KUBECONFIG=/tmp/kubeconfig
+
+          # Register the standalone Application manifests idempotently on every prod
+          # deploy. Terraform only applies them on first-provision, so on a VPS
+          # rebuild (or if one was never registered — e.g. sealed-secrets, #88) they
+          # would silently go missing. apply -f makes the repo the source of truth.
+          for app in fuzeinfra-prod sealed-secrets; do
+            kubectl apply -f "argocd/applications/$app.yaml" \
+              && echo "registered $app" \
+              || echo "::warning::failed to register $app"
+          done
+
+          # Kick an immediate sync so the rollout starts seconds after merge.
+          for app in fuzeinfra-prod sealed-secrets; do
+            kubectl -n argocd patch application "$app" --type merge \
+              -p '{"operation":{"initiatedBy":{"username":"ci"},"sync":{}}}' \
+              && echo "sync triggered for $app" \
+              || echo "::warning::sync patch failed for $app"
+          done

--- a/argocd/applications/sealed-secrets.yaml
+++ b/argocd/applications/sealed-secrets.yaml
@@ -25,9 +25,12 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://bitnami-labs.github.io/sealed-secrets
+    # NOTE: sealed-secrets migrated bitnami-labs -> bitnami org (2026-06-15) and
+    # GitHub Pages URLs do NOT redirect, so the old bitnami-labs.github.io URL
+    # 404s (wedged this app's manifest generation). New repo:
+    repoURL: https://bitnami.github.io/sealed-secrets
     chart: sealed-secrets
-    # Pin the chart; bump deliberately. 2.16.x ships controller v0.27.x.
+    # Pin the chart; bump deliberately. 2.16.0 ships controller v0.27.0.
     targetRevision: 2.16.0
     helm:
       releaseName: sealed-secrets

--- a/argocd/applications/sealed-secrets.yaml
+++ b/argocd/applications/sealed-secrets.yaml
@@ -75,7 +75,11 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true
+      # ServerSideApply intentionally OFF: the controller already exists in the
+      # cluster (adopted from a prior hand-apply). With SSA, Argo falls back to a
+      # forced apply on field-manager conflict and errors "--force cannot be used
+      # with --server-side", wedging the sync. Client-side apply adopts the
+      # existing resources cleanly via the last-applied annotation.
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
Gets #88 to completion. **Real root cause:** the `sealed-secrets` Argo app pulled its Helm chart from `https://bitnami-labs.github.io/sealed-secrets`, which now **404s** — the project migrated `bitnami-labs`→`bitnami` org on 2026-06-15 and GitHub Pages URLs don't redirect ([announcement](https://github.com/bitnami/sealed-secrets/issues/1982)). That wedged manifest generation (sync=Unknown). 

## Fixes
1. **repoURL → `https://bitnami.github.io/sealed-secrets`** (2.16.0 / controller 0.27.0 still published there — no controller change). Applied live → app is now **Synced/Healthy**, `cert.pem`=200.
2. **ServerSideApply off** — so the chart adopts the already-running (hand-installed) controller cleanly instead of erroring `--force cannot be used with --server-side`.
3. **Recur-proof** — `deploy-prod.yml` only ever *synced* `fuzeinfra-prod`; it never *registered* the standalone apps, so sealed-secrets (applied only by terraform on first-provision) silently vanished. Now every prod deploy idempotently `kubectl apply`s the standalone Application manifests → survives a VPS rebuild.

Live state already reconciled; this makes it GitOps-durable. Closes #88.