### PR TITLE
feat(argocd): isolate FuzeInfra namespace — FuzeInfra-owned restricted consumer projects

### DIFF
--- a/argocd/install/setup-argocd.sh
+++ b/argocd/install/setup-argocd.sh
@@ -27,8 +27,11 @@ kubectl apply -n argocd \
 echo "==> Waiting for Argo CD server to be ready"
 kubectl -n argocd rollout status deploy/argocd-server --timeout=300s
 
-echo "==> Applying FuzeInfra AppProject"
+echo "==> Applying AppProjects (FuzeInfra owns the destination/security boundary)"
 kubectl apply -f "$ARGOCD_DIR/projects/fuzeinfra.yaml"
+# Consumer projects are FuzeInfra-owned + restricted (cannot deploy into the
+# fuzeinfra namespace). Add one per consumer repo.
+kubectl apply -f "$ARGOCD_DIR/projects/fuzefront.yaml"
 
 case "$ENVIRONMENT" in
   local)

--- a/argocd/projects/fuzefront.yaml
+++ b/argocd/projects/fuzefront.yaml
@@ -1,0 +1,37 @@
+# Argo CD AppProject for the FuzeFront consumer — OWNED BY FuzeInfra.
+#
+# ISOLATION BOUNDARY (FuzeInfra#99): consumer apps must NOT be able to deploy into
+# FuzeInfra's own `fuzeinfra` namespace. FuzeFront previously self-created a
+# `fuzefront` project that granted itself the `fuzeinfra` namespace and used it to
+# redeploy a *duplicate* FuzeInfra (split-brain Postgres/Kafka, control-plane
+# saturation, cluster-wide 502 — see FuzeFront#95 / FuzeInfra#93).
+#
+# GOVERNANCE RULE: FuzeInfra owns AppProjects (the destination/security boundary);
+# consumers only create Applications WITHIN their assigned, restricted project.
+# Consumers consume FuzeInfra services via in-cluster service DNS (cross-namespace
+# networking) — that needs NO Argo destination into `fuzeinfra`.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: fuzefront
+  namespace: argocd
+spec:
+  description: FuzeFront product (consumer of FuzeInfra) — may deploy ONLY into its own namespace.
+  sourceRepos:
+    - https://github.com/izzywdev/FuzeFront.git
+  destinations:
+    # The product's workloads.
+    - namespace: fuzefront
+      server: https://kubernetes.default.svc
+    # The app-of-apps creates child Application objects here.
+    - namespace: argocd
+      server: https://kubernetes.default.svc
+    # NOTE: `fuzeinfra` is deliberately NOT a destination — that is FuzeInfra's
+    # namespace. A consumer that needs an infra service consumes it via DNS, it
+    # does not deploy into it.
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"


### PR DESCRIPTION
Stops consumers from deploying into FuzeInfra's own namespace (the root enabler of the duplicate-FuzeInfra incident).

## Problem
FuzeFront had **self-created** a `fuzefront` AppProject that granted itself the `fuzeinfra` **namespace** as a destination, then deployed a **duplicate FuzeInfra** into it → split-brain Postgres/Kafka, control-plane saturation, cluster-wide 502 (FuzeFront#95 / #93).

## Fix — FuzeInfra owns the boundary
- `argocd/projects/fuzefront.yaml` (FuzeInfra-owned): destinations = **`fuzefront` + `argocd` only**, `sourceRepos` = FuzeFront repo. **No `fuzeinfra` destination.**
- `setup-argocd.sh` applies it with the fuzeinfra project.
- **Applied live**: the `fuzefront` project now permits only `fuzefront`/`argocd`; all existing FuzeFront apps stay Synced. Any future app targeting `fuzeinfra` is rejected by Argo.

## Governance rule
FuzeInfra owns AppProjects (the security boundary); consumers create Applications only within their restricted project and consume infra via service DNS — they never redeploy FuzeInfra or deploy into its namespace.