### PR TITLE
fix(chart): parameterize selectorLabels by release name — no-op migration (#81)

### DIFF
--- a/argocd/applications/fuzeinfra-aws.yaml
+++ b/argocd/applications/fuzeinfra-aws.yaml
@@ -18,6 +18,10 @@ spec:
     targetRevision: main
     path: helm/fuzeinfra
     helm:
+      # Pin release name to "fuzeinfra" — the chart derives the (immutable)
+      # instance selector label from {{ .Release.Name }}; existing deployments
+      # carry instance=fuzeinfra, so the release name must render "fuzeinfra".
+      releaseName: fuzeinfra
       valueFiles:
         - values-aws.yaml
   destination:

--- a/argocd/applications/fuzeinfra-local.yaml
+++ b/argocd/applications/fuzeinfra-local.yaml
@@ -15,6 +15,10 @@ spec:
     targetRevision: main
     path: helm/fuzeinfra
     helm:
+      # Pin release name to "fuzeinfra" — the chart derives the (immutable)
+      # instance selector label from {{ .Release.Name }}; existing deployments
+      # carry instance=fuzeinfra, so the release name must render "fuzeinfra".
+      releaseName: fuzeinfra
       valueFiles:
         - values-local.yaml
   destination:

--- a/argocd/applications/fuzeinfra-prod.yaml
+++ b/argocd/applications/fuzeinfra-prod.yaml
@@ -15,6 +15,13 @@ spec:
     targetRevision: main
     path: helm/fuzeinfra
     helm:
+      # Pin the Helm release name to "fuzeinfra" (not the default app name
+      # "fuzeinfra-prod"). The chart's selectorLabels now derive instance from
+      # {{ .Release.Name }}; the LIVE StatefulSets carry instance=fuzeinfra (the
+      # old hardcoded value) and that label is IMMUTABLE, so the release name MUST
+      # render "fuzeinfra" to keep this a no-op. Verified: helm template with
+      # release "fuzeinfra" is byte-identical to the previous output.
+      releaseName: fuzeinfra
       valueFiles:
         - values-contabo.yaml
   destination:

--- a/helm/fuzeinfra/templates/_helpers.tpl
+++ b/helm/fuzeinfra/templates/_helpers.tpl
@@ -17,11 +17,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end -}}
 
 {{/*
-Per-component selector labels. Usage: {{ include "fuzeinfra.selectorLabels" (dict "component" "postgres") }}
+Per-component selector labels. Usage: {{ include "fuzeinfra.selectorLabels" (dict "component" "postgres" "root" $) }} — root REQUIRED (for .Release.Name)
 */}}
 {{- define "fuzeinfra.selectorLabels" -}}
 app.kubernetes.io/name: {{ .component }}
-app.kubernetes.io/instance: fuzeinfra
+app.kubernetes.io/instance: {{ .root.Release.Name }}
 {{- end -}}
 
 {{/*

--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -113,7 +113,7 @@ spec:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-init") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-init" "root" $) | nindent 8 }}
     spec:
       restartPolicy: Never
       containers:
@@ -168,10 +168,10 @@ metadata:
   name: fuzeinfra-airflow-webserver
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.airflow.webPort }}
@@ -187,12 +187,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver" "root" $) | nindent 8 }}
     spec:
       initContainers:
         {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
@@ -232,12 +232,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler" "root" $) | nindent 8 }}
     spec:
       initContainers:
         {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
@@ -265,12 +265,12 @@ spec:
   replicas: {{ .Values.airflow.workerReplicas }}
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-worker" "root" $) | nindent 8 }}
     spec:
       initContainers:
         {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
@@ -298,10 +298,10 @@ metadata:
   name: fuzeinfra-airflow-flower
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.airflow.flowerPort }}
@@ -317,12 +317,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: flower

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -6,11 +6,11 @@ metadata:
   name: fuzeinfra-postgres
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres" "root" $) | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres" "root" $) | nindent 4 }}
   ports:
     - name: postgres
       port: {{ .Values.postgres.port }}
@@ -27,12 +27,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: postgres
@@ -88,11 +88,11 @@ metadata:
   name: fuzeinfra-mongodb
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb" "root" $) | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb" "root" $) | nindent 4 }}
   ports:
     - name: mongodb
       port: {{ .Values.mongodb.port }}
@@ -109,12 +109,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: mongodb
@@ -168,11 +168,11 @@ metadata:
   name: fuzeinfra-redis
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "redis" "root" $) | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "redis" "root" $) | nindent 4 }}
   ports:
     - name: redis
       port: {{ .Values.redis.port }}
@@ -189,12 +189,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "redis" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "redis") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "redis" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: redis
@@ -238,10 +238,10 @@ metadata:
   name: fuzeinfra-neo4j
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.neo4j.httpPort }}
@@ -261,12 +261,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: neo4j
@@ -334,10 +334,10 @@ metadata:
   name: fuzeinfra-elasticsearch
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.elasticsearch.port }}
@@ -354,12 +354,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch" "root" $) | nindent 8 }}
     spec:
       initContainers:
         # Elasticsearch requires vm.max_map_count >= 262144.
@@ -418,10 +418,10 @@ metadata:
   name: fuzeinfra-chromadb
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.chromadb.port }}
@@ -438,12 +438,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "chromadb" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: chromadb

--- a/helm/fuzeinfra/templates/dns-tunnel.yaml
+++ b/helm/fuzeinfra/templates/dns-tunnel.yaml
@@ -29,11 +29,11 @@ metadata:
   name: fuzeinfra-dnsmasq
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq" "root" $) | nindent 4 }}
 spec:
   type: {{ .Values.dnsmasq.serviceType }}
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq" "root" $) | nindent 4 }}
   ports:
     - name: dns-udp
       port: {{ .Values.dnsmasq.dnsPort }}
@@ -58,7 +58,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq" "root" $) | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -66,7 +66,7 @@ spec:
         checksum/config: {{ .Values.global.domain | printf "%s-%s" .Values.dnsmasq.wildcardTarget | sha256sum }}
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "dnsmasq" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: dnsmasq
@@ -138,12 +138,12 @@ spec:
   replicas: {{ .Values.cloudflareTunnel.replicas }}
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "cloudflare-tunnel") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "cloudflare-tunnel" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "cloudflare-tunnel") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "cloudflare-tunnel" "root" $) | nindent 8 }}
       annotations:
         checksum/tunnel-id: {{ .Values.cloudflareTunnel.tunnelId | sha256sum }}
     spec:

--- a/helm/fuzeinfra/templates/kube-state-metrics.yaml
+++ b/helm/fuzeinfra/templates/kube-state-metrics.yaml
@@ -99,10 +99,10 @@ metadata:
   name: fuzeinfra-kube-state-metrics
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics" "root" $) | nindent 4 }}
   ports:
     - name: http-metrics
       port: 8080
@@ -121,12 +121,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "kube-state-metrics" "root" $) | nindent 8 }}
     spec:
       serviceAccountName: fuzeinfra-kube-state-metrics
       securityContext:

--- a/helm/fuzeinfra/templates/messaging.yaml
+++ b/helm/fuzeinfra/templates/messaging.yaml
@@ -6,11 +6,11 @@ metadata:
   name: fuzeinfra-kafka
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka" "root" $) | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka" "root" $) | nindent 4 }}
   ports:
     - name: broker
       port: {{ .Values.kafka.port }}
@@ -30,12 +30,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: kafka
@@ -112,10 +112,10 @@ metadata:
   name: fuzeinfra-kafka-ui
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.kafkaUi.port }}
@@ -131,12 +131,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka-ui" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: kafka-ui
@@ -171,10 +171,10 @@ metadata:
   name: fuzeinfra-rabbitmq
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq" "root" $) | nindent 4 }}
   ports:
     - name: amqp
       port: {{ .Values.rabbitmq.amqpPort }}
@@ -194,12 +194,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: rabbitmq
@@ -256,10 +256,10 @@ metadata:
   name: fuzeinfra-mongo-express
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.mongoExpress.port }}
@@ -275,12 +275,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "mongo-express" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: mongo-express

--- a/helm/fuzeinfra/templates/monitoring.yaml
+++ b/helm/fuzeinfra/templates/monitoring.yaml
@@ -50,10 +50,10 @@ metadata:
   name: fuzeinfra-prometheus
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.prometheus.port }}
@@ -70,12 +70,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "prometheus" "root" $) | nindent 8 }}
     spec:
       serviceAccountName: fuzeinfra-monitoring
       securityContext:
@@ -171,10 +171,10 @@ metadata:
   name: fuzeinfra-alertmanager
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.alertmanager.port }}
@@ -191,12 +191,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "alertmanager" "root" $) | nindent 8 }}
     spec:
       containers:
         - name: alertmanager
@@ -239,10 +239,10 @@ metadata:
   name: fuzeinfra-grafana
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.grafana.port }}
@@ -259,12 +259,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "grafana" "root" $) | nindent 8 }}
     spec:
       {{- if .Values.grafana.dashboardSidecar.enabled }}
       serviceAccountName: fuzeinfra-monitoring
@@ -416,10 +416,10 @@ metadata:
   name: fuzeinfra-loki
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "loki" "root" $) | nindent 4 }}
 spec:
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "loki" "root" $) | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.loki.port }}
@@ -436,12 +436,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "loki" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "loki") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "loki" "root" $) | nindent 8 }}
     spec:
       securityContext:
         fsGroup: 10001
@@ -510,12 +510,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "promtail") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "promtail" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "promtail") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "promtail" "root" $) | nindent 8 }}
     spec:
       serviceAccountName: fuzeinfra-monitoring
       containers:
@@ -563,11 +563,11 @@ metadata:
   name: fuzeinfra-node-exporter
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter" "root" $) | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter" "root" $) | nindent 4 }}
   ports:
     - name: metrics
       port: {{ .Values.nodeExporter.port }}
@@ -582,12 +582,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 6 }}
+      {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter" "root" $) | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter") | nindent 8 }}
+        {{- include "fuzeinfra.selectorLabels" (dict "component" "node-exporter" "root" $) | nindent 8 }}
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Completes #81 **without** the scary StatefulSet orphan-recreate migration.

## The problem (and why it looked blocking)
`fuzeinfra.selectorLabels` hardcoded `app.kubernetes.io/instance: fuzeinfra`, so two co-deployed releases cross-selected each other's pods (the split-brain Postgres root cause). That label is part of the **immutable** StatefulSet `.spec.selector` — a naive `{{ .Release.Name }}` change would render `fuzeinfra-prod` ≠ `fuzeinfra`, breaking the selector and forcing a recreate of every stateful service.

## The no-op fix
1. `selectorLabels` now takes root context (`"root" $` added at all **86** call sites) → `instance: {{ .root.Release.Name }}`.
2. **Pin `releaseName: fuzeinfra`** on all three fuzeinfra Argo apps. Since the live resources already carry `instance=fuzeinfra`, rendering `{{ .Release.Name }}` = `fuzeinfra` keeps it **identical** — no selector change, no migration.

## Verification
- `helm template fuzeinfra ...` is **semantically byte-identical** to before (`diff -w` empty; all 81 instance labels = `fuzeinfra`).
- `helm lint` clean.
- ArgoCD compares parsed objects → sees **no change** on sync.

A consumer deploying the chart under a different release name now gets a unique selector → no cross-select. Closes #81. (Also a live test of the robust auto-merge #94.)