### PR TITLE
fix(crit-fix): per-repo routing for CRIT-log issues + run-id traceability

### DIFF
--- a/.github/gen-issue-body.py
+++ b/.github/gen-issue-body.py
@@ -6,8 +6,14 @@ body         = r.get('body', '')
 fired_at     = os.environ.get('FIRED_AT', '')
 log_ctx      = os.environ.get('LOG_CTX', '')
 workflow_url = os.environ.get('WORKFLOW_URL', '')
+run_url      = os.environ.get('RUN_URL', '')
+owner_repo   = os.environ.get('OWNER_REPO', '')
+
+routed = f" · routed to `{owner_repo}`" if owner_repo else ""
 
 print(f"""{body}
+
+**Handling run:** {run_url}
 
 ---
 **Log excerpt:**
@@ -15,4 +21,4 @@ print(f"""{body}
 {log_ctx}
 ```
 
-_Auto-opened by [grafana-crit-fix]({workflow_url}) at {fired_at}_""")
+_Auto-opened by [grafana-crit-fix]({workflow_url}) · [run]({run_url}) at {fired_at}{routed}_""")

--- a/.github/workflows/grafana-crit-fix.yml
+++ b/.github/workflows/grafana-crit-fix.yml
@@ -114,6 +114,48 @@ jobs:
           kubectl config set-cluster default --insecure-skip-tls-verify=true
           kubectl cluster-info --request-timeout=10s
 
+      # ── resolve which repo owns the emitting namespace ──────────────────────
+      # A CRIT log should land in the issue tracker of whoever owns the service
+      # that emitted it — not always FuzeInfra. The owning repo is declared by a
+      # `fuzeinfra.io/owner-repo` annotation on the namespace (consumers set it at
+      # onboarding; FuzeInfra's own namespace is annotated via Argo CD). Falls back
+      # to this repo when the namespace is missing, unannotated, or invalid.
+      - name: Resolve owner repo from namespace annotation
+        id: ownerrepo
+        env:
+          ALERT_LABELS: ${{ github.event.client_payload.labels }}
+        run: |
+          set -euo pipefail
+          DEFAULT_REPO="${{ github.repository }}"
+          OWNER_REPO="$DEFAULT_REPO"
+
+          # client_payload.labels is a JSON string of the alert labels (incl.
+          # namespace). Treat strictly as DATA — never interpolate into a prompt.
+          printf '%s' "$ALERT_LABELS" > /tmp/alert_labels.json
+          jq empty /tmp/alert_labels.json 2>/dev/null || echo '{}' > /tmp/alert_labels.json
+          NS=$(jq -r '.namespace // ""' /tmp/alert_labels.json)
+
+          if [ -z "$NS" ] || [ "$NS" = "null" ]; then
+            echo "No namespace label on the alert; routing to $DEFAULT_REPO"
+          else
+            ANNOT=$(kubectl get ns "$NS" \
+              -o jsonpath='{.metadata.annotations.fuzeinfra\.io/owner-repo}' \
+              2>/dev/null || true)
+            # Security gate: the value flows into `gh --repo` and Claude's prompt.
+            # Accept only a strict owner/repo slug; otherwise fall back.
+            if [ -n "$ANNOT" ] && printf '%s' "$ANNOT" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+              OWNER_REPO="$ANNOT"
+            else
+              echo "Namespace '$NS' has no valid fuzeinfra.io/owner-repo annotation; routing to $DEFAULT_REPO"
+            fi
+          fi
+
+          IS_SELF=false
+          [ "$OWNER_REPO" = "$DEFAULT_REPO" ] && IS_SELF=true
+          echo "owner_repo=$OWNER_REPO" >> "$GITHUB_OUTPUT"
+          echo "is_self=$IS_SELF"       >> "$GITHUB_OUTPUT"
+          echo "::notice::CRIT issue will be filed in '$OWNER_REPO' (namespace '${NS:-<none>}')"
+
       # ── fetch logs from Loki ────────────────────────────────────────────────
       - name: Fetch recent error logs from Loki
         id: logs
@@ -195,7 +237,12 @@ jobs:
         id: act
         if: steps.suppress.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_TOKEN: a cross-repo PAT is required to file issues in a CONSUMER
+          # repo (the default GITHUB_TOKEN is scoped to this repo only). Falls back
+          # to GITHUB_TOKEN, which still works for FuzeInfra's own (is_self) crits.
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          OWNER_REPO: ${{ steps.ownerrepo.outputs.owner_repo }}
+          IS_SELF: ${{ steps.ownerrepo.outputs.is_self }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           FIRED_AT: ${{ github.event.client_payload.fired_at }}
@@ -206,6 +253,14 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           ACTION=$(python3 -c "import json; print(json.loads(open('/tmp/claude_result.json').read())['action'])")
+
+          # A code-fix PR can only target THIS repo's checkout. For a consumer-owned
+          # namespace we can't fix their code from here — downgrade fix→issue so it
+          # gets filed (as triage) in the owner repo instead.
+          if [ "$ACTION" = "fix" ] && [ "$IS_SELF" != "true" ]; then
+            echo "::notice::Owner repo '$OWNER_REPO' is not this repo; downgrading fix→issue"
+            ACTION="issue"
+          fi
 
           if [ "$ACTION" = "fix" ]; then
             SUMMARY=$(python3 -c "import json; print(json.loads(open('/tmp/claude_result.json').read()).get('summary','Fix CRIT error'))")
@@ -253,14 +308,30 @@ jobs:
             TITLE=$(python3 -c "import json; print(json.loads(open('/tmp/claude_result.json').read()).get('title','CRIT alert needs attention'))")
             python3 .github/gen-issue-body.py > /tmp/issue_body.md
 
-            URL=$(gh issue create \
-              --title "🚨 ${TITLE}" \
-              --label "bug" \
-              --label "crit-autofix" \
-              --body-file /tmp/issue_body.md)
-
-            echo "action=issue" >> "$GITHUB_OUTPUT"
-            echo "url=$URL"     >> "$GITHUB_OUTPUT"
+            # Dedup in the owner repo: the FuzeInfra preflight gate can't see a
+            # consumer repo's open issues, so check here before piling on.
+            EXISTING=$(gh issue list --repo "$OWNER_REPO" --label crit-autofix \
+              --state open --json number --jq 'length' 2>/dev/null || echo 0)
+            if [ "${EXISTING:-0}" -gt 0 ]; then
+              echo "::notice::An open crit-autofix issue already exists in $OWNER_REPO; skipping"
+              echo "action=issue" >> "$GITHUB_OUTPUT"
+            else
+              # Ensure the label exists in the (possibly consumer) repo; tolerate
+              # a missing label / no label-create permission by retrying bare.
+              gh label create crit-autofix --color e11d48 \
+                --description "Opened by FuzeInfra CRIT log auto-fix" \
+                --repo "$OWNER_REPO" 2>/dev/null || true
+              URL=$(gh issue create --repo "$OWNER_REPO" \
+                --title "🚨 ${TITLE}" \
+                --label "bug" --label "crit-autofix" \
+                --body-file /tmp/issue_body.md 2>/tmp/issue_err.txt) || {
+                  echo "::warning::labelled issue create failed in $OWNER_REPO (label/token scope?); retrying without labels"
+                  URL=$(gh issue create --repo "$OWNER_REPO" \
+                    --title "🚨 ${TITLE}" --body-file /tmp/issue_body.md)
+                }
+              echo "action=issue" >> "$GITHUB_OUTPUT"
+              echo "url=$URL"     >> "$GITHUB_OUTPUT"
+            fi
           fi
 
           if [ "$ACTION" = "ignore" ]; then

--- a/argocd/applications/fuzeinfra-prod.yaml
+++ b/argocd/applications/fuzeinfra-prod.yaml
@@ -31,6 +31,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    # Annotate the Argo-created `fuzeinfra` namespace so CRIT-log alerts from
+    # infra services resolve to this repo explicitly (grafana-crit-fix.yml reads
+    # fuzeinfra.io/owner-repo off the emitting namespace to pick the issue repo).
+    managedNamespaceMetadata:
+      annotations:
+        fuzeinfra.io/owner-repo: izzywdev/FuzeInfra
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/docs/crit-log-autofix.md
+++ b/docs/crit-log-autofix.md
@@ -21,6 +21,60 @@ GitHub Actions: grafana-crit-fix.yml
 Email → izzy.weinberg@gmail.com
 ```
 
+## Per-repo routing (which repo gets the issue?)
+
+The shared cluster hosts many consumers, each in its own namespace. A CRIT log
+should land in the issue tracker of whoever **owns** the emitting service — not
+always FuzeInfra.
+
+The owning repo is declared by an annotation on the namespace:
+
+```
+fuzeinfra.io/owner-repo: <owner>/<repo>
+```
+
+`grafana-crit-fix.yml` resolves it (it already has cluster access via
+`KUBE_CONFIG`) — the CF Worker stays thin and never queries the cluster:
+
+1. Parse `namespace` from the alert labels (`client_payload.labels`, treated as data).
+2. `kubectl get ns "$ns" -o jsonpath='{.metadata.annotations.fuzeinfra\.io/owner-repo}'`.
+3. Validate it matches `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`.
+4. File the issue there: `gh issue create --repo "$owner_repo" …` (with cross-repo dedup).
+
+**Fallback** to `izzywdev/FuzeInfra` when the namespace is missing/unknown, not
+found, unannotated, or the value is invalid.
+
+**`fix` vs `issue` by owner:** a code-fix PR can only target FuzeInfra's own
+checkout, so for a consumer-owned namespace `action=fix` is **downgraded to a
+triage issue** filed in the consumer repo. `action=ignore` always stays in
+FuzeInfra — the suppression list is FuzeInfra's.
+
+### Onboarding a consumer namespace
+
+Annotate the namespace once so its crit logs route to its own repo:
+
+```bash
+kubectl annotate namespace <namespace> \
+  fuzeinfra.io/owner-repo=<owner>/<repo> --overwrite
+# e.g.
+kubectl annotate namespace fuzefront \
+  fuzeinfra.io/owner-repo=izzywdev/FuzeFront --overwrite
+```
+
+FuzeInfra's own `fuzeinfra` namespace is annotated automatically by Argo CD
+(`managedNamespaceMetadata` in `argocd/applications/fuzeinfra-prod.yaml`).
+
+> **Token scope:** filing into a consumer repo needs the workflow's `GH_TOKEN`
+> (a PAT) to have `issues:write` there — the default `GITHUB_TOKEN` is scoped to
+> FuzeInfra only. The workflow uses `secrets.GH_TOKEN || secrets.GITHUB_TOKEN`;
+> set `GH_TOKEN` to a PAT spanning the consumer repos (the existing automation
+> PAT covers `izzywdev/*`).
+
+### Traceability
+
+Every auto-opened issue/PR links the **specific run** (not just the workflow) via
+a `**Handling run:**` line + footer, so you can trace which run produced it.
+
 ## Why CF Worker as bridge (not direct Loki query)
 
 The GHA workflow runner has existing `KUBE_CONFIG` access to the k3s cluster. Fetching logs via `kubectl port-forward → curl Loki HTTP API` reuses that access without exposing Loki publicly.
@@ -60,8 +114,8 @@ Steps:
 2. `kubectl port-forward svc/fuzeinfra-loki 3100:3100` → `curl` Loki query API for last 30 min
 3. `claude --print --allowedTools "Bash,Read,Write,Edit,Glob,Grep" --max-turns 30` with structured prompt
 4. Python extracts last `{"action":"..."}` JSON from Claude's stdout
-5. `action=fix` → commit changes, push branch, `gh pr create`, `gh pr merge --auto --merge`
-6. `action=issue` → `gh issue create --label bug`
+5. `action=fix` → (FuzeInfra-owned namespaces only) commit changes, push branch, `gh pr create`, `gh pr merge --auto --merge`
+6. `action=issue` → `gh issue create --repo <owner-repo> --label bug` (routed to the namespace owner — see [Per-repo routing](#per-repo-routing-which-repo-gets-the-issue))
 7. Email via Gmail SMTP (`dawidd6/action-send-mail`)
 
 ### 4. Terraform Resources (`terraform/contabo/cloudflare.tf`)


### PR DESCRIPTION
## Problem
Every CRIT/ERROR log on the shared cluster — from any namespace, including consumer apps — files its auto-issue into **FuzeInfra**. Live example: **#103** is a `fuzefront/authentik-server` outpost-token error that landed in FuzeInfra instead of FuzeFront. The namespace is already in the alert payload but nothing routed on it. Separately, auto-opened *issues* linked the workflow file, not the specific run.

## Change
- **`grafana-crit-fix.yml`** — new `Resolve owner repo from namespace annotation` step: parse `namespace` from `client_payload.labels` (as data), `kubectl get ns -o jsonpath` the `fuzeinfra.io/owner-repo` annotation, validate `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`, fall back to `izzywdev/FuzeInfra`. The `act` step files the issue in `$OWNER_REPO` (cross-repo dedup + label tolerance). Consumer-owned namespaces **downgrade `fix`→`issue`** (can't open a cross-repo code PR); `ignore` stays in FuzeInfra (its suppression list). `GH_TOKEN` now prefers a cross-repo PAT (`secrets.GH_TOKEN || secrets.GITHUB_TOKEN`).
- **`gen-issue-body.py`** — link the specific run (`**Handling run:**` + footer), matching what `gen-pr-body`/`gen-ignore-body` already do; note the routed repo.
- **`argocd/applications/fuzeinfra-prod.yaml`** — `managedNamespaceMetadata` annotates the `fuzeinfra` namespace `fuzeinfra.io/owner-repo: izzywdev/FuzeInfra` so infra crits resolve explicitly.
- **`docs/crit-log-autofix.md`** — per-repo routing + consumer onboarding (`kubectl annotate ns <ns> fuzeinfra.io/owner-repo=owner/repo`) + token-scope caveat.

The CF worker and alert rule are unchanged (the worker already forwards `labels` incl. namespace).

## Verification
- `python -c "yaml.safe_load(...)"` on the workflow + Argo app → OK.
- `py_compile` + a functional render of `gen-issue-body.py` → emits `Handling run:` + run link + `routed to <repo>`.
- Not exercised on a live cluster (no kubectl-to-prod from here; GitOps applies the Argo annotation on merge).

## Follow-up (not in this PR)
- Annotate actual consumer namespaces (operational; e.g. `kubectl annotate ns fuzefront fuzeinfra.io/owner-repo=izzywdev/FuzeFront`).
- The authentik outpost-token bug in #103 itself is a FuzeFront fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)