### PR TITLE
feat(arc): per-repo runner registration script + workflow template

### DIFF
--- a/runners/arc/register-repo.sh
+++ b/runners/arc/register-repo.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# =============================================================================
+# register-repo.sh — register a GitHub repo as an ARC self-hosted runner
+#
+# Installs a gha-runner-scale-set Helm release on the shared FuzeInfra ARC
+# controller.  The controller already runs in arc-systems; this script only
+# adds a new AutoscalingRunnerSet pointing at your repo.
+#
+# Prerequisites
+#   - kubectl pointing at the FuzeInfra cluster (kubeconfig set up)
+#   - helm >= 3.10
+#   - A GitHub App or PAT with the repo in scope (see --help)
+#
+# Usage
+#   ./runners/arc/register-repo.sh \
+#       --repo-url   https://github.com/izzywdev/FuzeFront \
+#       --name       fuzefront \
+#       --app-id     123456 \
+#       --app-install-id  789012 \
+#       --app-private-key /path/to/private-key.pem
+#
+#   # or: supply an existing k8s secret that already holds the GitHub App creds
+#   ./runners/arc/register-repo.sh \
+#       --repo-url  https://github.com/izzywdev/FuzeFront \
+#       --name      fuzefront \
+#       --secret    arc-runner-github-app   # existing secret in arc-runners
+#
+#   # uninstall a repo's scale set
+#   ./runners/arc/register-repo.sh --name fuzefront --uninstall
+#
+# After registration, add to your repo's workflows:
+#   jobs:
+#     build:
+#       runs-on: fuzefront   # matches --name
+# =============================================================================
+
+set -euo pipefail
+
+# ---- defaults ---------------------------------------------------------------
+RUNNER_NS="arc-systems-runners"
+RUNNER_NS="arc-runners"          # must match controller watchSingleNamespace
+CONTROLLER_NS="arc-systems"
+CONTROLLER_SA="arc-controller-gha-rs-controller"
+ARC_RUNNER_CHART="oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
+ARC_VERSION="0.14.2"
+MAX_RUNNERS=5
+MIN_RUNNERS=0
+
+REPO_URL=""
+SCALE_SET_NAME=""
+GITHUB_SECRET_NAME=""
+APP_ID=""
+APP_INSTALL_ID=""
+APP_PRIVATE_KEY_FILE=""
+UNINSTALL=false
+
+# ---- arg parsing ------------------------------------------------------------
+usage() {
+  grep '^#' "$0" | sed 's/^# \{0,1\}//' | sed -n '/Usage/,/^===/{ /^===/d; p }'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-url)          REPO_URL="$2"; shift 2 ;;
+    --name)              SCALE_SET_NAME="$2"; shift 2 ;;
+    --secret)            GITHUB_SECRET_NAME="$2"; shift 2 ;;
+    --app-id)            APP_ID="$2"; shift 2 ;;
+    --app-install-id)    APP_INSTALL_ID="$2"; shift 2 ;;
+    --app-private-key)   APP_PRIVATE_KEY_FILE="$2"; shift 2 ;;
+    --max-runners)       MAX_RUNNERS="$2"; shift 2 ;;
+    --uninstall)         UNINSTALL=true; shift ;;
+    --help|-h)           usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# ---- validate ---------------------------------------------------------------
+if [[ -z "$SCALE_SET_NAME" ]]; then
+  echo "ERROR: --name is required (e.g. --name fuzefront)" >&2
+  exit 1
+fi
+
+if $UNINSTALL; then
+  echo "==> Uninstalling scale set '$SCALE_SET_NAME' from $RUNNER_NS …"
+  helm uninstall "$SCALE_SET_NAME" --namespace "$RUNNER_NS" --wait 2>/dev/null \
+    || echo "(not installed — nothing to do)"
+  SECRET_NAME="arc-runner-${SCALE_SET_NAME}-github-app"
+  kubectl -n "$RUNNER_NS" delete secret "$SECRET_NAME" --ignore-not-found
+  echo "Done."
+  exit 0
+fi
+
+if [[ -z "$REPO_URL" ]]; then
+  echo "ERROR: --repo-url is required (e.g. --repo-url https://github.com/izzywdev/FuzeFront)" >&2
+  exit 1
+fi
+
+# ---- GitHub App secret ------------------------------------------------------
+if [[ -n "$GITHUB_SECRET_NAME" ]]; then
+  # Caller supplied an existing secret name — verify it exists
+  if ! kubectl -n "$RUNNER_NS" get secret "$GITHUB_SECRET_NAME" &>/dev/null; then
+    echo "ERROR: secret '$GITHUB_SECRET_NAME' not found in namespace $RUNNER_NS" >&2
+    exit 1
+  fi
+  K8S_SECRET_NAME="$GITHUB_SECRET_NAME"
+  echo "==> Using existing secret: $K8S_SECRET_NAME"
+else
+  # Create a new secret from GitHub App credentials
+  if [[ -z "$APP_ID" || -z "$APP_INSTALL_ID" || -z "$APP_PRIVATE_KEY_FILE" ]]; then
+    echo "ERROR: supply --secret <existing> OR all three of --app-id / --app-install-id / --app-private-key" >&2
+    exit 1
+  fi
+  if [[ ! -f "$APP_PRIVATE_KEY_FILE" ]]; then
+    echo "ERROR: private key file not found: $APP_PRIVATE_KEY_FILE" >&2
+    exit 1
+  fi
+
+  K8S_SECRET_NAME="arc-runner-${SCALE_SET_NAME}-github-app"
+  echo "==> Creating GitHub App secret '$K8S_SECRET_NAME' …"
+  kubectl -n "$RUNNER_NS" create secret generic "$K8S_SECRET_NAME" \
+    --from-literal=github_app_id="$APP_ID" \
+    --from-literal=github_app_installation_id="$APP_INSTALL_ID" \
+    --from-file=github_app_private_key="$APP_PRIVATE_KEY_FILE" \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+# ---- Build per-repo values (in-memory, no temp file) ------------------------
+VALUES=$(cat <<YAML
+githubConfigUrl: "${REPO_URL}"
+githubConfigSecret: ${K8S_SECRET_NAME}
+runnerScaleSetName: ${SCALE_SET_NAME}
+
+minRunners: ${MIN_RUNNERS}
+maxRunners: ${MAX_RUNNERS}
+
+template:
+  spec:
+    serviceAccountName: arc-runner-sa
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: "2"
+            memory: 1Gi
+        env:
+          - name: DISABLE_RUNNER_UPDATE
+            value: "1"
+    nodeSelector:
+      fuzeinfra.io/pool: ci
+    tolerations:
+      - key: fuzeinfra.io/ci
+        operator: Exists
+        effect: NoSchedule
+
+controllerServiceAccount:
+  namespace: ${CONTROLLER_NS}
+  name: ${CONTROLLER_SA}
+YAML
+)
+
+# ---- Ensure runner SA exists in the namespace (idempotent) ------------------
+echo "==> Ensuring runner ServiceAccount in $RUNNER_NS …"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: arc-runner-sa
+  namespace: ${RUNNER_NS}
+EOF
+
+# ---- Helm install/upgrade ---------------------------------------------------
+echo "==> Registering scale set '$SCALE_SET_NAME' for $REPO_URL …"
+echo "$VALUES" | helm upgrade --install "$SCALE_SET_NAME" \
+  "$ARC_RUNNER_CHART" \
+  --version "$ARC_VERSION" \
+  --namespace "$RUNNER_NS" \
+  --create-namespace \
+  --values - \
+  --wait --timeout 3m
+
+echo ""
+echo "✓ Scale set '${SCALE_SET_NAME}' registered for ${REPO_URL}"
+echo ""
+echo "Add to your repo's workflows:"
+echo "  jobs:"
+echo "    build:"
+echo "      runs-on: ${SCALE_SET_NAME}"
+echo ""
+echo "Verify in GitHub:"
+echo "  ${REPO_URL}/settings/actions/runners"

--- a/runners/arc/workflow-template/arc-register.yml
+++ b/runners/arc/workflow-template/arc-register.yml
@@ -1,0 +1,106 @@
+# =============================================================================
+# arc-register.yml — TEMPLATE: copy to .github/workflows/ in your repo
+#
+# Registers this repository as an ARC self-hosted runner on the shared
+# FuzeInfra cluster.  Run once to set up; re-run to upgrade the scale set.
+#
+# Required secrets in your repo:
+#   KUBE_CONFIG           — base64-encoded kubeconfig for the FuzeInfra cluster
+#                           (copy from FuzeInfra repo or ask infra team)
+#   GH_APP_ID             — GitHub App ID (from izzywdev/FuzeInfra runner app)
+#   GH_APP_INSTALLATION_ID — Installation ID for THIS repo
+#   GH_APP_PRIVATE_KEY    — PEM-encoded private key (set as multiline secret)
+#
+# OR: if you share the FuzeInfra GitHub App and the existing
+# arc-runner-github-app k8s secret already covers your repo, set:
+#   USE_EXISTING_SECRET: "arc-runner-github-app"
+# and leave the GH_APP_* secrets empty.
+#
+# After this workflow succeeds, use in your jobs:
+#   runs-on: <your-scale-set-name>   # matches SCALE_SET_NAME below
+# =============================================================================
+name: arc-register
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "install or uninstall"
+        required: true
+        default: install
+        type: choice
+        options: [install, uninstall]
+
+# ---- CONFIGURE THESE --------------------------------------------------------
+env:
+  SCALE_SET_NAME: ""        # FILL IN: e.g. "fuzefront" — used in runs-on:
+  ARC_VERSION: "0.14.2"
+  RUNNER_NS: "arc-runners"  # must match FuzeInfra controller watchSingleNamespace
+  # Set to the name of an existing k8s secret if sharing the FuzeInfra GitHub App:
+  USE_EXISTING_SECRET: ""   # e.g. "arc-runner-github-app", or leave empty
+# -----------------------------------------------------------------------------
+
+permissions:
+  contents: read
+
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: izzywdev/FuzeInfra
+          ref: main
+          sparse-checkout: |
+            runners/arc/register-repo.sh
+
+      - name: Setup kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "3.14.0"
+
+      - name: Write GitHub App private key
+        if: ${{ env.USE_EXISTING_SECRET == '' && inputs.action == 'install' }}
+        run: |
+          echo "${{ secrets.GH_APP_PRIVATE_KEY }}" > /tmp/arc-app-key.pem
+
+      - name: Install / upgrade scale set
+        if: ${{ inputs.action == 'install' }}
+        run: |
+          chmod +x runners/arc/register-repo.sh
+          REPO_URL="https://github.com/${{ github.repository }}"
+
+          if [ -n "$USE_EXISTING_SECRET" ]; then
+            ./runners/arc/register-repo.sh \
+              --repo-url "$REPO_URL" \
+              --name     "$SCALE_SET_NAME" \
+              --secret   "$USE_EXISTING_SECRET"
+          else
+            ./runners/arc/register-repo.sh \
+              --repo-url        "$REPO_URL" \
+              --name            "$SCALE_SET_NAME" \
+              --app-id          "${{ secrets.GH_APP_ID }}" \
+              --app-install-id  "${{ secrets.GH_APP_INSTALLATION_ID }}" \
+              --app-private-key /tmp/arc-app-key.pem
+          fi
+
+      - name: Uninstall scale set
+        if: ${{ inputs.action == 'uninstall' }}
+        run: |
+          chmod +x runners/arc/register-repo.sh
+          ./runners/arc/register-repo.sh --name "$SCALE_SET_NAME" --uninstall
+
+      - name: Verify registration
+        if: ${{ inputs.action == 'install' }}
+        run: |
+          echo "=== AutoscalingRunnerSets in $RUNNER_NS ==="
+          kubectl -n "$RUNNER_NS" get autoscalingrunnersets
+          echo ""
+          echo "=== Listener pod (may take 30s to appear) ==="
+          kubectl -n arc-systems get pods | grep "$SCALE_SET_NAME" || echo "(listener not up yet — wait ~30s)"


### PR DESCRIPTION
## Summary
- **`runners/arc/register-repo.sh`** — idempotent shell script any repo can run to install its own ARC scale set on the shared FuzeInfra cluster controller. Usage: `--repo-url`, `--name` (becomes the `runs-on:` value), plus either `--secret` (reuse existing k8s secret) or `--app-id / --app-install-id / --app-private-key` (creates a new per-repo secret)
- **`runners/arc/workflow-template/arc-register.yml`** — GitHub Actions workflow template repos copy to their `.github/workflows/`. Checks out the script from FuzeInfra main, connects via `KUBE_CONFIG` secret, installs or uninstalls. Supports sharing the existing `arc-runner-github-app` k8s secret via `USE_EXISTING_SECRET`

## How a new repo onboards
1. Copy `workflow-template/arc-register.yml` → `.github/workflows/arc-register.yml`
2. Fill in `SCALE_SET_NAME` (e.g. `fuzefront`)
3. Add secrets: `KUBE_CONFIG` + either `USE_EXISTING_SECRET: "arc-runner-github-app"` (if app covers your repo) or `GH_APP_ID / GH_APP_INSTALLATION_ID / GH_APP_PRIVATE_KEY`
4. Run the workflow → `runs-on: fuzefront` works in that repo's CI

## Note on controller scope
The ARC controller's `watchSingleNamespace: arc-runners` means all scale sets must land in `arc-runners`. The `--name` flag differentiates repos within that namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)