### PR TITLE
chore: remove envmanager submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "envmanager"]
-	path = envmanager
-	url = https://github.com/izzywdev/EnvManager.git


### PR DESCRIPTION
## Summary
- Removes the `envmanager` submodule (`izzywdev/EnvManager`) — it is a standalone tool and does not need to be embedded here
- Runs `git submodule deinit -f`, `git rm`, and removes `.git/modules/` entry

## Test plan
- [ ] Verify `.gitmodules` no longer contains `EnvManager` entry after merge
- [ ] Confirm no other code in this repo imports from the `envmanager/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)