### PR TITLE
feat(crit-fix): cross-repo handoff for consumer-owned crits

### DIFF
--- a/.github/workflows/grafana-crit-fix.yml
+++ b/.github/workflows/grafana-crit-fix.yml
@@ -304,33 +304,67 @@ jobs:
             fi
           fi
 
-          if [ "$ACTION" = "issue" ]; then
+          if [ "$ACTION" = "issue" ] && [ "$IS_SELF" = "true" ]; then
+            # ── FuzeInfra-owned crit: file the issue here ─────────────────────
+            TITLE=$(python3 -c "import json; print(json.loads(open('/tmp/claude_result.json').read()).get('title','CRIT alert needs attention'))")
+            python3 .github/gen-issue-body.py > /tmp/issue_body.md
+            URL=$(gh issue create --repo "$OWNER_REPO" \
+              --title "🚨 ${TITLE}" --label "bug" --label "crit-autofix" \
+              --body-file /tmp/issue_body.md 2>/dev/null) \
+              || URL=$(gh issue create --repo "$OWNER_REPO" \
+                   --title "🚨 ${TITLE}" --body-file /tmp/issue_body.md)
+            echo "action=issue" >> "$GITHUB_OUTPUT"
+            echo "url=$URL"     >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$ACTION" = "issue" ] && [ "$IS_SELF" != "true" ]; then
+            # ── Consumer-owned crit: HAND OFF to the owner repo ───────────────
+            # The crit came from a consumer's namespace, so FuzeInfra can't fix it.
+            # Record a FuzeInfra tracking issue, open an @claude issue in the owner
+            # repo (its own process fixes the root cause + deploys), cross-link the
+            # two, then close the FuzeInfra tracking issue as handed-off. Dedup on
+            # the owner repo so repeated alerts don't pile on.
             TITLE=$(python3 -c "import json; print(json.loads(open('/tmp/claude_result.json').read()).get('title','CRIT alert needs attention'))")
             python3 .github/gen-issue-body.py > /tmp/issue_body.md
 
-            # Dedup in the owner repo: the FuzeInfra preflight gate can't see a
-            # consumer repo's open issues, so check here before piling on.
             EXISTING=$(gh issue list --repo "$OWNER_REPO" --label crit-autofix \
               --state open --json number --jq 'length' 2>/dev/null || echo 0)
             if [ "${EXISTING:-0}" -gt 0 ]; then
-              echo "::notice::An open crit-autofix issue already exists in $OWNER_REPO; skipping"
-              echo "action=issue" >> "$GITHUB_OUTPUT"
+              echo "::notice::open crit-autofix issue already exists in $OWNER_REPO; skipping handoff"
+              echo "action=handoff" >> "$GITHUB_OUTPUT"
             else
-              # Ensure the label exists in the (possibly consumer) repo; tolerate
-              # a missing label / no label-create permission by retrying bare.
+              # 1) FuzeInfra tracking issue (the audit record)
+              TRACK_URL=$(gh issue create --repo "${{ github.repository }}" \
+                --title "🚨 ${TITLE} (→ ${OWNER_REPO})" --label "crit-autofix" \
+                --body-file /tmp/issue_body.md 2>/dev/null) \
+                || TRACK_URL=$(gh issue create --repo "${{ github.repository }}" \
+                     --title "🚨 ${TITLE} (→ ${OWNER_REPO})" --body-file /tmp/issue_body.md)
+              TRACK_NUM="${TRACK_URL##*/}"
+
+              # 2) Owner-repo issue with @claude + a back-link to the tracking issue
+              {
+                cat /tmp/issue_body.md
+                echo ""; echo "---"
+                echo "**Origin:** ${{ github.repository }}#${TRACK_NUM} (FuzeInfra crit-alert auto-triage)."
+                echo ""
+                echo "@claude please investigate and fix the root cause in this repo, open a PR, and report back here when triggered, fixed, and deployed."
+              } > /tmp/handoff_body.md
               gh label create crit-autofix --color e11d48 \
-                --description "Opened by FuzeInfra CRIT log auto-fix" \
-                --repo "$OWNER_REPO" 2>/dev/null || true
-              URL=$(gh issue create --repo "$OWNER_REPO" \
-                --title "🚨 ${TITLE}" \
-                --label "bug" --label "crit-autofix" \
-                --body-file /tmp/issue_body.md 2>/tmp/issue_err.txt) || {
-                  echo "::warning::labelled issue create failed in $OWNER_REPO (label/token scope?); retrying without labels"
-                  URL=$(gh issue create --repo "$OWNER_REPO" \
-                    --title "🚨 ${TITLE}" --body-file /tmp/issue_body.md)
-                }
-              echo "action=issue" >> "$GITHUB_OUTPUT"
-              echo "url=$URL"     >> "$GITHUB_OUTPUT"
+                --description "Handed off from FuzeInfra CRIT auto-fix" --repo "$OWNER_REPO" 2>/dev/null || true
+              FF_URL=$(gh issue create --repo "$OWNER_REPO" \
+                --title "🚨 ${TITLE}" --label "crit-autofix" \
+                --body-file /tmp/handoff_body.md 2>/dev/null) \
+                || FF_URL=$(gh issue create --repo "$OWNER_REPO" \
+                     --title "🚨 ${TITLE}" --body-file /tmp/handoff_body.md)
+
+              # 3) Cross-link + close the FuzeInfra tracking issue
+              gh issue comment "$TRACK_NUM" --repo "${{ github.repository }}" \
+                --body "🤝 Handed off to ${OWNER_REPO}: ${FF_URL} — that repo's @claude process will fix + deploy. Closing here; tracking continues in the linked issue." 2>/dev/null || true
+              gh issue close "$TRACK_NUM" --repo "${{ github.repository }}" --reason "not planned" 2>/dev/null || true
+
+              echo "::notice::handed off ${TRACK_URL} → ${FF_URL}"
+              echo "action=handoff" >> "$GITHUB_OUTPUT"
+              echo "url=$FF_URL"    >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -369,18 +403,21 @@ jobs:
       # ── email (fix and issue actions only) ─────────────────────────────────
       - name: Prepare email subject
         id: email
-        if: steps.suppress.outputs.skip != 'true' && (steps.act.outputs.action == 'fix' || steps.act.outputs.action == 'issue')
+        if: steps.suppress.outputs.skip != 'true' && (steps.act.outputs.action == 'fix' || steps.act.outputs.action == 'issue' || steps.act.outputs.action == 'handoff')
         run: |
           if [ "${{ steps.act.outputs.action }}" = "fix" ]; then
             echo "subject=🚨 FuzeInfra Alert — Fix PR Opened" >> "$GITHUB_OUTPUT"
             echo "action_line=Fix PR: ${{ steps.act.outputs.url }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.act.outputs.action }}" = "handoff" ]; then
+            echo "subject=🤝 FuzeInfra Alert — Handed off to owner repo" >> "$GITHUB_OUTPUT"
+            echo "action_line=Handed off (owner repo will fix + deploy): ${{ steps.act.outputs.url }}" >> "$GITHUB_OUTPUT"
           else
             echo "subject=🚨 FuzeInfra Alert — Needs Attention (Issue Created)" >> "$GITHUB_OUTPUT"
             echo "action_line=GitHub Issue: ${{ steps.act.outputs.url }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Send email
-        if: steps.suppress.outputs.skip != 'true' && (steps.act.outputs.action == 'fix' || steps.act.outputs.action == 'issue')
+        if: steps.suppress.outputs.skip != 'true' && (steps.act.outputs.action == 'fix' || steps.act.outputs.action == 'issue' || steps.act.outputs.action == 'handoff')
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com

--- a/docs/crit-log-autofix.md
+++ b/docs/crit-log-autofix.md
@@ -44,10 +44,17 @@ fuzeinfra.io/owner-repo: <owner>/<repo>
 **Fallback** to `izzywdev/FuzeInfra` when the namespace is missing/unknown, not
 found, unannotated, or the value is invalid.
 
-**`fix` vs `issue` by owner:** a code-fix PR can only target FuzeInfra's own
-checkout, so for a consumer-owned namespace `action=fix` is **downgraded to a
-triage issue** filed in the consumer repo. `action=ignore` always stays in
-FuzeInfra — the suppression list is FuzeInfra's.
+**`fix` vs `issue` vs handoff, by owner:**
+- **FuzeInfra-owned** crit (`is_self`): unchanged — `fix` opens a PR here, `issue`
+  files here, `ignore` requests suppression here.
+- **Consumer-owned** crit (a code-fix PR can't target another repo's checkout):
+  the handler performs a **cross-repo handoff** — it (1) records a FuzeInfra
+  **tracking** issue, (2) opens an issue in the owner repo that **`@claude`-mentions**
+  so the owner's own handler fixes the root cause and deploys, (3) cross-links the
+  two, and (4) **closes the FuzeInfra tracking issue** as handed-off. `action=fix`
+  on a consumer namespace is first downgraded into this handoff path. Dedup is on
+  the owner repo (skip if it already has an open `crit-autofix` issue).
+- `action=ignore` always stays in FuzeInfra — the suppression list is FuzeInfra's.
 
 ### Onboarding a consumer namespace
 


### PR DESCRIPTION
Implements the handoff lifecycle you described for #103: a CRIT from a consumer namespace now (1) records a FuzeInfra **tracking** issue, (2) opens an **@claude** issue in the owner repo so its own process fixes + deploys, (3) cross-links them, (4) **closes** the FuzeInfra tracking issue as handed-off. `action=fix` on a consumer namespace downgrades into this path; owner-repo dedup prevents pile-ons; `ignore` stays in FuzeInfra. Email fires on handoff too.

This is the automated version of the manual handoff just executed: FuzeInfra #103 → **FuzeFront #104** (which already triggered FF's @claude and pushed a fix branch `claude/issue-104-...`).

YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)