### PR TITLE
feat(secrets): seal mendys credentials + enable Postgres/MongoDB provisioning (#166)

### DIFF
--- a/deploy/sealed-secrets/mendys-db-credentials.yaml
+++ b/deploy/sealed-secrets/mendys-db-credentials.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: mendys-db-credentials
+  namespace: fuzeinfra
+spec:
+  encryptedData:
+    password: AgCJ88VtmBisdnN5Jsf9CjDfCDXIfoJj18EL7pl0fjsWhdLmtjcRWiV7Tlhal9nBN4ATs4tVBKztOCwWHRtaTZPM3egzyZPXxnZPmtMb5PZyOTU143gYggccEuIHV7ab6/tk7Ds/IVuaXwuOhIT5wRABtyawmRbb+LnrbWnK6oPDfpIgT1EP2W5ehEEm9rhTlGVg/knu7ntZROCi2VXpF0QVX1GdEBSNgBQW29RJ9vqCroqxCnV9lP8F3hkCL7l9faathxJUs7xfcLav+8AKyJThTFb9nuOaDmaePb1F85sSQvle6sUoIjq++DxsuovuPp+lOBk6kZdexggffDMRGN+IkPPolKG646QZfcrqAp0S/fJ8/s5AZ94G1a6y4tIBjX9aL17t7WeKxhhwxKzHMctMENtrmvI1qcmJKaV4kLlYpVKmN3CNqbn5jAojbTrfE0/6nSOohpQ638oz3MtMEDeYUivtvNFSNfHMj5xS27W5oqhUxZBHBf1mFjJJlzliJTZUNwEo/knv16kmIA2voEEtS2TuFskwLBOzvziiZH8/0m8DFDeYSluL2YTQq+q/nJSYEdotDHEiTsu+yzmbuHqHjhD6NGWMEfGjd1ZEZidfZjsnqN3KWqWkeAcMGbqqd+B1cVRKmM9aefeLBL++pPfXFH4HNtCcqfdCboOMiWsD8YxvXXksNXMZ3U5ejx8ij2YIh2gmHZFKqNoSF63bOUIWeq4KtZtxX+Wso1zXSxfVlKk+666OnMVi
+  template:
+    metadata:
+      creationTimestamp: null
+      name: mendys-db-credentials
+      namespace: fuzeinfra
+    type: Opaque

--- a/deploy/sealed-secrets/mendys-mongo-credentials.yaml
+++ b/deploy/sealed-secrets/mendys-mongo-credentials.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: mendys-mongo-credentials
+  namespace: fuzeinfra
+spec:
+  encryptedData:
+    password: AgCcUHwnl1GRcC0w93saLQicmWV/vsc6hn5zbD+AN6gv3gmTdqGbk2tcF4/SS+dqXo/PDSnCrJybI+DdDGU34iBnzjmTIVX8oZb48alU2jXAnrfs1i/Cmlymmj+Ifr/EoHpmHqYefx+oYImWoflV0oMYLTPNPpLRIPMQjbNOroqyMCGA+krM/CIrsDXU5KIXXqon+IjIDbVAf7x7tNFKQGWB8Yvw3b39DrhPwycsOv6RXHks1SLqgRQ95738XM8CT9nSdzwVuie5Ff38cKo+q8wINg3Ea2uAzInOMEE92xJ+e6RGfRXRMosVrgax7lo6CG+KmmS3zUriwap1Lwds6eFFLs3bK6JDw1d5zvgAfhvbf8uM/RK4nqpWsDqHYK7igEOAdlTAAqxSka0WoHQFUueip3R6jiaXxXLDmsKhQk38RDO6yT6RNTV5EaXFYChS4QOiZjsuzKqTRTYK/WE1eb88KX220Rui54pwWgCgBSkyv01fnxyuKiBZIKVP+WhVtdII9xcKN+P02IhXDsu3JtK5h6rNHNpFagun6b17sU4IkaoD1XZUuM1NOIjSgT1M6fYm/qF/fWo4WVP4g5yGhZruajkhyb4yHeS5nzuQUtZ6ertUVUMLM8Y6MHv7Y0QuR5eIVuWnTjZaczmroGmEAaAKls8kjxOfhRVF+BnXXNq95LKxbXCWgxoF/kEipjdZBtOz31x3tsLEViKYpkVAFMoP3PdBZRxnrIqCSCHhA+czQjTOgmNiSO1R
+  template:
+    metadata:
+      creationTimestamp: null
+      name: mendys-mongo-credentials
+      namespace: fuzeinfra
+    type: Opaque


### PR DESCRIPTION
Seals the Postgres and MongoDB credentials for MendysRobotics (#166).

## What this PR does
- `deploy/sealed-secrets/mendys-db-credentials.yaml` — Postgres password SealedSecret (scope: fuzeinfra/mendys-db-credentials)
- `deploy/sealed-secrets/mendys-mongo-credentials.yaml` — MongoDB password SealedSecret (scope: fuzeinfra/mendys-mongo-credentials)

Note: `values-contabo.yaml` already has `mendys.enabled: true` for both serviceDatabases and serviceMongoDatabases.
Once this merges, Argo CD runs the PostSync provisioning Jobs.

## GH secrets already set
The four MendysRobotics secrets were set in the same workflow run (never in logs):
- `MENDYS_PG_USERNAME` = mendys_svc
- `MENDYS_PG_PASSWORD` = (sealed)
- `MENDYS_MONGO_USERNAME` = mendys_app
- `MENDYS_MONGO_PASSWORD` = (sealed)

Closes #166
