### PR TITLE
feat(local-tls): centralized cert-manager + local CA for kind (#10)

### DIFF
--- a/docs/LOCAL_TLS.md
+++ b/docs/LOCAL_TLS.md
@@ -1,0 +1,77 @@
+# Local TLS — shared cert management (issue #10)
+
+FuzeInfra provides **centralized cert management for local (kind) development** so
+consumer apps don't each install their own cert-manager + CA. `setup-kind.sh`
+installs **cert-manager** and a self-signed **`fuzeinfra-local-ca` ClusterIssuer**;
+any app gets a trusted cert for its `*.dev.local` host just by annotating its
+Ingress.
+
+> **Scope: local dev only.** Production terminates TLS at the **Cloudflare edge**
+> (the Named Tunnel), so prod services are HTTP behind Traefik and need no
+> cert-manager. Do **not** apply this to the Contabo cluster.
+
+## What you get
+
+- `cert-manager` running in the `cert-manager` namespace.
+- A 10-year self-signed root CA → the **`fuzeinfra-local-ca`** ClusterIssuer.
+- Cert manifests in [`k8s/local-tls/cluster-issuer.yaml`](../k8s/local-tls/cluster-issuer.yaml).
+
+## Get HTTPS for your service (2 steps)
+
+### 1. Annotate your Ingress
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: myapp
+  annotations:
+    cert-manager.io/cluster-issuer: fuzeinfra-local-ca   # <- issue from the shared CA
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [myapp.dev.local]
+      secretName: myapp-tls                                # cert-manager fills this in
+  rules:
+    - host: myapp.dev.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: myapp
+                port: { number: 80 }
+```
+
+cert-manager watches the Ingress, issues a cert signed by `fuzeinfra-local-ca`,
+and stores it in `myapp-tls`. ingress-nginx then serves `https://myapp.dev.local`.
+
+### 2. Trust the CA once (so no `-k` / browser warnings)
+
+```bash
+kubectl -n cert-manager get secret fuzeinfra-local-ca \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d > fuzeinfra-local-ca.crt
+```
+
+Import `fuzeinfra-local-ca.crt` into your trust store:
+
+- **macOS:** `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain fuzeinfra-local-ca.crt`
+- **Linux:** `sudo cp fuzeinfra-local-ca.crt /usr/local/share/ca-certificates/ && sudo update-ca-certificates`
+- **Windows:** `Import-Certificate -FilePath fuzeinfra-local-ca.crt -CertStoreLocation Cert:\LocalMachine\Root`
+
+Now `https://myapp.dev.local` is trusted everywhere on your machine.
+
+## Migrating off a per-repo cert-manager
+
+If your repo ships its own local cert-manager + CA (e.g. FuzeFront's
+`deploy/local-tls/cert-manager-local-ca.yaml`), you can **delete it** and switch
+the Ingress annotation to `cert-manager.io/cluster-issuer: fuzeinfra-local-ca`.
+FuzeInfra now owns it centrally.
+
+## Notes
+
+- The CA secret lives at `cert-manager/fuzeinfra-local-ca`. Re-running
+  `setup-kind.sh` is idempotent; the CA is regenerated only if the secret is
+  missing (after which re-trust the new CA).
+- Bump `CERT_MANAGER_VERSION` in `k8s/kind/setup-kind.sh` to upgrade cert-manager.

--- a/k8s/kind/setup-kind.sh
+++ b/k8s/kind/setup-kind.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CLUSTER_NAME="fuzeinfra"
 NAMESPACE="fuzeinfra"
+CERT_MANAGER_VERSION="v1.16.2"   # bump deliberately
 
 command -v kind   >/dev/null || { echo "kind not found - https://kind.sigs.k8s.io"; exit 1; }
 command -v kubectl>/dev/null || { echo "kubectl not found"; exit 1; }
@@ -34,6 +35,22 @@ kubectl wait --namespace ingress-nginx \
   --selector=app.kubernetes.io/component=controller \
   --timeout=180s
 
+echo "==> Installing cert-manager ($CERT_MANAGER_VERSION)"
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+echo "==> Waiting for cert-manager to be ready"
+kubectl wait --namespace cert-manager \
+  --for=condition=Available --timeout=180s deployment --all
+
+echo "==> Installing the FuzeInfra local CA ClusterIssuer (shared local TLS)"
+# Retry: the CRDs/webhook may take a moment to register after the deployments are Available.
+for i in 1 2 3 4 5; do
+  kubectl apply -f "$REPO_ROOT/k8s/local-tls/cluster-issuer.yaml" && break
+  echo "    cert-manager webhook not ready yet, retrying ($i)..."; sleep 6
+done
+kubectl wait --for=condition=Ready --timeout=120s \
+  clusterissuer/fuzeinfra-local-ca 2>/dev/null || \
+  echo "    (CA ClusterIssuer still initializing — it'll be Ready shortly)"
+
 echo "==> Deploying FuzeInfra Helm chart"
 helm upgrade --install fuzeinfra "$REPO_ROOT/helm/fuzeinfra" \
   --namespace "$NAMESPACE" --create-namespace \
@@ -55,4 +72,14 @@ wildcard for *.dev.local:
 
 Then open:  http://grafana.dev.local  (admin / admin)
 Check pods: kubectl -n $NAMESPACE get pods
+
+==> Local HTTPS (shared cert management — issue #10)
+cert-manager + the 'fuzeinfra-local-ca' ClusterIssuer are installed. Any app's
+Ingress gets a trusted cert by adding:
+    annotations: { cert-manager.io/cluster-issuer: fuzeinfra-local-ca }
+    spec.tls: [{ hosts: [<host>.dev.local], secretName: <host>-tls }]
+Trust the local CA ONCE so browsers/curl accept it (no -k needed):
+    kubectl -n cert-manager get secret fuzeinfra-local-ca -o jsonpath='{.data.tls\\.crt}' | base64 -d > fuzeinfra-local-ca.crt
+    # then import fuzeinfra-local-ca.crt into your OS/browser trust store
+See docs/LOCAL_TLS.md for the full consumer guide.
 EOF

--- a/k8s/local-tls/cluster-issuer.yaml
+++ b/k8s/local-tls/cluster-issuer.yaml
@@ -1,0 +1,50 @@
+# =============================================================================
+# FuzeInfra LOCAL (kind) TLS — self-signed CA + ClusterIssuer
+# =============================================================================
+# Centralized cert management for local dev so consumer apps DON'T each install
+# their own cert-manager + CA (issue #10). Applied by k8s/kind/setup-kind.sh
+# after cert-manager is installed.
+#
+# Chain: a self-signed bootstrap issuer mints a long-lived root CA, which backs
+# the `fuzeinfra-local-ca` ClusterIssuer. Any Ingress in any namespace that adds
+#   cert-manager.io/cluster-issuer: fuzeinfra-local-ca
+# plus a tls: block gets a cert signed by that CA — trusted once the CA is
+# imported into the host trust store (see docs/LOCAL_TLS.md).
+#
+# LOCAL DEV ONLY. Prod terminates TLS at the Cloudflare edge (the tunnel), so
+# prod needs no cert-manager — do not apply this to the Contabo cluster.
+# =============================================================================
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: fuzeinfra-selfsigned-bootstrap
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: fuzeinfra-local-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: FuzeInfra Local Dev CA
+  secretName: fuzeinfra-local-ca           # the CA keypair the ClusterIssuer signs with
+  duration: 87600h0m0s                     # 10 years — local dev, no rotation churn
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fuzeinfra-selfsigned-bootstrap
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: fuzeinfra-local-ca
+spec:
+  ca:
+    # A CA ClusterIssuer reads its keypair from a Secret in the cluster
+    # resource namespace (cert-manager's namespace by default).
+    secretName: fuzeinfra-local-ca


### PR DESCRIPTION
Implements #10 **for local dev only** (per the owner: prod terminates TLS at the Cloudflare edge, so prod needs no cert-manager).

## What
- `setup-kind.sh` installs **cert-manager** + a self-signed **`fuzeinfra-local-ca` ClusterIssuer** (manifest in `k8s/local-tls/cluster-issuer.yaml`).
- Consumers get a trusted `*.dev.local` cert by adding `cert-manager.io/cluster-issuer: fuzeinfra-local-ca` + a `tls:` block to their Ingress — no per-repo cert-manager needed.
- `docs/LOCAL_TLS.md`: 2-step consumer guide + one-time CA trust + how to delete a per-repo CA (e.g. FuzeFront's `deploy/local-tls/`) and use this instead.

## Not touched
Prod (`values-contabo` / the Contabo cluster) — intentionally. The cert-manager install is gated to the kind setup script.

Closes #10.