### PR TITLE
feat(secrets): hands-off SealedSecret rotation workflow (family-standard)

### DIFF
--- a/.github/workflows/rotate-sealed-secret.yml
+++ b/.github/workflows/rotate-sealed-secret.yml
@@ -1,0 +1,165 @@
+# =============================================================================
+# rotate-sealed-secret — self-service, hands-off SealedSecret rotation (GitOps).
+#
+# THE point of this workflow: rotating a secret must be an automated primitive,
+# never a manual "reseal + redeploy" runbook. It generates a fresh value, seals
+# it OFFLINE against FuzeInfra's published *public* cert (no cluster access, no
+# plaintext ever in logs — see scripts/seal-secret.sh), commits the encrypted
+# manifest, and opens a PR that auto-merges on green → Argo CD syncs the new
+# SealedSecret → the controller decrypts it.
+#
+# The consumer then picks up the new value automatically IF it has a reloader
+# trigger (stakater/reloader annotation, or a Helm `checksum/secret` pod
+# annotation). Without that, add `reload_argocd_app` to have this workflow ask
+# Argo to hard-refresh + sync the app so the rollout happens. Either way: no human
+# runs a script. This is the family-standard template — replicate it per repo
+# (like claude.yml / auto-merge.yml) and point --scope/--manifest at that repo's
+# SealedSecret.
+#
+# Secrets (optional): ARGOCD_SERVER + ARGOCD_AUTH_TOKEN (only if you use
+# reload_argocd_app to trigger an explicit sync).
+# =============================================================================
+name: rotate-sealed-secret
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "SealedSecret scope as ns/name (e.g. fuzeinfra/fuzeinfra-secrets)"
+        required: true
+      key:
+        description: "Secret key to rotate (e.g. AUTHENTIK_BOOTSTRAP_TOKEN)"
+        required: true
+      manifest:
+        description: "Path to the SealedSecret manifest to update (merge-into)"
+        required: true
+      value:
+        description: "Explicit new value (leave BLANK to auto-generate a random hex token)"
+        required: false
+        default: ""
+      length:
+        description: "Random byte length when auto-generating (hex output is 2x this)"
+        required: false
+        default: "32"
+      reload_argocd_app:
+        description: "Optional Argo CD Application to hard-refresh+sync after merge (needs ARGOCD_* secrets)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: rotate-${{ inputs.scope }}-${{ inputs.key }}
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate inputs
+        env:
+          SCOPE: ${{ inputs.scope }}
+          KEY: ${{ inputs.key }}
+          MANIFEST: ${{ inputs.manifest }}
+        run: |
+          set -euo pipefail
+          # Pass inputs via env (never interpolate ${{ }} into the shell) to avoid injection.
+          printf '%s' "$SCOPE" | grep -qE '^[a-z0-9-]+/[a-z0-9-]+$' || { echo "::error::scope must be ns/name"; exit 1; }
+          printf '%s' "$KEY" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*$' || { echo "::error::key must be a valid env-var name"; exit 1; }
+          case "$MANIFEST" in
+            *..*|/*) echo "::error::manifest must be a repo-relative path"; exit 1 ;;
+          esac
+          [ -f "$MANIFEST" ] || { echo "::error::manifest not found: $MANIFEST"; exit 1; }
+
+      - name: Install kubeseal
+        run: |
+          set -euo pipefail
+          VER="0.27.1"
+          curl -fsSL -o /tmp/ks.tgz \
+            "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${VER}/kubeseal-${VER}-linux-amd64.tar.gz"
+          tar -xzf /tmp/ks.tgz -C /tmp kubeseal
+          sudo install -m0755 /tmp/kubeseal /usr/local/bin/kubeseal
+          kubeseal --version
+
+      - name: Generate + seal the new value (offline, public cert)
+        env:
+          KEY: ${{ inputs.key }}
+          SCOPE: ${{ inputs.scope }}
+          MANIFEST: ${{ inputs.manifest }}
+          IN_VALUE: ${{ inputs.value }}
+          LEN: ${{ inputs.length }}
+        run: |
+          set -euo pipefail
+          umask 077
+          TMP="$(mktemp)"; trap 'rm -f "$TMP"' EXIT
+          if [ -n "$IN_VALUE" ]; then
+            # scrub whitespace defensively — a stray newline in a token is the exact
+            # bug this primitive exists to prevent (see crit-log-autofix handoff).
+            printf '%s' "$IN_VALUE" | tr -d '[:space:]' > "$TMP"
+          else
+            openssl rand -hex "$LEN" | tr -d '[:space:]' > "$TMP"
+          fi
+          # Seal offline via the canonical script — merges into the existing manifest,
+          # never prints plaintext, needs zero cluster access.
+          bash scripts/seal-secret.sh "$SCOPE" "${KEY}=@${TMP}" --out "$MANIFEST"
+
+      - name: Open auto-merging rotation PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          KEY: ${{ inputs.key }}
+          SCOPE: ${{ inputs.scope }}
+          MANIFEST: ${{ inputs.manifest }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$MANIFEST"; then
+            echo "::notice::no change to $MANIFEST (already up to date) — nothing to rotate"; exit 0
+          fi
+          BRANCH="rotate/${KEY}-${RUN_ID}"
+          git config user.name "FuzeInfra Secret Rotation"
+          git config user.email "rotation@fuzeinfra"
+          git checkout -b "$BRANCH"
+          git add "$MANIFEST"
+          {
+            printf 'chore(secrets): rotate %s in %s [skip ci]\n\n' "$KEY" "$SCOPE"
+            printf 'Automated SealedSecret rotation. Only the encrypted ciphertext changed;\n'
+            printf 'the new value was generated + sealed offline (public cert) and never logged.\n'
+          } > /tmp/commit_msg.txt
+          git commit -F /tmp/commit_msg.txt
+          git push origin "$BRANCH"
+          {
+            printf '%s\n\n' "Automated, hands-off SealedSecret rotation (no manual reseal)."
+            printf -- '- Key: `%s` · Scope: `%s` · Manifest: `%s`\n' "$KEY" "$SCOPE" "$MANIFEST"
+            printf -- '- New value generated + sealed **offline** against the published public cert; only ciphertext changed.\n'
+            printf -- '- On merge, Argo CD syncs the SealedSecret, the controller decrypts it, and the Secret is updated.\n'
+            printf -- '- Consumer reloads via a reloader annotation (stakater/reloader) or a `checksum/secret` pod annotation; else pass `reload_argocd_app`.\n\n'
+            printf '%s\n' "Auto-merges on green (auto-merge.yml)."
+          } > /tmp/pr_body.md
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(secrets): rotate ${KEY} in ${SCOPE}" \
+            --body-file /tmp/pr_body.md --label "secret-rotation" 2>/dev/null \
+            || gh pr create --base main --head "$BRANCH" \
+                 --title "chore(secrets): rotate ${KEY} in ${SCOPE}" --body-file /tmp/pr_body.md
+
+      - name: Trigger Argo sync (optional)
+        if: ${{ inputs.reload_argocd_app != '' }}
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+          APP: ${{ inputs.reload_argocd_app }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ARGOCD_SERVER:-}" ] || [ -z "${ARGOCD_AUTH_TOKEN:-}" ]; then
+            echo "::warning::reload_argocd_app set but ARGOCD_SERVER/ARGOCD_AUTH_TOKEN missing — skipping explicit sync (rely on reloader)"; exit 0
+          fi
+          # Hard-refresh + sync so the consumer rolls onto the new secret value.
+          curl -fsSL "https://${ARGOCD_SERVER}/api/v1/applications/${APP}?refresh=hard" \
+            -H "Authorization: Bearer ${ARGOCD_AUTH_TOKEN}" >/dev/null
+          curl -fsSL -X POST "https://${ARGOCD_SERVER}/api/v1/applications/${APP}/sync" \
+            -H "Authorization: Bearer ${ARGOCD_AUTH_TOKEN}" \
+            -H "Content-Type: application/json" -d '{"prune":false}' >/dev/null
+          echo "Requested Argo hard-refresh + sync of $APP"

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -151,8 +151,37 @@ decrypt. Because consumers always fetch the cert from the published URL, rotatio
 is transparent: the next seal automatically uses the newest key. You do **not**
 need to re-seal existing secrets when the key rotates.
 
-You only re-seal when **you** change a secret's value. Re-run `seal-secret.sh`
-against the same `--out` file; it merges the new value in place.
+You only re-seal when a secret's **value** changes. That must be a hands-off
+automated primitive — never a manual runbook.
+
+### Automated value rotation (`rotate-sealed-secret.yml`)
+
+`.github/workflows/rotate-sealed-secret.yml` is the self-service rotation gate.
+Trigger it (UI → Actions → *rotate-sealed-secret* → Run, or
+`gh workflow run rotate-sealed-secret.yml -f scope=<ns>/<name> -f key=<KEY> -f manifest=<path>`)
+and it:
+
+1. generates a fresh value (`openssl rand -hex` + whitespace-scrubbed) — or takes
+   an explicit `value` input;
+2. seals it **offline** against the published public cert via `seal-secret.sh`
+   (no cluster access, plaintext never logged) and merges it into the manifest;
+3. opens a PR that **auto-merges on green** → Argo CD syncs the SealedSecret →
+   the controller decrypts it → the Secret updates.
+
+For the consumer to pick up the new value automatically, it must carry a
+**reloader trigger** — a [stakater/reloader](https://github.com/stakater/Reloader)
+annotation or a Helm `checksum/secret` pod annotation — so its pods restart on
+the Secret change. (If neither is present, pass `reload_argocd_app=<app>` to have
+the workflow hard-refresh + sync that Argo app.) The result: rotating a secret is
+**fire-the-workflow → done**, with no human running `seal-secret.sh` by hand.
+
+This is the family-standard primitive — replicate the workflow in each repo (like
+`claude.yml` / `auto-merge.yml`) pointed at that repo's SealedSecret. An agent's
+remediation for a bad/leaked secret should be *"triggered rotation → PR #N →
+synced"*, never *"please run this script."*
+
+`seal-secret.sh` remains available for the rare interactive case, but rotation
+should go through the workflow.
 
 **Operator responsibilities** (not consumers):
 


### PR DESCRIPTION
Makes secret rotation an **automated primitive**, not the manual reseal runbook that FuzeFront #104's fix had to fall back on.

`rotate-sealed-secret.yml` (workflow_dispatch): generate fresh value → seal **offline** via `scripts/seal-secret.sh` (public cert, no cluster access, plaintext never logged) → auto-merging PR → Argo syncs SealedSecret → controller decrypts. Consumer reloads via reloader/`checksum/secret` annotation, or pass `reload_argocd_app` for an explicit Argo sync. Inputs via env (no `${{ }}` injection) + strict validation.

Family-standard: replicate per repo (like claude.yml / auto-merge.yml). Documented in docs/SECRETS_MANAGEMENT.md §5. YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)