### PR TITLE
fix(arc): debug runner startup + stop Argo selfHeal from fighting listener

### DIFF
--- a/.github/workflows/arc-reinstall-scaleset.yml
+++ b/.github/workflows/arc-reinstall-scaleset.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           echo "=== Installing fresh scale set ==="
           helm upgrade --install staging \
-            oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set:0.14.2 \
+            oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+            --version 0.14.2 \
             --namespace arc-runners \
             --values runners/arc/runner-scale-set-values.yaml \
             --wait --timeout 5m

--- a/argocd/applications/arc-runners.yaml
+++ b/argocd/applications/arc-runners.yaml
@@ -38,6 +38,15 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: arc-runners
+  # Argo CD must not revert EphemeralRunnerSet replicas/patchID — the ARC listener
+  # owns those fields and patches them at runtime.  selfHeal reverting them causes
+  # the listener to loop indefinitely without runners ever completing a job.
+  ignoreDifferences:
+    - group: actions.github.com
+      kind: EphemeralRunnerSet
+      jsonPointers:
+        - /spec/replicas
+        - /spec/patchID
   syncPolicy:
     automated:
       prune: true

--- a/runners/arc/runner-scale-set-values.yaml
+++ b/runners/arc/runner-scale-set-values.yaml
@@ -38,6 +38,27 @@ template:
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest
+        # Debug wrapper: print JIT config presence + GitHub connectivity before
+        # handing off to the real runner entrypoint.  Remove once runner is stable.
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            echo "=== ARC RUNNER STARTUP DEBUG ==="
+            echo "JITCONFIG length: ${#ACTIONS_RUNNER_INPUT_JITCONFIG}"
+            echo "JITCONFIG prefix: ${ACTIONS_RUNNER_INPUT_JITCONFIG:0:60}"
+            echo "Hostname: $(hostname)"
+            echo "GitHub API connectivity:"
+            curl -s --connect-timeout 10 https://api.github.com/status 2>&1 | head -5 || echo "GITHUB API UNREACHABLE"
+            echo "=== Launching runner entrypoint ==="
+            if [ -f /entrypoint.sh ]; then
+              exec /entrypoint.sh
+            elif [ -f /home/runner/run.sh ]; then
+              exec /home/runner/run.sh
+            else
+              echo "ERROR: no runner entrypoint found"
+              ls -la / /home/runner/ 2>&1
+              exit 1
+            fi
         # securityContext omitted — seccompProfile.type:RuntimeDefault is not
         # guaranteed available on k3s nodes; add back once runner is stable.
         resources:


### PR DESCRIPTION
## Summary
- Add debug command wrapper to runner container to capture JIT config presence and GitHub connectivity before the runner binary executes — runner currently exits in 3-5s with no logs, this will show us why
- Add `ignoreDifferences` for `EphemeralRunnerSet.spec.replicas` and `.spec.patchID` so Argo CD `selfHeal:true` stops reverting the listener's runtime patches — the listener loop showing `original:{replicas:-1,patchID:-1}` after every patch strongly suggests Argo is reverting those fields immediately after the listener applies them

## Test plan
- [ ] Merge → Argo CD syncs new values → reinstall scale set workflow runs → smoke test triggered
- [ ] Runner pod logs now show debug output (JIT config length, GitHub API reachability)
- [ ] EphemeralRunnerSet patchID no longer resets to -1 after each listener patch
- [ ] arc-smoke-test job transitions to `in_progress` and completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)