### PR TITLE
fix(arc-reinstall): correct OCI chart --version flag placement

### DIFF
--- a/.github/workflows/arc-reinstall-scaleset.yml
+++ b/.github/workflows/arc-reinstall-scaleset.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           echo "=== Installing fresh scale set ==="
           helm upgrade --install staging \
-            oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set:0.14.2 \
+            oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+            --version 0.14.2 \
             --namespace arc-runners \
             --values runners/arc/runner-scale-set-values.yaml \
             --wait --timeout 5m


### PR DESCRIPTION
Separates `--version 0.14.2` from the OCI registry URL in arc-reinstall-scaleset.yml. The OCI chart URL must not include the tag inline.