### PR TITLE
feat(local-k8s): one-command kind dev stack + per-merge deployability gate

### DIFF
--- a/.github/workflows/kind-validate.yml
+++ b/.github/workflows/kind-validate.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# kind-validate — per-merge "the local Kubernetes deployment still works" gate.
+#
+# Stands the FULL FuzeInfra stack up on a fresh kind cluster and proves every
+# enabled service is Ready + reachable, then runs the pytest smoke suite against
+# it. This is the stand-up + smoke half of gate-localup (helm-validate.yml covers
+# the static lint + kubeconform half).
+#
+# Runs on a HOST-LEVEL self-hosted runner (label `kind-host`) — NOT the hardened
+# in-pod ARC `staging` runners, which drop all caps / run non-root / are capped at
+# 1Gi and cannot run kind. Register a classic Actions runner as a process on a
+# machine that has docker + kind + kubectl + helm (see runners/README.md →
+# "Host-level kind runner"). If no such runner is online, this job simply stays
+# queued — it never blocks on GitHub-hosted infra.
+# =============================================================================
+name: kind-validate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'helm/**'
+      - 'k8s/kind/**'
+      - 'tests/**'
+      - 'scripts-tools/validate_kind_deployment.py'
+      - 'scripts-tools/kind_port_forward.py'
+      - 'helm/fuzeinfra/profiles/**'
+      - 'Makefile'
+      - '.github/workflows/kind-validate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'helm/**'
+      - 'k8s/kind/**'
+      - 'scripts-tools/validate_kind_deployment.py'
+      - 'scripts-tools/kind_port_forward.py'
+
+# kind is a host singleton (one cluster named "fuzeinfra"); never run two at once.
+concurrency:
+  group: kind-validate-host
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  kind-up-validate:
+    runs-on: [self-hosted, kind-host]
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tool check (docker / kind / kubectl / helm / python)
+        shell: bash
+        run: |
+          for t in docker kind kubectl helm python3; do
+            command -v "$t" >/dev/null || { echo "::error::$t not found on the kind-host runner"; exit 1; }
+          done
+          docker info >/dev/null || { echo "::error::docker daemon not reachable"; exit 1; }
+
+      # Clean any leftover cluster from a cancelled run, then a FRESH full-stack
+      # bring-up — proving the env is deployable from scratch (the consumer promise).
+      - name: Fresh cluster + full stack
+        shell: bash
+        run: |
+          ./k8s/kind/teardown-kind.sh 2>/dev/null || true
+          ./k8s/kind/setup-kind.sh
+
+      - name: Deployability gate (every enabled service Ready + reachable)
+        shell: bash
+        run: python3 scripts-tools/validate_kind_deployment.py --reuse
+
+      - name: Install pytest smoke deps
+        shell: bash
+        run: |
+          python3 -m pip install --quiet --upgrade pip
+          if [ -f tests/requirements.txt ]; then
+            python3 -m pip install --quiet -r tests/requirements.txt
+          else
+            python3 -m pip install --quiet pytest requests psycopg2-binary pymongo redis \
+              neo4j elasticsearch kafka-python pika
+          fi
+
+      - name: Functional smoke (pytest via port-forward)
+        shell: bash
+        run: python3 scripts-tools/kind_port_forward.py -- pytest tests/ -v -m "not integration"
+
+      - name: Tear down
+        if: always()
+        shell: bash
+        run: ./k8s/kind/teardown-kind.sh 2>/dev/null || true

--- a/.github/workflows/kind-validate.yml
+++ b/.github/workflows/kind-validate.yml
@@ -45,6 +45,12 @@ permissions:
 
 jobs:
   kind-up-validate:
+    # SECURITY: this job executes PR-supplied scripts (setup-kind.sh, tests/,
+    # tests/requirements.txt, the validators) on a self-hosted HOST runner. A fork
+    # PR running here would be RCE on the host. Gate to same-repo branches + pushes
+    # to main only — fork PRs are skipped. (Mirrors terraform-plan-apply.yml; also
+    # keep the org setting "Require approval for all outside collaborators" on.)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
     runs-on: [self-hosted, kind-host]
     timeout-minutes: 40
     steps:

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,32 @@
 CHART      := helm/fuzeinfra
 NAMESPACE  := fuzeinfra
 RELEASE    := fuzeinfra
+PROFILE    ?=
+
+# Cross-platform: native Windows `make` shells to the PowerShell scripts; macOS/
+# Linux (and Git Bash/WSL) use the bash scripts. The Python helpers run the same
+# everywhere (python on Windows, python3 elsewhere).
+ifeq ($(OS),Windows_NT)
+  KIND_UP      := pwsh -NoProfile -ExecutionPolicy Bypass -File k8s/kind/setup-kind.ps1
+  KIND_DOWN    := pwsh -NoProfile -ExecutionPolicy Bypass -File k8s/kind/teardown-kind.ps1
+  PROFILE_FLAG := -Profile
+  PY           := python
+else
+  KIND_UP      := ./k8s/kind/setup-kind.sh
+  KIND_DOWN    := ./k8s/kind/teardown-kind.sh
+  PROFILE_FLAG := --profile
+  PY           := python3
+endif
 
 .PHONY: help
 help:
 	@echo "FuzeInfra make targets:"
 	@echo "  Local Kubernetes (kind):"
-	@echo "    make kind-up         Create kind cluster + ingress + deploy chart"
-	@echo "    make kind-down       Delete the kind cluster"
+	@echo "    make kind-up                     Create kind cluster + ingress + deploy full stack"
+	@echo "    make kind-profile PROFILE=<name> Deploy a subset (minimal, data-stores, full)"
+	@echo "    make kind-validate               Assert every enabled service is ready + reachable"
+	@echo "    make kind-test                   Run the pytest suite via kubectl port-forward"
+	@echo "    make kind-down                   Delete the kind cluster"
 	@echo "    make k8s-deploy      Deploy/upgrade chart to current kube-context (local values)"
 	@echo "    make k8s-status      Show pods in the $(NAMESPACE) namespace"
 	@echo "  Chart validation (no cluster needed):"
@@ -27,11 +46,24 @@ help:
 # ----------------------------------------------------------------------------
 .PHONY: kind-up
 kind-up:
-	./k8s/kind/setup-kind.sh
+	$(KIND_UP)
+
+.PHONY: kind-profile
+kind-profile:
+	@if [ -z "$(PROFILE)" ]; then echo "Usage: make kind-profile PROFILE=<minimal|data-stores|full>"; exit 1; fi
+	$(KIND_UP) $(PROFILE_FLAG) $(PROFILE)
+
+.PHONY: kind-validate
+kind-validate:
+	$(PY) scripts-tools/validate_kind_deployment.py --reuse
+
+.PHONY: kind-test
+kind-test:
+	$(PY) scripts-tools/kind_port_forward.py -- pytest tests/ -v
 
 .PHONY: kind-down
 kind-down:
-	./k8s/kind/teardown-kind.sh
+	$(KIND_DOWN)
 
 .PHONY: k8s-deploy
 k8s-deploy:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,31 @@ A comprehensive containerized shared infrastructure platform providing databases
 
 ## 🚀 Quick Start
 
+FuzeInfra runs two ways — pick one:
+
+### A) Docker Compose (fastest local path)
+
 1. **Clone repository**: `git clone --recursive https://github.com/izzywdev/FuzeInfra.git`
 2. **Set up environment**: `python scripts-tools/setup_environment.py`
 3. **Generate certificates**: `./tools/cert-manager/setup-local-certs.sh`
 4. **Start infrastructure**: `./infra-up.bat` (Windows) or `./infra-up.sh` (Linux/Mac)
 
 > **Note**: Use `--recursive` to automatically clone the envmanager submodule. If already cloned, run `git submodule update --init --recursive`.
+
+### B) Kubernetes on kind (production parity)
+
+Mirrors the EKS/Contabo prod deployment locally. Prereqs: docker, kind, kubectl, helm.
+
+```bash
+make kind-up            # cluster + ingress + cert-manager + full chart
+make kind-validate      # prove every enabled service is Ready + reachable
+make kind-test          # functional smoke (pytest via port-forward)
+make kind-down          # tear down
+```
+
+Windows (no make): `.\k8s\kind\setup-kind.ps1`. Deploy a subset with
+`make kind-profile PROFILE=minimal`. **Full guide:
+[docs/LOCAL_KUBERNETES.md](docs/LOCAL_KUBERNETES.md).**
 
 ## 📁 Repository Structure
 

--- a/docs/LOCAL_KUBERNETES.md
+++ b/docs/LOCAL_KUBERNETES.md
@@ -1,0 +1,145 @@
+# Run FuzeInfra locally on Kubernetes — getting started on your machine
+
+FuzeInfra ships the same stack two ways: the legacy **docker-compose** path
+(`./infra-up.sh`) and the **Kubernetes** path (a Helm chart on **kind** locally,
+mirroring EKS/Contabo prod). This guide is the Kubernetes path — the one that
+matches production. If you just want services on localhost ports fast, the
+compose path in the main README is fine; use this when you want prod parity.
+
+> One command once set up: **`make kind-up`** (full stack) → **`make kind-validate`**
+> (prove it's healthy) → **`make kind-test`** (functional smoke) → **`make kind-down`**.
+
+---
+
+## 1. Prerequisites — what you need installed
+
+| Tool | Why | Install |
+|------|-----|---------|
+| **docker** | kind runs the cluster as containers | Docker Desktop (Win/Mac) · `docker` engine (Linux) |
+| **kind** | the local Kubernetes cluster | https://kind.sigs.k8s.io · `choco install kind` · `brew install kind` |
+| **kubectl** | talk to the cluster | `choco install kubernetes-cli` · `brew install kubectl` |
+| **helm** | deploy the chart | `choco install kubernetes-helm` · `brew install helm` |
+| **python 3** | the validate / smoke scripts | python.org · already present on most machines |
+
+That's it — **docker + kind + kubectl + helm** (plus python for the validators).
+`make` is optional: on Windows you can call the PowerShell scripts directly.
+A GitHub Actions runner binary is only needed if you host the per-merge gate
+(see §6) — not for local use.
+
+Give Docker enough headroom: the **full** stack wants ~6–8 GB RAM. On a smaller
+machine, deploy a [profile](#3-turn-services-on--off-profiles) instead.
+
+---
+
+## 2. One-command bring-up
+
+```bash
+# macOS / Linux / WSL / Git-Bash
+make kind-up
+#   └─ creates the kind cluster, installs ingress-nginx + cert-manager + the
+#      local-CA issuer, and `helm upgrade --install`s the chart (values-local.yaml)
+```
+
+```powershell
+# Windows PowerShell (no make needed)
+.\k8s\kind\setup-kind.ps1
+```
+
+When it finishes, check it:
+
+```bash
+make kind-status            # kubectl -n fuzeinfra get pods
+```
+
+Reach the UIs by adding the hostnames it prints to your hosts file (all →
+`127.0.0.1`), e.g. `grafana.dev.local`, `prometheus.dev.local`. Local HTTPS via
+the `fuzeinfra-local-ca` issuer is covered in [LOCAL_TLS.md](LOCAL_TLS.md).
+
+---
+
+## 3. Turn services on / off (profiles)
+
+Every service has an `enabled` gate in `helm/fuzeinfra/values.yaml`. Different
+consuming repos need different subsets — one needs Mongo, another Neo4j, another
+Kafka — so you can deploy exactly what you need.
+
+```bash
+make kind-profile PROFILE=minimal       # ./k8s/kind/setup-kind.sh --profile minimal
+#                                          .\k8s\kind\setup-kind.ps1 -Profile minimal
+```
+
+| Profile | Services | Use for |
+|---------|----------|---------|
+| `minimal` | Postgres + Redis | a service that only needs a DB + cache |
+| `data-stores` | all databases (Postgres/Mongo/Redis/Neo4j/ES/Chroma) | data-heavy apps, no messaging/monitoring |
+| `full` | everything (default = `make kind-up`) | prod parity / the CI gate |
+
+Ad-hoc trimming works too: `make kind-up` then re-run with
+`helm upgrade ... --set kafka.enabled=false`, or add a file to
+`helm/fuzeinfra/profiles/`.
+
+> **Consumers:** annotate your namespace so its CRIT logs route to *your* repo:
+> `kubectl annotate ns <ns> fuzeinfra.io/owner-repo=<owner>/<repo> --overwrite`
+> (see [crit-log-autofix.md](crit-log-autofix.md)).
+
+---
+
+## 4. Validate — prove the whole env is deployable
+
+```bash
+make kind-validate
+```
+
+Reads which services are enabled, waits for every workload to become **Ready**,
+asserts none are missing, runs in-cluster reachability probes, and prints a
+`service × {ready, reachable}` matrix. Exits non-zero if any enabled service
+isn't deployable — this is the "the entire env stands up" guarantee.
+
+## 5. Test — functional smoke (the existing pytest suite)
+
+```bash
+make kind-test
+```
+
+Port-forwards each service to the localhost ports the `tests/` suite expects and
+runs `pytest tests/` against the live cluster — real connectivity, no test
+rewrite. (`scripts-tools/kind_port_forward.py` does the forwarding.)
+
+Tear it all down when done:
+
+```bash
+make kind-down
+```
+
+---
+
+## 6. Per-merge gate — keep the local deployment working
+
+`.github/workflows/kind-validate.yml` runs the **full** bring-up + validate +
+smoke on **every PR** that touches the chart, kind scripts, profiles, tests, or
+the validators — so the local deployment can never silently rot.
+
+It runs on a **host-level self-hosted runner** (`runs-on: [self-hosted, kind-host]`)
+because kind needs Docker + real RAM, which the hardened in-pod ARC `staging`
+runners can't provide. Register that runner once — see
+[runners/README.md → Host-level kind runner](../runners/README.md#host-level-kind-runner-for-the-kind-validate-gate).
+Prefer zero infra? The same commands run as a `pre-push` git hook (also documented
+there).
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Pods `Pending` / OOM | Docker has too little RAM — raise it, or use `PROFILE=minimal`/`data-stores` |
+| `helm ... timed out` | Heavy images (Elasticsearch, Kafka) are still pulling — `make kind-status`, re-run is idempotent |
+| PVC won't bind | Local uses `storageClass: standard` (kind's provisioner) — don't set the prod `local-path` |
+| `*.dev.local` won't resolve | Add the hostnames to your hosts file (→ `127.0.0.1`) or use the dnsmasq service |
+| Cert not trusted | Import the local CA — see [LOCAL_TLS.md](LOCAL_TLS.md) |
+| `kubectl` hits the wrong cluster | `kubectl config use-context kind-fuzeinfra` |
+
+---
+
+See also: [kubernetes-migration.md](kubernetes-migration.md) (kind/EKS/Contabo
+overview), [gitops.md](gitops.md) (Argo CD / prod), [LOCAL_TLS.md](LOCAL_TLS.md).

--- a/helm/fuzeinfra/profiles/data-stores.yaml
+++ b/helm/fuzeinfra/profiles/data-stores.yaml
@@ -1,0 +1,29 @@
+# =============================================================================
+# Profile: data-stores — every database, no messaging/monitoring/workflow.
+#
+# For consumers that need the data tier (any of Postgres, MongoDB, Redis, Neo4j,
+# Elasticsearch, ChromaDB) but not Kafka/RabbitMQ, the monitoring stack, or
+# Airflow. Layered ON TOP of values-local.yaml:
+#   make kind-profile PROFILE=data-stores
+#
+# Trim further with --set <svc>.enabled=false (e.g. drop neo4j if unused).
+# =============================================================================
+postgres:      { enabled: true }
+mongodb:       { enabled: true }
+mongoExpress:  { enabled: true }
+redis:         { enabled: true }
+neo4j:         { enabled: true }
+elasticsearch: { enabled: true }
+chromadb:      { enabled: true }
+
+kafka:            { enabled: false }
+kafkaUi:          { enabled: false }
+rabbitmq:         { enabled: false }
+prometheus:       { enabled: false }
+grafana:          { enabled: false }
+alertmanager:     { enabled: false }
+loki:             { enabled: false }
+promtail:         { enabled: false }
+nodeExporter:     { enabled: false }
+kubeStateMetrics: { enabled: false }
+airflow:          { enabled: false }

--- a/helm/fuzeinfra/profiles/full.yaml
+++ b/helm/fuzeinfra/profiles/full.yaml
@@ -1,0 +1,31 @@
+# =============================================================================
+# Profile: full — the entire FuzeInfra stack (explicit).
+#
+# This is the default when no profile is given (values-local.yaml already
+# enables everything via the base chart). It exists so `full` is a nameable,
+# self-documenting target and so the complete service set is visible in one
+# place — the inverse of minimal / data-stores.
+#   make kind-profile PROFILE=full     # == make kind-up
+#
+# This is the profile the per-merge validation gate deploys: every enabled
+# service must stand up, because different consuming repos depend on different
+# subsets (one needs mongo, another neo4j, another kafka).
+# =============================================================================
+postgres:         { enabled: true }
+mongodb:          { enabled: true }
+mongoExpress:     { enabled: true }
+redis:            { enabled: true }
+neo4j:            { enabled: true }
+elasticsearch:    { enabled: true }
+chromadb:         { enabled: true }
+kafka:            { enabled: true }
+kafkaUi:          { enabled: true }
+rabbitmq:         { enabled: true }
+prometheus:       { enabled: true }
+grafana:          { enabled: true }
+alertmanager:     { enabled: true }
+loki:             { enabled: true }
+promtail:         { enabled: true }
+nodeExporter:     { enabled: true }
+kubeStateMetrics: { enabled: true }
+airflow:          { enabled: true }

--- a/helm/fuzeinfra/profiles/minimal.yaml
+++ b/helm/fuzeinfra/profiles/minimal.yaml
@@ -1,0 +1,31 @@
+# =============================================================================
+# Profile: minimal — Postgres + Redis only.
+#
+# For consumers that just need a relational DB + a cache. Layered ON TOP of
+# values-local.yaml (so it inherits the kind/local tuning):
+#   make kind-profile PROFILE=minimal
+#   ./k8s/kind/setup-kind.sh --profile minimal
+#   .\k8s\kind\setup-kind.ps1 -Profile minimal
+#
+# Toggling is just the per-service `enabled` gate — copy this pattern for any
+# bespoke subset, or pass --set <svc>.enabled=false ad hoc.
+# =============================================================================
+postgres:     { enabled: true }
+redis:        { enabled: true }
+
+mongodb:          { enabled: false }
+mongoExpress:     { enabled: false }
+neo4j:            { enabled: false }
+elasticsearch:    { enabled: false }
+chromadb:         { enabled: false }
+kafka:            { enabled: false }
+kafkaUi:          { enabled: false }
+rabbitmq:         { enabled: false }
+prometheus:       { enabled: false }
+grafana:          { enabled: false }
+alertmanager:     { enabled: false }
+loki:             { enabled: false }
+promtail:         { enabled: false }
+nodeExporter:     { enabled: false }
+kubeStateMetrics: { enabled: false }
+airflow:          { enabled: false }

--- a/k8s/kind/setup-kind.ps1
+++ b/k8s/kind/setup-kind.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+  Bring up a local FuzeInfra Kubernetes cluster on kind (Windows-native).
+
+.DESCRIPTION
+  PowerShell port of setup-kind.sh. Creates a kind cluster, installs the
+  ingress-nginx controller, cert-manager + the FuzeInfra local-CA ClusterIssuer,
+  and deploys the FuzeInfra Helm chart with values-local.yaml (plus an optional
+  profile overlay).
+
+  Prereqs: docker, kind, kubectl, helm.
+
+.PARAMETER Profile
+  Optional profile overlay name from helm/fuzeinfra/profiles/<name>.yaml
+  (e.g. minimal, data-stores, full). Layered on top of values-local.yaml.
+
+.PARAMETER Reuse
+  Reuse an existing cluster instead of failing if one is present (default
+  behaviour already reuses; this switch is accepted for parity with CI flags).
+
+.EXAMPLE
+  .\k8s\kind\setup-kind.ps1
+  .\k8s\kind\setup-kind.ps1 -Profile minimal
+#>
+[CmdletBinding()]
+param(
+  [string]$Profile = "",
+  [switch]$Reuse
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = (Resolve-Path (Join-Path $ScriptDir "..\..")).Path
+$ClusterName = "fuzeinfra"
+$Namespace   = "fuzeinfra"
+$CertManagerVersion = "v1.16.2"   # bump deliberately
+
+foreach ($tool in @("kind", "kubectl", "helm")) {
+  if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+    throw "$tool not found in PATH. Install it before running this script (see docs/LOCAL_KUBERNETES.md)."
+  }
+}
+
+Write-Host "==> Creating kind cluster '$ClusterName' (if missing)" -ForegroundColor Cyan
+$existing = (& kind get clusters) 2>$null
+if ($existing -notcontains $ClusterName) {
+  & kind create cluster --config (Join-Path $ScriptDir "kind-cluster.yaml")
+} else {
+  Write-Host "    cluster already exists, reusing"
+}
+& kubectl cluster-info --context "kind-$ClusterName"
+
+Write-Host "==> Installing ingress-nginx (kind provider)" -ForegroundColor Cyan
+& kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+Write-Host "==> Waiting for ingress-nginx controller to be ready" -ForegroundColor Cyan
+& kubectl wait --namespace ingress-nginx `
+  --for=condition=ready pod `
+  --selector=app.kubernetes.io/component=controller `
+  --timeout=180s
+
+Write-Host "==> Installing cert-manager ($CertManagerVersion)" -ForegroundColor Cyan
+& kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/$CertManagerVersion/cert-manager.yaml"
+Write-Host "==> Waiting for cert-manager to be ready" -ForegroundColor Cyan
+& kubectl wait --namespace cert-manager --for=condition=Available --timeout=180s deployment --all
+
+Write-Host "==> Installing the FuzeInfra local CA ClusterIssuer (shared local TLS)" -ForegroundColor Cyan
+# Retry: the CRDs/webhook may take a moment to register after the deployments are Available.
+$issuerApplied = $false
+for ($i = 1; $i -le 5; $i++) {
+  try {
+    & kubectl apply -f (Join-Path $RepoRoot "k8s\local-tls\cluster-issuer.yaml")
+    $issuerApplied = $true
+    break
+  } catch {
+    Write-Host "    cert-manager webhook not ready yet, retrying ($i)..."
+    Start-Sleep -Seconds 6
+  }
+}
+if ($issuerApplied) {
+  try {
+    & kubectl wait --for=condition=Ready --timeout=120s clusterissuer/fuzeinfra-local-ca 2>$null
+  } catch {
+    Write-Host "    (CA ClusterIssuer still initializing - it'll be Ready shortly)"
+  }
+}
+
+Write-Host "==> Deploying FuzeInfra Helm chart" -ForegroundColor Cyan
+$helmArgs = @(
+  "upgrade", "--install", "fuzeinfra", (Join-Path $RepoRoot "helm\fuzeinfra"),
+  "--namespace", $Namespace, "--create-namespace",
+  "-f", (Join-Path $RepoRoot "helm\fuzeinfra\values-local.yaml")
+)
+if ($Profile) {
+  $profilePath = Join-Path $RepoRoot "helm\fuzeinfra\profiles\$Profile.yaml"
+  if (-not (Test-Path $profilePath)) {
+    throw "Profile '$Profile' not found at $profilePath. Available: $(Get-ChildItem (Join-Path $RepoRoot 'helm\fuzeinfra\profiles') -Filter *.yaml | ForEach-Object { $_.BaseName } | Join-String -Separator ', ')"
+  }
+  Write-Host "    applying profile overlay: $Profile" -ForegroundColor Yellow
+  $helmArgs += @("-f", $profilePath)
+}
+$helmArgs += @("--wait", "--timeout", "10m")
+& helm @helmArgs
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Helm install reported a timeout; some heavy images (elasticsearch, kafka)" -ForegroundColor Yellow
+  Write-Host "may still be pulling. Check: kubectl -n $Namespace get pods" -ForegroundColor Yellow
+}
+
+Write-Host @"
+
+==> Done.
+Add these hostnames to your hosts file (all -> 127.0.0.1) or use the dnsmasq
+wildcard for *.dev.local:
+
+  127.0.0.1 grafana.dev.local prometheus.dev.local airflow.dev.local
+            flower.dev.local kafka-ui.dev.local mongo-express.dev.local
+            rabbitmq.dev.local neo4j.dev.local alertmanager.dev.local
+
+Then open:  http://grafana.dev.local  (admin / admin)
+Check pods: kubectl -n $Namespace get pods
+Validate:   make kind-validate   (or python scripts-tools/validate_kind_deployment.py --reuse)
+
+See docs/LOCAL_KUBERNETES.md for the full guide.
+"@ -ForegroundColor Green

--- a/k8s/kind/setup-kind.sh
+++ b/k8s/kind/setup-kind.sh
@@ -4,7 +4,11 @@
 # ingress-nginx controller, and deploy the FuzeInfra Helm chart.
 #
 # Prereqs: docker, kind, kubectl, helm.
-# Usage:   ./k8s/kind/setup-kind.sh
+# Usage:   ./k8s/kind/setup-kind.sh [--profile <name>] [--reuse]
+#   --profile <name>  Layer helm/fuzeinfra/profiles/<name>.yaml on top of
+#                     values-local.yaml (e.g. minimal, data-stores, full).
+#   --reuse           Reuse an existing cluster (already the default; accepted
+#                     for parity with the PowerShell/CI entrypoints).
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
@@ -13,6 +17,16 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CLUSTER_NAME="fuzeinfra"
 NAMESPACE="fuzeinfra"
 CERT_MANAGER_VERSION="v1.16.2"   # bump deliberately
+
+PROFILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --profile)   PROFILE="${2:-}"; shift 2 ;;
+    --profile=*) PROFILE="${1#*=}"; shift ;;
+    --reuse)     shift ;;   # default already reuses; accepted for parity
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
 
 command -v kind   >/dev/null || { echo "kind not found - https://kind.sigs.k8s.io"; exit 1; }
 command -v kubectl>/dev/null || { echo "kubectl not found"; exit 1; }
@@ -52,9 +66,21 @@ kubectl wait --for=condition=Ready --timeout=120s \
   echo "    (CA ClusterIssuer still initializing — it'll be Ready shortly)"
 
 echo "==> Deploying FuzeInfra Helm chart"
+PROFILE_ARGS=()
+if [ -n "$PROFILE" ]; then
+  PFILE="$REPO_ROOT/helm/fuzeinfra/profiles/${PROFILE}.yaml"
+  [ -f "$PFILE" ] || {
+    echo "profile '$PROFILE' not found at $PFILE" >&2
+    echo "available: $(ls "$REPO_ROOT/helm/fuzeinfra/profiles" 2>/dev/null | sed 's/\.yaml$//' | tr '\n' ' ')" >&2
+    exit 1
+  }
+  echo "    applying profile overlay: $PROFILE"
+  PROFILE_ARGS=(-f "$PFILE")
+fi
 helm upgrade --install fuzeinfra "$REPO_ROOT/helm/fuzeinfra" \
   --namespace "$NAMESPACE" --create-namespace \
   -f "$REPO_ROOT/helm/fuzeinfra/values-local.yaml" \
+  ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} \
   --wait --timeout 10m || {
     echo "Helm install reported a timeout; some heavy images (elasticsearch, kafka)"
     echo "may still be pulling. Check: kubectl -n $NAMESPACE get pods"

--- a/k8s/kind/teardown-kind.ps1
+++ b/k8s/kind/teardown-kind.ps1
@@ -1,0 +1,15 @@
+<#
+.SYNOPSIS
+  Delete the local FuzeInfra kind cluster (Windows-native).
+.DESCRIPTION
+  PowerShell mirror of teardown-kind.sh.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$ClusterName = "fuzeinfra"
+
+Write-Host "==> Deleting kind cluster '$ClusterName'" -ForegroundColor Cyan
+& kind delete cluster --name $ClusterName
+Write-Host "==> Done." -ForegroundColor Green

--- a/runners/README.md
+++ b/runners/README.md
@@ -337,6 +337,13 @@ make kind-up && make kind-validate && make kind-test && make kind-down
 
 The PR gate is simply the automated version of these commands.
 
+> **Security (public repo):** a self-hosted runner executes PR-supplied code.
+> `kind-validate.yml` is gated to skip **fork** PRs (`pull_request.head.repo.fork`),
+> so only same-repo branches and pushes to `main` run on the host. Also keep the
+> org setting **Settings → Actions → "Require approval for all outside
+> collaborators"** enabled so a fork PR can never auto-launch any workflow on
+> self-hosted infra. For untrusted contributions, prefer ephemeral runners.
+
 ---
 
 ## Cluster-level bootstrap note (ArgoCD project)

--- a/runners/README.md
+++ b/runners/README.md
@@ -294,6 +294,51 @@ share the same environment.
 
 ---
 
+## Host-level kind runner (for the `kind-validate` gate)
+
+The `kind-validate.yml` workflow stands the **full FuzeInfra stack up on a kind
+cluster** on every PR. That needs Docker + privilege and several GB of RAM —
+which the hardened in-pod ARC `staging` runners above **cannot** provide (they
+drop all capabilities, run non-root, and are capped at 1Gi). Running kind inside
+those pods is out of scope by design.
+
+Instead, register a **classic Actions runner as a process on a host** that already
+has `docker`, `kind`, `kubectl`, and `helm` — e.g. the developer / Docker-Desktop
+machine. kind then creates its cluster as a sibling container on that host's
+Docker, with the host's full resources.
+
+```bash
+# On the host (Linux / macOS / WSL / Git-Bash):
+mkdir actions-runner && cd actions-runner
+curl -O -L https://github.com/actions/runner/releases/latest/download/actions-runner-<os>-<arch>.tar.gz
+tar xzf actions-runner-*.tar.gz
+
+# Register against the org (or a single repo). Give it the kind-host label.
+./config.sh --url https://github.com/izzywdev \
+  --token <RUNNER_REGISTRATION_TOKEN> \
+  --labels self-hosted,kind-host \
+  --name kind-host-$(hostname) --unattended
+
+# Run it (or install as a service: ./svc.sh install && ./svc.sh start)
+./run.sh
+```
+
+Add the repo to the runner group's allowlist (same gate as the staging runners).
+`kind-validate.yml` uses `runs-on: [self-hosted, kind-host]`, so it only ever
+schedules onto this host runner — the hardened `staging` pods are untouched.
+
+**Don't want to host a runner?** The same gate runs locally as a pre-push hook —
+zero runner infrastructure:
+
+```bash
+# .git/hooks/pre-push   (chmod +x)
+make kind-up && make kind-validate && make kind-test && make kind-down
+```
+
+The PR gate is simply the automated version of these commands.
+
+---
+
 ## Cluster-level bootstrap note (ArgoCD project)
 
 The `arc-runners` and `arc-systems` namespaces are created by `install.sh`.  If you want

--- a/scripts-tools/kind_port_forward.py
+++ b/scripts-tools/kind_port_forward.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Port-forward the deployed FuzeInfra services to the localhost ports the pytest
+suite expects (tests/conftest.py), then run a command (default: pytest tests/).
+
+This is the *functional* smoke layer of the local-k8s gate — it reuses the
+existing tests/ suite (written for docker-compose's host-published ports) against
+the kind cluster, with no test rewrite. The deployability gate
+(validate_kind_deployment.py) verifies readiness; this verifies real reachability.
+
+Each entry is (local_port, remote_port, service-name keyword). The k8s Service is
+discovered by keyword (so it adapts to the release name) and skipped if absent
+(disabled service / profile). Grafana (3000→3001) and Airflow (8080→8082) are the
+only port remaps; everything else is 1:1, matching conftest.
+
+Usage:
+  python scripts-tools/kind_port_forward.py [--namespace fuzeinfra] -- pytest tests/ -v
+  python scripts-tools/kind_port_forward.py            # defaults to: pytest tests/
+"""
+from __future__ import annotations
+
+import argparse
+import atexit
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+# (local_port, remote_port, service-name keyword) — keyword matches the chart's
+# `fuzeinfra-<svc>` Service names. Longest-keyword match wins (kafka-ui vs kafka).
+FORWARDS = [
+    (5432, 5432, "postgres"),
+    (27017, 27017, "mongodb"),
+    (6379, 6379, "redis"),
+    (7474, 7474, "neo4j"),
+    (7687, 7687, "neo4j"),
+    (9200, 9200, "elasticsearch"),
+    (29092, 29092, "kafka"),
+    (9090, 9090, "prometheus"),
+    (3001, 3000, "grafana"),          # conftest expects grafana on 3001
+    (9093, 9093, "alertmanager"),
+    (3100, 3100, "loki"),
+    (8081, 8081, "mongo-express"),
+    (8080, 8080, "kafka-ui"),
+    (15672, 15672, "rabbitmq"),
+    (8082, 8080, "airflow-webserver"),  # conftest expects airflow on 8082
+    (5555, 5555, "airflow-flower"),
+]
+
+
+def run(cmd: list[str], timeout: int = 30) -> tuple[int, str]:
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return p.returncode, p.stdout
+
+
+def services(namespace: str) -> list[str]:
+    rc, out = run(["kubectl", "-n", namespace, "get", "svc", "-o",
+                   "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"])
+    return [s for s in out.splitlines() if s] if rc == 0 else []
+
+
+def match_service(svcs: list[str], keyword: str) -> str | None:
+    # Prefer the longest service name containing the keyword but excluding more
+    # specific siblings (so "kafka" doesn't grab "kafka-ui").
+    cands = [s for s in svcs if keyword in s]
+    if not cands:
+        return None
+    # exact-ish: shortest candidate that still contains the keyword as a token
+    cands.sort(key=len)
+    return cands[0]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--namespace", default="fuzeinfra")
+    ap.add_argument("--settle", type=int, default=6, help="seconds to let forwards establish")
+    ap.add_argument("command", nargs=argparse.REMAINDER,
+                    help="command to run after '--' (default: pytest tests/)")
+    args = ap.parse_args()
+
+    cmd = args.command
+    if cmd and cmd[0] == "--":
+        cmd = cmd[1:]
+    if not cmd:
+        cmd = ["pytest", "tests/"]
+
+    svcs = services(args.namespace)
+    if not svcs:
+        print(f"!! no Services found in namespace '{args.namespace}'. Is the cluster up?",
+              file=sys.stderr)
+        return 2
+
+    procs: list[subprocess.Popen] = []
+
+    def cleanup():
+        for p in procs:
+            try:
+                if os.name == "nt":
+                    p.terminate()
+                else:
+                    p.send_signal(signal.SIGTERM)
+            except Exception:
+                pass
+    atexit.register(cleanup)
+
+    print("==> Establishing port-forwards")
+    forwarded = []
+    for local, remote, kw in FORWARDS:
+        svc = match_service(svcs, kw)
+        if not svc:
+            continue  # service not deployed (disabled/profile) — skip silently
+        p = subprocess.Popen(
+            ["kubectl", "-n", args.namespace, "port-forward",
+             f"svc/{svc}", f"{local}:{remote}"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        procs.append(p)
+        forwarded.append(f"{svc} {local}->{remote}")
+    for f in forwarded:
+        print(f"    {f}")
+    if not forwarded:
+        print("!! nothing to forward", file=sys.stderr)
+        return 2
+
+    time.sleep(args.settle)
+
+    # conftest reads POSTGRES_* from env; align to the chart's dev defaults.
+    env = dict(os.environ)
+    env.setdefault("POSTGRES_HOST", "localhost")
+    env.setdefault("POSTGRES_PORT", "5432")
+
+    print(f"\n==> Running: {' '.join(cmd)}\n")
+    rc = subprocess.run(cmd, env=env).returncode
+    cleanup()
+    return rc
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts-tools/validate_kind_deployment.py
+++ b/scripts-tools/validate_kind_deployment.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Validate that every *enabled* FuzeInfra service stands up Ready (and, where a
+cheap probe exists, is reachable) on a local kind cluster.
+
+This is the "the entire env is deployable" gate. Different consuming repos need
+different service subsets (one needs mongo, another neo4j, another kafka), so the
+platform must prove each enabled service actually comes up — not just that the
+chart renders.
+
+What it does
+  1. Reads the *computed* Helm values (`helm get values <release> -a`) to learn
+     which services are enabled (honours whatever profile/overlay was deployed).
+  2. Lists Deployments / StatefulSets / DaemonSets in the namespace and matches
+     each enabled service to its workload(s), asserting all replicas are Ready.
+  3. Runs a light in-cluster connectivity probe for the core data/monitoring
+     services (best-effort; deep functional checks live in the pytest suite via
+     scripts-tools/kind_port_forward.py).
+  4. Prints a service x {ready, reachable} matrix and exits non-zero if any
+     enabled service has no Ready workload.
+
+Cross-platform: shells out to `kubectl` and `helm` (both prereqs of the kind
+setup), so it needs no Python packages.
+
+Usage:
+  python scripts-tools/validate_kind_deployment.py [--reuse] [--namespace fuzeinfra]
+                                                    [--release fuzeinfra]
+                                                    [--timeout 600] [--no-probes]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+# service key in values.yaml -> workload-name keyword used to match the running
+# Deployment/StatefulSet/DaemonSet. Each workload is assigned to the service with
+# the LONGEST matching keyword, so "kafka-ui" wins over "kafka" and
+# "mongo-express" never matches the "mongodb" service.
+SERVICE_KEYWORDS = {
+    "postgres": "postgres",
+    "mongodb": "mongodb",
+    "mongoExpress": "mongo-express",
+    "redis": "redis",
+    "neo4j": "neo4j",
+    "elasticsearch": "elasticsearch",
+    "chromadb": "chromadb",
+    "kafka": "kafka",
+    "kafkaUi": "kafka-ui",
+    "rabbitmq": "rabbitmq",
+    "prometheus": "prometheus",
+    "grafana": "grafana",
+    "alertmanager": "alertmanager",
+    "loki": "loki",
+    "promtail": "promtail",
+    "nodeExporter": "node-exporter",
+    "kubeStateMetrics": "kube-state-metrics",
+    "airflow": "airflow",
+    "dnsmasq": "dnsmasq",
+}
+
+# Optional in-cluster reachability probe per service: a shell command run inside
+# the service's own pod. None => readiness-only (k8s readiness already implies the
+# port is accepting). Probes are best-effort confidence checks; the pytest suite
+# does the deep functional verification.
+SERVICE_PROBES = {
+    "postgres": "pg_isready -U postgres 2>/dev/null || pg_isready",
+    "redis": "redis-cli ping",
+    "elasticsearch": "curl -sf http://localhost:9200/_cluster/health >/dev/null && echo ok",
+    "prometheus": "wget -qO- http://localhost:9090/-/healthy >/dev/null && echo ok",
+    "grafana": "wget -qO- http://localhost:3000/api/health >/dev/null && echo ok",
+    "loki": "wget -qO- http://localhost:3100/ready >/dev/null && echo ok",
+    "alertmanager": "wget -qO- http://localhost:9093/-/healthy >/dev/null && echo ok",
+    "rabbitmq": "rabbitmq-diagnostics -q ping",
+}
+
+OK = "ok"
+FAIL = "FAIL"
+SKIP = "-"
+
+
+def run(cmd: list[str], timeout: int = 60) -> tuple[int, str, str]:
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return p.returncode, p.stdout, p.stderr
+
+
+def enabled_services(release: str, namespace: str) -> list[str]:
+    """Read computed Helm values; return the enabled service keys we know about."""
+    rc, out, err = run(["helm", "get", "values", release, "-n", namespace, "-a", "-o", "json"])
+    if rc != 0:
+        print(f"!! could not read helm values ({err.strip()}); falling back to "
+              f"deployed-workload discovery", file=sys.stderr)
+        return []  # caller falls back to "validate whatever is deployed"
+    values = json.loads(out or "{}")
+    enabled = []
+    for svc in SERVICE_KEYWORDS:
+        node = values.get(svc)
+        # default-enabled unless explicitly false; matches the chart's `enabled` gates
+        if isinstance(node, dict) and node.get("enabled", True) is not False:
+            enabled.append(svc)
+    return enabled
+
+
+def list_workloads(namespace: str) -> list[dict]:
+    """Return [{name, kind, desired, ready}] for all workloads in the namespace."""
+    rc, out, err = run(["kubectl", "-n", namespace, "get",
+                        "deployments,statefulsets,daemonsets", "-o", "json"])
+    if rc != 0:
+        print(f"!! kubectl get workloads failed: {err.strip()}", file=sys.stderr)
+        return []
+    items = json.loads(out or "{}").get("items", [])
+    workloads = []
+    for it in items:
+        kind = it["kind"]
+        name = it["metadata"]["name"]
+        status = it.get("status", {})
+        if kind == "DaemonSet":
+            desired = status.get("desiredNumberScheduled", 0)
+            ready = status.get("numberReady", 0)
+        else:  # Deployment / StatefulSet
+            desired = it.get("spec", {}).get("replicas", 0)
+            ready = status.get("readyReplicas", 0)
+        workloads.append({"name": name, "kind": kind, "desired": desired, "ready": ready})
+    return workloads
+
+
+def assign(workloads: list[dict]) -> dict[str, list[dict]]:
+    """Map each workload to the service with the longest matching keyword."""
+    by_service: dict[str, list[dict]] = {}
+    for wl in workloads:
+        best_svc, best_len = None, -1
+        for svc, kw in SERVICE_KEYWORDS.items():
+            if kw in wl["name"] and len(kw) > best_len:
+                best_svc, best_len = svc, len(kw)
+        if best_svc:
+            by_service.setdefault(best_svc, []).append(wl)
+    return by_service
+
+
+def first_ready_pod(namespace: str, workload_name: str) -> str | None:
+    # Pods are conventionally named "<workload>-..."; grab a Running one.
+    rc, out, _ = run(["kubectl", "-n", namespace, "get", "pods",
+                      "-o", "jsonpath={range .items[*]}{.metadata.name}{\" \"}{.status.phase}{\"\\n\"}{end}"])
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[0].startswith(workload_name) and parts[1] == "Running":
+            return parts[0]
+    return None
+
+
+def probe(namespace: str, pod: str, command: str, timeout: int = 30) -> bool:
+    rc, out, _ = run(["kubectl", "-n", namespace, "exec", pod, "--",
+                      "sh", "-c", command], timeout=timeout)
+    return rc == 0
+
+
+def wait_until_ready(namespace: str, services: list[str], timeout: int) -> None:
+    """Block (best-effort) until workloads settle, so the matrix isn't a snapshot
+    of a mid-rollout state. Uses kubectl rollout status per workload."""
+    deadline = time.time() + timeout
+    workloads = assign(list_workloads(namespace))
+    targets = [wl for svc in services for wl in workloads.get(svc, [])]
+    for wl in targets:
+        remaining = max(5, int(deadline - time.time()))
+        kind = wl["kind"].lower()
+        if kind == "daemonset":
+            continue  # rollout status on DS can hang on single-node; readiness check covers it
+        run(["kubectl", "-n", namespace, "rollout", "status",
+             f"{kind}/{wl['name']}", f"--timeout={remaining}s"], timeout=remaining + 10)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--namespace", default="fuzeinfra")
+    ap.add_argument("--release", default="fuzeinfra")
+    ap.add_argument("--timeout", type=int, default=600,
+                    help="overall budget (s) for workloads to become Ready")
+    ap.add_argument("--reuse", action="store_true",
+                    help="use the running cluster as-is (no-op flag; the script never creates one)")
+    ap.add_argument("--no-probes", action="store_true", help="skip in-cluster reachability probes")
+    args = ap.parse_args()
+
+    for tool in ("kubectl", "helm"):
+        if run([tool, "version", "--client"] if tool == "kubectl" else [tool, "version"])[0] not in (0,):
+            pass  # version flags differ across versions; tolerate, real calls will error clearly
+
+    print(f"==> Validating release '{args.release}' in namespace '{args.namespace}'")
+    services = enabled_services(args.release, args.namespace)
+    workloads = assign(list_workloads(args.namespace))
+    if not services:
+        # Fallback: validate whatever workloads are deployed.
+        services = sorted(workloads.keys())
+        print("    (using deployed-workload discovery)")
+    print(f"    enabled services: {', '.join(services)}\n")
+
+    print("==> Waiting for workloads to become Ready (budget %ds)..." % args.timeout)
+    try:
+        wait_until_ready(args.namespace, services, args.timeout)
+    except subprocess.TimeoutExpired:
+        print("    (rollout wait hit the budget; reporting current state)")
+
+    # Re-read after the wait for an accurate matrix.
+    workloads = assign(list_workloads(args.namespace))
+
+    rows, failures = [], []
+    for svc in services:
+        wls = workloads.get(svc, [])
+        if not wls:
+            rows.append((svc, "MISSING", FAIL, "no Deployment/StatefulSet/DaemonSet found"))
+            failures.append(svc)
+            continue
+        not_ready = [w for w in wls if w["ready"] < (w["desired"] or 1)]
+        ready_str = "/".join(f"{w['ready']}/{w['desired']}" for w in wls)
+        if not_ready:
+            rows.append((svc, f"ready {ready_str}", FAIL, "workload not fully Ready"))
+            failures.append(svc)
+            continue
+
+        reach = SKIP
+        if not args.no_probes and svc in SERVICE_PROBES:
+            pod = first_ready_pod(args.namespace, wls[0]["name"])
+            if pod:
+                reach = OK if probe(args.namespace, pod, SERVICE_PROBES[svc]) else FAIL
+                # A probe failure is a warning, not a hard fail — readiness already
+                # gates acceptance, and deep checks run in the pytest suite.
+        rows.append((svc, f"ready {ready_str}", reach, ""))
+
+    print("\n==> Result matrix")
+    print(f"    {'SERVICE':<18}{'WORKLOAD':<16}{'REACHABLE':<11}NOTE")
+    for svc, wl, reach, note in rows:
+        print(f"    {svc:<18}{wl:<16}{reach:<11}{note}")
+
+    if failures:
+        print(f"\n[FAIL] {len(failures)} enabled service(s) not deployable: {', '.join(failures)}")
+        return 1
+    print(f"\n[OK] all {len(services)} enabled service(s) are Ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## Why
FuzeInfra already had a working kind+Helm local path (`k8s/kind/setup-kind.sh` + `values-local.yaml`), but it wasn't in the README, had no Windows entrypoint, and **nothing gated it** — so local-k8s deployability could silently rot. Consuming repos each need different service subsets (mongo here, neo4j there), so the platform must prove the whole env is deployable and each service is independently toggleable.

This is the **stand-up + smoke** half of `gate-localup` (the static `helm lint`/kubeconform half is `helm-validate.yml`).

## What
- **Cross-platform entrypoints** — `k8s/kind/setup-kind.ps1` + `teardown-kind.ps1` (Windows-native); `--profile` support in `setup-kind.sh`; OS-aware `Makefile` targets (`kind-up/profile/validate/test/down`) that shell to the right per-OS script.
- **Consumer profiles** — `helm/fuzeinfra/profiles/{minimal,data-stores,full}.yaml` via the chart's per-service `enabled` gates (render-verified: 3 / 8 / 22 workloads).
- **Deployability validator** — `scripts-tools/validate_kind_deployment.py`: reads computed Helm values, asserts every enabled service has a Ready workload, runs in-cluster reachability probes, prints a `service × {ready,reachable}` matrix, exits non-zero on any not-deployable service.
- **Functional smoke** — `scripts-tools/kind_port_forward.py` forwards services to the localhost ports the `tests/` suite expects (grafana 3000→3001, airflow 8080→8082) and runs `pytest tests/` — reuses the suite, no rewrite.
- **Per-merge gate** — `.github/workflows/kind-validate.yml` (`runs-on: [self-hosted, kind-host]`): fresh full-stack bring-up → validate → smoke → teardown, on every PR touching the chart/kind/tests/validators. **Fork-PR gated** (public-repo RCE protection).
- **Docs** — `docs/LOCAL_KUBERNETES.md` (prereqs, one-command, profile table, validate/test, gate, troubleshooting); README "Kubernetes on kind" path; host-runner setup + pre-push fallback in `runners/README.md`.

## Verification (run here)
- `helm lint -f values-local.yaml` → clean.
- Profile render: `minimal=3`, `data-stores=8`, `full=22` workloads; minimal renders only postgres+redis.
- All scripts `py_compile`; all YAML `safe_load`s; workflow fork-gate validated.
- **Not run here:** a full live `make kind-up` cluster deploy (heavy; it's exactly what the `kind-host` gate runs). Can be run on demand.

## To activate the gate
Register a host-level runner labeled `kind-host` (see `runners/README.md` → "Host-level kind runner"), or use the documented `pre-push` hook for local-only enforcement. The hardened ARC `staging` runners can't run kind (no privilege/1Gi) — that's why this needs a host runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)