### PR TITLE
governance: shared-datastore provisioning pattern + allocation registry

### DIFF
--- a/governance/datastore-allocations.md
+++ b/governance/datastore-allocations.md
@@ -8,12 +8,12 @@ PR (or provisioning run) that creates an allocation. See
 
 | App | Role | Database | Consumer repo | Status |
 |---|---|---|---|---|
-| fuzekeys | `fuzekeys_user` | `fuzekeys` | izzywdev/FuzeKeys | pending (FuzeInfra#136) |
+| fuzekeys | `fuzekeys_user` | `fuzekeys` | izzywdev/FuzeKeys | active (FuzeInfra#136) |
 
 ## Redis (shared `fuzeinfra-redis`)
 
 | App | ACL user | Key prefix | DB index | Consumer repo | Status |
 |---|---|---|---|---|---|
-| fuzekeys | `fuzekeys` | `fuzekeys:` | 1 | izzywdev/FuzeKeys | pending (FuzeInfra#136) |
+| fuzekeys | `fuzekeys` | `fuzekeys:` | 1 | izzywdev/FuzeKeys | active (FuzeInfra#136) |
 
 DB index 0 is reserved for FuzeInfra platform services.

--- a/governance/datastore-allocations.md
+++ b/governance/datastore-allocations.md
@@ -1,0 +1,19 @@
+# Datastore allocation registry
+
+Names, prefixes, and indexes only — **never credentials**. Update in the same
+PR (or provisioning run) that creates an allocation. See
+`governance/datastore-provisioning.md` for the process.
+
+## Postgres (shared `fuzeinfra-postgres`)
+
+| App | Role | Database | Consumer repo | Status |
+|---|---|---|---|---|
+| fuzekeys | `fuzekeys_user` | `fuzekeys` | izzywdev/FuzeKeys | pending (FuzeInfra#136) |
+
+## Redis (shared `fuzeinfra-redis`)
+
+| App | ACL user | Key prefix | DB index | Consumer repo | Status |
+|---|---|---|---|---|---|
+| fuzekeys | `fuzekeys` | `fuzekeys:` | 1 | izzywdev/FuzeKeys | pending (FuzeInfra#136) |
+
+DB index 0 is reserved for FuzeInfra platform services.

--- a/governance/datastore-provisioning.md
+++ b/governance/datastore-provisioning.md
@@ -1,0 +1,103 @@
+# Shared datastore provisioning (Postgres / Redis / Mongo / Neo4j)
+
+How a consumer repo gets a least-privilege silo on FuzeInfra's shared datastores
+— **without any credential ever appearing in plaintext in git, issues, or logs**.
+
+> FuzeInfra is the datastore master. Consumers never hold superuser creds and
+> never operate the cluster. All provisioning is delegated to FuzeInfra's
+> `@claude` handler, whose runner holds the prod `KUBE_CONFIG` and a cross-repo
+> `GH_TOKEN` PAT (see `.github/workflows/claude.yml`).
+
+## The flow (push, not pull)
+
+1. **Consumer opens an `@claude` issue on FuzeInfra** naming only the app
+   (e.g. "provision Postgres + Redis for `fuzekeys`"). The issue **must not**
+   contain proposed usernames, passwords, or connection strings — issues are
+   plaintext and public. Requesting "create user xyz with password pass123"
+   is forbidden.
+2. **FuzeInfra's `@claude` provisions on the runner.** Credentials are
+   generated runner-side (`openssl rand -hex 24` — hex-only, no shell
+   metachars) and exist only in runner memory. Superuser access is read
+   directly from the cluster secret via `kubectl` — never echoed.
+3. **FuzeInfra pushes the creds to the consumer repo** as GitHub Actions
+   secrets via `gh secret set -R izzywdev/<consumer>` using `GH_TOKEN`.
+   Direction matters: a workflow's `GITHUB_TOKEN` cannot write Actions
+   secrets even on its own repo, so the consumer can never pull — the PAT
+   holder (FuzeInfra's handler) pushes.
+4. **Registry updated.** Every allocation is recorded in
+   `governance/datastore-allocations.md` (names/prefixes/indexes only, never
+   secrets) so future allocations don't collide.
+5. **Done + hand-off.** FuzeInfra's `@claude` comments `DONE:` on the issue
+   listing the secret **names** (never values), then opens a hand-off issue on
+   the consumer repo mentioning its `@claude` ("creds delivered as `<APP>_DB_*`,
+   run seal-secrets, verify migrations").
+
+## Naming convention (deterministic, per app `<app>`)
+
+| Thing | Name |
+|---|---|
+| Postgres role | `<app>_user` |
+| Postgres database | `<app>` (owner = `<app>_user`) |
+| Redis ACL user | `<app>` |
+| Redis key prefix | `<app>:` (mandatory in app code) |
+| Redis DB index | next free index in the registry (tidiness only — see below) |
+| GH Actions secrets | `<APP>_DB_USER`, `<APP>_DB_PASSWORD`, `<APP>_REDIS_URL` |
+
+Hosts follow the published contract: `fuzeinfra-<svc>.fuzeinfra.svc.cluster.local`.
+
+## Postgres recipe (runner-side)
+
+```bash
+PW=$(openssl rand -hex 24)   # hex-only: FastAPI/alembic init breaks on shell metachars
+kubectl exec -n fuzeinfra <postgres-pod> -- psql -U postgres \
+  -c "CREATE ROLE <app>_user LOGIN PASSWORD '${PW}';" \
+  -c "CREATE DATABASE <app> OWNER <app>_user;" \
+  -c "REVOKE CONNECT ON DATABASE <app> FROM PUBLIC;"
+gh secret set <APP>_DB_USER     -R izzywdev/<consumer> -b "<app>_user"
+gh secret set <APP>_DB_PASSWORD -R izzywdev/<consumer> -b "${PW}"
+```
+
+Verify from inside the cluster before reporting DONE (e.g. `kubectl exec` into
+the Postgres pod and connect as the new role to the new DB).
+
+## Redis recipe — ACL user per app, NOT the shared password
+
+A Redis **DB index is not a security boundary**: any client holding the
+instance password can `SELECT` into every DB and `FLUSHALL`. The silo is a
+**per-app ACL user** (Redis 6+) restricted to the app's key prefix:
+
+```bash
+RPW=$(openssl rand -hex 24)
+kubectl exec -n fuzeinfra <redis-pod> -- redis-cli -a "$MASTER_PW" \
+  ACL SETUSER <app> on ">${RPW}" "~<app>:*" +@all -@admin -@dangerous
+gh secret set <APP>_REDIS_URL -R izzywdev/<consumer> \
+  -b "redis://<app>:${RPW}@fuzeinfra-redis.fuzeinfra.svc.cluster.local:6379/<n>"
+```
+
+- The key-prefix restriction (`~<app>:*`) is enforced server-side; the DB
+  index `<n>` is a convention on top. App code MUST prefix all keys.
+- **Persistence gotcha:** imperative `ACL SETUSER` does not survive a pod
+  restart unless an `aclfile` is configured and `ACL SAVE` is run, or the ACL
+  is codified in the Redis chart values. The imperative command unblocks
+  go-live; the chart/values change (GitOps PR) is required follow-up before
+  the issue is closed.
+- If ACLs are unavailable on the deployed Redis, fall back to shared password
+  + dedicated DB index, and record the accepted risk in the issue.
+
+## Security invariants
+
+- Secrets exist only in runner memory and in the destination secret stores
+  (GH Actions secrets / sealed k8s secrets). Never in git, issues, PRs, or logs.
+- Passwords are hex-only (`openssl rand -hex 24`).
+- One role per app per datastore; no shared roles, no superuser hand-out.
+- Every allocation lands in `governance/datastore-allocations.md`.
+
+## Future direction (not yet required)
+
+Since consumers deploy into namespaces on the same cluster, the GH-secret hop
+can be eliminated: FuzeInfra writes the creds as a plain k8s `Secret` directly
+into the consumer's namespace (imperative non-chart-managed Secrets are
+allowed), and the consumer chart references it via `existingSecret`, composing
+`DATABASE_URL` in-pod from env. The cluster becomes the sole trust boundary.
+Beyond that, a CRD-based operator (CloudNativePG-style "database request" CRs)
+would make this fully declarative — revisit when consumer count grows.


### PR DESCRIPTION
Codifies the cross-repo shared-datastore provisioning pattern that #136 exercises, so every future consumer repo follows the same zero-plaintext flow.

**What this adds**

- `governance/datastore-provisioning.md` — the process: consumer opens an `@claude` issue on FuzeInfra naming only the app (never proposed creds); FuzeInfra's handler generates hex-only creds runner-side, provisions the least-privilege silo via `kubectl`, and **pushes** the creds as GH Actions secrets to the consumer repo via `GH_TOKEN` (push not pull — `GITHUB_TOKEN` can't write Actions secrets, so consumers can never pull). Includes Postgres and Redis recipes, naming conventions, and security invariants.
- `governance/datastore-allocations.md` — registry of allocations (names/prefixes/DB indexes only, never secrets), seeded with the pending fuzekeys rows from #136.

**Key decisions**

- Redis silos are **per-app ACL users with key-prefix restriction** (`~<app>:*`), not shared password + DB index — a DB index is not a security boundary. DB index remains as a tidiness convention. Notes the ACL-persistence gotcha (aclfile / chart values follow-up required).
- Documented future direction: deliver creds as k8s Secrets directly into the consumer namespace (`existingSecret`) to eliminate the GH-secret hop entirely; operator/CRD pattern when consumer count grows.

Refs #136.
