### PR TITLE
fix(chart): deployable on non-Traefik clusters (kind / Docker Desktop) + dd-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ help:
 	@echo "    make kind-validate               Assert every enabled service is ready + reachable"
 	@echo "    make kind-test                   Run the pytest suite via kubectl port-forward"
 	@echo "    make kind-down                   Delete the kind cluster"
+	@echo "  Docker Desktop Kubernetes (no kind needed):"
+	@echo "    make dd-up                       Deploy the chart to Docker Desktop k8s"
+	@echo "    make dd-down                     Uninstall the chart from Docker Desktop k8s"
+	@echo "    (then: make kind-validate / kind-test run against the docker-desktop context)"
 	@echo "    make k8s-deploy      Deploy/upgrade chart to current kube-context (local values)"
 	@echo "    make k8s-status      Show pods in the $(NAMESPACE) namespace"
 	@echo "  Chart validation (no cluster needed):"
@@ -64,6 +68,23 @@ kind-test:
 .PHONY: kind-down
 kind-down:
 	$(KIND_DOWN)
+
+# ----------------------------------------------------------------------------
+# Docker Desktop's built-in Kubernetes (alternative to kind — needs no kind and
+# works where kind can't, e.g. a Docker Desktop on cgroup v1). Enable it in
+# Docker Desktop → Settings → Kubernetes. Deploys the same chart/values-local;
+# kind-validate / kind-test then run against the docker-desktop context.
+# ----------------------------------------------------------------------------
+.PHONY: dd-up
+dd-up:
+	kubectl config use-context docker-desktop
+	helm upgrade --install $(RELEASE) $(CHART) --kube-context docker-desktop \
+	  -n $(NAMESPACE) --create-namespace \
+	  -f $(CHART)/values-local.yaml
+
+.PHONY: dd-down
+dd-down:
+	-helm --kube-context docker-desktop uninstall $(RELEASE) -n $(NAMESPACE)
 
 .PHONY: k8s-deploy
 k8s-deploy:

--- a/docs/LOCAL_KUBERNETES.md
+++ b/docs/LOCAL_KUBERNETES.md
@@ -55,6 +55,27 @@ Reach the UIs by adding the hostnames it prints to your hosts file (all →
 `127.0.0.1`), e.g. `grafana.dev.local`, `prometheus.dev.local`. Local HTTPS via
 the `fuzeinfra-local-ca` issuer is covered in [LOCAL_TLS.md](LOCAL_TLS.md).
 
+### Alternative: Docker Desktop's built-in Kubernetes (no kind)
+
+Docker Desktop ships a single-node Kubernetes — enable it in **Settings →
+Kubernetes → Enable Kubernetes**. It's the simplest path on Windows/macOS and
+works where kind can't (notably a Docker Desktop still on **cgroup v1**, which
+kind's control-plane can't bootstrap — check with `docker info | grep -i cgroup`;
+if it says v1, either use this path or switch Docker to the WSL 2 engine).
+
+```bash
+make dd-up            # deploy the chart to the docker-desktop context
+make kind-validate    # validator/test target the *current* context
+make kind-test
+make dd-down          # uninstall
+```
+
+Same `values-local.yaml` (Docker Desktop provides the `standard` storageClass).
+ingress-nginx/cert-manager aren't preinstalled, so `*.dev.local` routing won't
+work out of the box — reach services via `kubectl port-forward` (`make kind-test`
+does this) or install ingress-nginx separately. Verified: all 19 services come up
+Ready.
+
 ---
 
 ## 3. Turn services on / off (profiles)

--- a/helm/fuzeinfra/templates/neo4j-ingress.yaml
+++ b/helm/fuzeinfra/templates/neo4j-ingress.yaml
@@ -1,4 +1,10 @@
 {{- if and .Values.ingress.enabled .Values.neo4j.enabled }}
+{{- /* The retry Middleware is a Traefik CRD (traefik.io/v1alpha1) — it only
+       exists on the Traefik-based ingress (prod / Contabo k3s). On nginx-based
+       clusters (kind, Docker Desktop) the CRD is absent, so render the Traefik
+       Middleware + its annotation only when the ingress class is traefik. */ -}}
+{{- $traefik := eq .Values.ingress.className "traefik" }}
+{{- if $traefik }}
 ---
 # Traefik retry middleware for Neo4j's HTTP server.
 #
@@ -17,19 +23,21 @@ spec:
   retry:
     attempts: 4
     initialInterval: 150ms
+{{- end }}
 
 ---
-# Dedicated Ingress for Neo4j (HTTP UI + Bolt WebSocket) with the retry
-# middleware wired in.  Kept separate from the shared fuzeinfra Ingress so
-# the middleware annotation applies only to these two routes.
+# Dedicated Ingress for Neo4j (HTTP UI + Bolt WebSocket). On Traefik the retry
+# middleware is wired in via annotation; on nginx the route is plain.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: fuzeinfra-neo4j
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
+  {{- if $traefik }}
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-neo4j-retry@kubernetescrd
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls.enabled }}

--- a/k8s/kind/setup-kind.ps1
+++ b/k8s/kind/setup-kind.ps1
@@ -47,7 +47,16 @@ $existing = (& kind get clusters) 2>$null
 if ($existing -notcontains $ClusterName) {
   & kind create cluster --config (Join-Path $ScriptDir "kind-cluster.yaml")
 } else {
-  Write-Host "    cluster already exists, reusing"
+  & kubectl cluster-info --context "kind-$ClusterName" *> $null
+  if ($LASTEXITCODE -eq 0) {
+    Write-Host "    cluster already exists and is reachable, reusing"
+  } else {
+    # A leftover-but-dead cluster (e.g. after a Docker restart) would wedge every
+    # kubectl/helm call below — recreate it instead of reusing.
+    Write-Host "    existing cluster is unreachable - recreating" -ForegroundColor Yellow
+    & kind delete cluster --name $ClusterName 2>$null
+    & kind create cluster --config (Join-Path $ScriptDir "kind-cluster.yaml")
+  }
 }
 & kubectl cluster-info --context "kind-$ClusterName"
 

--- a/k8s/kind/setup-kind.sh
+++ b/k8s/kind/setup-kind.sh
@@ -35,8 +35,14 @@ command -v helm   >/dev/null || { echo "helm not found"; exit 1; }
 echo "==> Creating kind cluster '$CLUSTER_NAME' (if missing)"
 if ! kind get clusters | grep -qx "$CLUSTER_NAME"; then
   kind create cluster --config "$SCRIPT_DIR/kind-cluster.yaml"
+elif kubectl cluster-info --context "kind-${CLUSTER_NAME}" >/dev/null 2>&1; then
+  echo "    cluster already exists and is reachable, reusing"
 else
-  echo "    cluster already exists, reusing"
+  # A leftover-but-dead cluster (e.g. after a Docker restart) would otherwise
+  # wedge every kubectl/helm call below — recreate it instead of reusing.
+  echo "    existing cluster is unreachable — recreating"
+  kind delete cluster --name "$CLUSTER_NAME" || true
+  kind create cluster --config "$SCRIPT_DIR/kind-cluster.yaml"
 fi
 kubectl cluster-info --context "kind-${CLUSTER_NAME}"
 


### PR DESCRIPTION
## Problem (found by live-deploying locally)
`helm install` of the chart fails on any **non-Traefik** cluster (kind, Docker Desktop):
```
no matches for kind "Middleware" in version "traefik.io/v1alpha1"
```
`templates/neo4j-ingress.yaml` always renders a Traefik `Middleware` CRD, but Traefik only exists on prod (Contabo k3s). This silently broke local Kubernetes deployability — exactly what the new `kind-validate` gate is meant to catch (surfaced here because kind itself can't run on this machine's cgroup-v1 Docker Desktop, so I deployed to Docker Desktop's built-in k8s instead).

## Fix
- **Gate the Traefik bits** (`Middleware` + its router annotation) behind `ingress.className == "traefik"`. Prod renders it unchanged; local (nginx) renders **0** Traefik resources. Verified: `helm template` local=0, prod=1 Middleware; `helm lint` clean.
- **`make dd-up` / `dd-down`** — deploy/uninstall the chart on Docker Desktop's built-in Kubernetes (works where kind can't, e.g. cgroup v1). Same `values-local.yaml`; `make kind-validate`/`kind-test` then target the docker-desktop context.
- **`setup-kind.sh` / `.ps1`** — recreate a dead leftover cluster (unreachable `cluster-info`) instead of reusing it and wedging the bring-up.
- **`docs/LOCAL_KUBERNETES.md`** — documents the Docker Desktop path + the cgroup-v1 caveat.

## Live verification
Full stack deployed to Docker Desktop k8s; `validate_kind_deployment.py` → **`[OK] all 19 enabled services Ready`** (postgres/mongo/redis/neo4j/elasticsearch/chromadb/kafka/rabbitmq/prometheus/grafana/alertmanager/loki/airflow/…); reachability probes pass for postgres, redis, elasticsearch, rabbitmq, prometheus, grafana, alertmanager, loki.

## Follow-up (noted, not here)
`fuzeinfra-airflow-init` post-install Job can exceed helm's hook timeout → release shows `failed` even though the Job completes and all pods run. Worth making the hook non-blocking or bumping its timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)