### PR TITLE
fix: governance-nightly OIDC permission

### DIFF
--- a/.github/workflows/governance-nightly.yml
+++ b/.github/workflows/governance-nightly.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write      # triage/update/comment, update-branch
   issues: write             # file the tracking issue, close resolved issues
   actions: read
+  id-token: write           # claude-code-action OIDC
 
 concurrency:
   group: governance-nightly


### PR DESCRIPTION
Add id-token:write so claude-code-action can fetch its OIDC token.