### PR TITLE
fix(contabo): scale elastic/rabbitmq/airflow to 0 for headroom — reversible (#93)

### DIFF
--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -184,7 +184,7 @@ metadata:
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ dig "replicas" 1 .Values.airflow }}
   selector:
     matchLabels:
       {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-webserver" "root" $) | nindent 6 }}
@@ -229,7 +229,7 @@ metadata:
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ dig "replicas" 1 .Values.airflow }}
   selector:
     matchLabels:
       {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-scheduler" "root" $) | nindent 6 }}
@@ -314,7 +314,7 @@ metadata:
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ dig "replicas" 1 .Values.airflow }}
   selector:
     matchLabels:
       {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower" "root" $) | nindent 6 }}

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -351,7 +351,7 @@ metadata:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
   serviceName: fuzeinfra-elasticsearch
-  replicas: 1
+  replicas: {{ dig "replicas" 1 .Values.elasticsearch }}
   selector:
     matchLabels:
       {{- include "fuzeinfra.selectorLabels" (dict "component" "elasticsearch" "root" $) | nindent 6 }}

--- a/helm/fuzeinfra/templates/messaging.yaml
+++ b/helm/fuzeinfra/templates/messaging.yaml
@@ -191,7 +191,7 @@ metadata:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 spec:
   serviceName: fuzeinfra-rabbitmq
-  replicas: 1
+  replicas: {{ dig "replicas" 1 .Values.rabbitmq }}
   selector:
     matchLabels:
       {{- include "fuzeinfra.selectorLabels" (dict "component" "rabbitmq" "root" $) | nindent 6 }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -44,12 +44,20 @@ redis:
     requests: { cpu: 50m,  memory: 128Mi }
     limits:   { cpu: 500m, memory: 256Mi }
 
+# TEMPORARY headroom reduction for the saturated single control-plane node (#93).
+# elasticsearch / rabbitmq / airflow are scaled to 0 pods. Their StatefulSets and
+# PVCs are RETAINED (no prune, no data loss) — set replicas back to 1 to restore.
+# mongo / neo4j / postgres / redis / kafka / chromadb / monitoring stay running.
 elasticsearch:
+  replicas: 0
   storage: 20Gi
   javaOpts: "-Xms512m -Xmx512m"
   resources:
     requests: { cpu: 250m, memory: 1Gi }
     limits:   { cpu: "1",  memory: 1536Mi }
+
+rabbitmq:
+  replicas: 0   # TEMP headroom (#93) — restore to 1 when the node has capacity
 
 kafka:
   storage: 10Gi
@@ -100,7 +108,8 @@ grafana:
 #     existingSecret: "loki-s3"
 
 airflow:
-  workerReplicas: 1
+  replicas: 0          # TEMP headroom (#93): webserver/scheduler/flower -> 0 pods
+  workerReplicas: 0    # TEMP headroom (#93): celery worker -> 0 pods
   # 4 vCPU / 8 GB node — cap concurrency and memory to stop the worker from
   # crowding out CoreDNS/Postgres under memory pressure.
   celeryWorkerConcurrency: 4


### PR DESCRIPTION
Frees the saturated single control-plane node **without removing anything** (per the owner: mongo/neo4j/elastic are needed; only temporarily reduce elastic/rabbit/airflow to 0 pods).

## What
- Temporarily **scale to 0 pods**: `elasticsearch`, `rabbitmq`, `airflow` (webserver/scheduler/worker/flower). **Reversible** — StatefulSets + PVCs are **retained** (no prune, no data loss); set `replicas: 1` to restore.
- **Kept running**: mongo, neo4j, postgres, redis, kafka, chromadb, monitoring.
- Replicas parameterized via `dig` (Helm's `default` treats `0` as empty → would render 1; `dig` honors `0`).
- Verified: render = elastic/rabbit/airflow → 0, mongo/neo4j → 1; `helm lint` clean.

## vs #97
Supersedes #97, which used `enabled: false` and would have **pruned** mongo/neo4j/elastic (services you need). Closing #97.