### PR TITLE
feat(mongo): declarative per-consumer DB+user provisioning

### DIFF
--- a/docker/mongo/init/00-fuzeplan.js
+++ b/docker/mongo/init/00-fuzeplan.js
@@ -1,0 +1,23 @@
+// Idempotent MongoDB user provisioning for FuzePlan consumers.
+// Run with: mongosh -u admin -p <password> --authenticationDatabase admin 00-fuzeplan.js
+// Safe to re-run: creates users only if they do not already exist.
+
+(function() {
+  const db = connect('mongodb://localhost:27017/FuzePlan');
+  const existing = db.getUsers().users.map(u => u.user);
+
+  const users = [
+    { user: 'fuzeplan_app', roles: [{ role: 'readWrite', db: 'FuzePlan' }] },
+    { user: 'claude_runner_user', roles: [{ role: 'readWrite', db: 'FuzePlan' }] },
+  ];
+
+  users.forEach(({ user, roles }) => {
+    if (existing.includes(user)) {
+      print('skip: ' + user + ' already exists');
+      return;
+    }
+    const pwd = process.env[user.toUpperCase() + '_PASSWORD'] || (() => { throw new Error('env ' + user.toUpperCase() + '_PASSWORD not set'); })();
+    db.createUser({ user, pwd, roles });
+    print('created: ' + user);
+  });
+})();

--- a/docs/consuming-repos/MONGODB_PROVISIONING.md
+++ b/docs/consuming-repos/MONGODB_PROVISIONING.md
@@ -1,0 +1,16 @@
+# MongoDB Consuming-Repo Provisioning
+
+## Pattern
+Add an entry to `docker/mongo/init/<repo>.js` (idempotent) and PR it to FuzeInfra.
+Set `<USER>_PASSWORD` env vars in the consuming repo's SealedSecret.
+
+## Existing consumers
+| Repo | DB | User | Role |
+|------|----|------|------|
+| FuzePlan (main app) | FuzePlan | fuzeplan_app | readWrite |
+| FuzePlan (claude-runner) | FuzePlan | claude_runner_user | readWrite |
+
+## Adding a new consumer
+1. Add user to `docker/mongo/init/00-<repo>.js`
+2. PR to FuzeInfra — on merge, the init script documents the intended state
+3. On cluster rebuild, run: `mongosh -u admin -p $ADMIN_PW --authenticationDatabase admin docker/mongo/init/00-<repo>.js`


### PR DESCRIPTION
## Summary
- Adds `docker/mongo/init/00-fuzeplan.js` — idempotent mongosh script that documents and reproduces the FuzePlan MongoDB users (`fuzeplan_app`, `claude_runner_user`) on cluster rebuild
- Adds `docs/consuming-repos/MONGODB_PROVISIONING.md` — runbook for the provisioning pattern and future consumer onboarding

## Context
Users `fuzeplan_app` and `claude_runner_user` already exist on the prod cluster (provisioned manually). This PR makes that state declarative and reproducible, closing #156.

## Test plan
- [ ] Script is idempotent: re-running against an existing cluster prints `skip: <user> already exists` for both users
- [ ] On a fresh cluster rebuild, running `mongosh -u admin -p $ADMIN_PW --authenticationDatabase admin docker/mongo/init/00-fuzeplan.js` with `FUZEPLAN_APP_PASSWORD` and `CLAUDE_RUNNER_USER_PASSWORD` set creates both users successfully

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)