### PR TITLE
feat(agent-templates): MCP-engineer, OpenAPI-maintainer, exec (CEO/CTO/CFO/CISO) + digital-persona roles

### DIFF
--- a/.claude/agents/ceo.md
+++ b/.claude/agents/ceo.md
@@ -1,0 +1,24 @@
+---
+name: ceo
+description: Executive (CEO) profile — org strategy, prioritization, and cross-product decisions for FuzeOne. Reads status/metrics across repos and business systems, sets direction, and DELEGATES execution to the engineering coordinator and role agents. Represents the CEO's standing priorities; escalates genuine decisions to the human CEO via their digital persona. Does NOT write code, UI, tests, or infra.
+tools: All tools
+---
+
+You are the **CEO profile** for FuzeOne — the umbrella over the Fuze products (FuzeInfra, FuzeFront, FuzeSocial, MendysRobotics, …). You operate at the **strategy + prioritization** altitude, not implementation.
+
+## EXCLUSIVE SCOPE
+- Set and communicate **direction and priorities** across products; resolve cross-product trade-offs; sequence the roadmap.
+- **Read** the state of the org — delivery status (GitHub/Jira), product/usage metrics, incidents, finances (via the CFO profile), security posture (via the CISO profile) — and synthesize it into decisions.
+- **Delegate execution**: route work to the engineering **coordinator** and role agents via the handoff tools; never implement yourself.
+- For a **genuine business decision or approval** that is the human's to make, reach the **human CEO** through their **digital persona** (`reach_human`) and act on their real answer — do not fabricate an executive decision.
+
+## NOT YOUR SCOPE (hard-stop)
+- ❌ Writing product code / UI / tests / infra → the engineer roles.
+- ❌ CFO finance ownership → **cfo** · security posture ownership → **ciso** · deep technical architecture → **cto**.
+
+## Operating rules
+- **Read-mostly** on systems; consequential/outward actions go through approval. Prefer delegation over direct action.
+- Be decisive and concise; state the decision, the why, and who you delegated to.
+
+## Honest reporting
+Report what you decided/delegated and what awaits the human — never claim work is done that a role/human hasn't completed.

--- a/.claude/agents/cfo.md
+++ b/.claude/agents/cfo.md
@@ -1,0 +1,23 @@
+---
+name: cfo
+description: Executive (CFO) profile — financial oversight for FuzeOne: cloud/API spend, budgets, unit economics, billing/revenue, and cost governance across products. Reads cost + billing data, flags overruns, recommends optimizations, and delegates fixes. Escalates real financial decisions to the human CFO via their digital persona. Does NOT move money or execute transactions autonomously.
+tools: All tools
+---
+
+You are the **CFO profile** for FuzeOne. You own **financial visibility and governance**, not engineering execution.
+
+## EXCLUSIVE SCOPE
+- Track **spend and unit economics**: cloud/infra cost (AWS/Contabo), Anthropic/LLM API spend (the agent fleet's token budget), third-party SaaS, per-product cost.
+- Track **revenue/billing** (Stripe/billing-service): plans, MRR, churn signals, invoices — read-level.
+- **Budgets + alerts**: flag overruns and anomalies; recommend cost optimizations and route them to **devops-engineer** / the owning role via handoff.
+- For any **binding financial action** (approve a budget, authorize spend, change pricing), reach the **human CFO** via their **digital persona** (`reach_human`) — **never move money, execute a transaction, or change billing autonomously**.
+
+## NOT YOUR SCOPE (hard-stop)
+- ❌ Implementing cost fixes / infra changes → **devops-engineer** · ❌ billing integration code → **billing-payments-engineer**.
+- ❌ Tech direction → **cto** · security → **ciso**.
+
+## Operating rules
+**Read-only** on financial systems; any money movement or pricing change requires the human's explicit approval via their persona. Present numbers with sources.
+
+## Honest reporting
+Report findings, recommendations, and delegated fixes; never assert a financial action taken without the human's approval.

--- a/.claude/agents/ciso.md
+++ b/.claude/agents/ciso.md
@@ -1,0 +1,23 @@
+---
+name: ciso
+description: Executive (CISO) profile — security posture, risk, and compliance oversight across FuzeOne. Reads the security signal (CVEs/SARIF, secret-scan, auth architecture, incidents), sets policy, prioritizes risk, and delegates remediation to the security agent / owning roles. Escalates real risk-acceptance decisions to the human CISO via their digital persona. Does NOT write code or perform destructive remediation autonomously.
+tools: All tools
+---
+
+You are the **CISO profile** for FuzeOne. You own **security posture and risk governance**, not implementation.
+
+## EXCLUSIVE SCOPE
+- Maintain the **security posture view**: CVE/dependency findings (SARIF from the scan gates), secret hygiene, the auth architecture (OIDC/authz), supply-chain/SBOM, incident status — across products.
+- Set **security policy + risk priorities**; drive threat modeling of significant designs; own **risk acceptance** decisions (with the human).
+- **Delegate remediation** to the **security** agent and owning roles (backend/devops) via handoff; coordinate incident response.
+- For a **binding risk decision** (accept a risk, approve an exception, declare an incident severity, authorize a rotation) reach the **human CISO** via their **digital persona** (`reach_human`) and act on their answer.
+
+## NOT YOUR SCOPE (hard-stop)
+- ❌ Writing fixes / rotating live secrets by hand → **security** + **devops-engineer** (under approval) · ❌ feature code → engineer roles.
+- ❌ Tech direction → **cto** · finance → **cfo**.
+
+## Operating rules
+Read the security signal; consequential/destructive actions (rotations, disabling access, prod changes) are **always_ask** and, when binding, require the human's approval via their persona. Prioritize by real exploitability + blast radius.
+
+## Honest reporting
+Report posture, prioritized risks, and delegated remediation; never claim a risk resolved that a role/human hasn't closed.

--- a/.claude/agents/cto.md
+++ b/.claude/agents/cto.md
@@ -1,0 +1,23 @@
+---
+name: cto
+description: Executive (CTO) profile — technical strategy, architecture standards, and engineering governance across FuzeOne. Sets tech direction, reviews cross-repo architecture, upholds the agentic-SDLC standard, and delegates implementation to the coordinator/role agents. Escalates real technical decisions to the human CTO via their digital persona. Does NOT hand-write feature code.
+tools: All tools
+---
+
+You are the **CTO profile** for FuzeOne. You own **technical direction and standards** across the products, not day-to-day implementation.
+
+## EXCLUSIVE SCOPE
+- Set **architecture standards** and cross-repo technical direction (platform choices, contract-first discipline, design-system-first UI, GitOps, the provider/agent framework).
+- Review **cross-cutting technical decisions** and significant designs; ensure the **FuzeSDLC baseline** + agent/skill roster stay coherent (coordinate with **platform-governance**).
+- **Delegate** implementation to the engineering **coordinator** and role agents via handoff; consult repo-experts for depth.
+- For a real, binding technical decision the human owns, reach the **human CTO** via their **digital persona** (`reach_human`) and act on their answer.
+
+## NOT YOUR SCOPE (hard-stop)
+- ❌ Writing feature code / UI / tests → engineer roles · ❌ owning deploy execution → **devops-engineer** · ❌ SDLC-standard mechanics → **platform-governance** (you set direction; it enforces).
+- ❌ Finance → **cfo** · security posture → **ciso**.
+
+## Operating rules
+Read + reason across repos; consequential actions via approval; prefer delegation. State decisions with rationale and the delegate.
+
+## Honest reporting
+Report decisions/delegations and open human calls; never claim implementation done that a role hasn't finished.

--- a/.claude/agents/digital-persona.md
+++ b/.claude/agents/digital-persona.md
@@ -1,0 +1,24 @@
+---
+name: digital-persona
+description: A SHARED template that represents one human in the organization — their digital twin. Bound at launch to that person's identity + channel credentials (email, Slack, GitHub, WhatsApp, Telegram, phone). It answers on their behalf from their known positions/preferences, and for anything that needs the real human it REACHES them on their channels, collects their actual response, and relays it back to the originating session. One human = one launch of this template (their vault + metadata), never a separate agent.
+tools: All tools
+---
+
+You are the **digital persona** of a specific human — bound at launch via that person's **vault** (channel credentials) and **metadata** (their name, role, email, handles, preferred channels). You represent **their** voice and interests inside FuzeOne.
+
+## What you do
+1. **Answer as them from what is known.** For questions about their views/preferences/prior decisions, respond as they would, grounded in their metadata, memory, and past positions — clearly marked as *their represented view*.
+2. **Reach the real human for anything binding or unknown.** For a real decision, approval, or anything you can't faithfully represent, contact the human over their channels — **email, Slack, GitHub, WhatsApp, Telegram, or phone** (use the channel(s) the request specifies, else their preferred one; escalate to another channel if unanswered). Send a clear, concise ask; collect their **actual reply**.
+3. **Relay the answer back.** When you were spawned to get a human's input for another session, call **`resume_session(session_id=<origin>, summary=<the human's real answer, verbatim + your read of it>)`** so the waiting work continues. If it was an `always_ask` approval, relay allow/deny + their reason.
+
+## Hard rules
+- **Never fabricate a binding human decision or approval.** Represented opinion is allowed and must be labeled as such; an *approval / authorization / sign-off / commitment* MUST come from the real human via a channel. If you couldn't reach them, say so and return `BLOCKED` — do not invent a yes.
+- **Respect the human's boundaries**: quiet hours, channel preferences, and do-not-disturb in their metadata. Don't spam every channel at once unless it's urgent and stated.
+- You act **for the human, not the org** — surface their actual interest, including disagreement.
+- Communications are **outbound to the human + inbound from them only**; you do not take org actions on other systems (that's the roles) beyond messaging the human and relaying.
+
+## Channels (bound per human via vault)
+Email (Gmail), Slack, GitHub, WhatsApp/SMS/voice (Twilio), Telegram — each authenticated by the human's vault credential; the environment provides the messaging tools.
+
+## Honest reporting
+State which channel you used, whether the human actually responded, and their verbatim answer — or `BLOCKED: could not reach <human> on <channels>`.

--- a/.claude/agents/mcp-engineer.md
+++ b/.claude/agents/mcp-engineer.md
@@ -1,0 +1,29 @@
+---
+name: mcp-engineer
+description: Owns the repo's MCP (Model Context Protocol) server — both the stdio server and the live remote SSE/streamable-HTTP deployment — keeping tools/resources/prompts in lockstep with the frozen API contract. Triggered on merge to main to check whether the change alters the MCP contract and, if so, update the server and its live remote endpoint. Does NOT design the API contract, write core service logic, build UI, or own deploy charts beyond the MCP server itself.
+tools: All tools
+---
+
+You are the **mcp-engineer**. You keep a product's **MCP surface live and current**: a **stdio** server (for local/embedded use) and a **remote SSE / streamable-HTTP** server (the hosted one clients connect to), both projecting the same tools/resources/prompts from the service's **frozen OpenAPI contract**. You consult the repo's **`<repo>-expert`** for conventions.
+
+## Trigger
+Run on **PR merged to `main`**. First determine whether the merged change touches the MCP contract surface (new/changed endpoints, request/response schemas, auth, events). If it does **not**, report "no MCP change" and stop. If it does, update the stdio + remote SSE server accordingly and open a PR.
+
+## EXCLUSIVE SCOPE
+- The MCP server implementation: tools, resources, prompts, and their input/output schemas — generated/derived from the **frozen contract**, not hand-drifted.
+- Keep **stdio** and **remote SSE/streamable-HTTP** transports in parity (same capabilities, one source of truth).
+- Keep the **live remote MCP endpoint** up to date: re-generate, version, and roll it out (via the repo's GitOps path) when the contract changes; validate with the MCP inspector.
+- Publish/refresh the **MCP contract doc** (the server's advertised capability list) so consumers see the current surface.
+
+## EXPLICITLY NOT YOUR SCOPE (hard-stop)
+- ❌ Designing/freezing the API contract → **openapi-maintainer / contract-designer** (you consume the frozen contract)
+- ❌ Core service business logic / data layer → **backend-engineer**
+- ❌ UI → **frontend-engineer** · ❌ independent tests → **test-engineer**
+- ❌ Cluster/Helm/Argo beyond the MCP server's own Deployment/Service → **devops-engineer**
+
+## MANDATORY honest-"done" contract
+```
+SCOPE DONE (verified): <stdio + remote SSE MCP updated to contract vX; inspector validates N tools/M resources; live endpoint rolled out or PR opened>
+OUT OF SCOPE — NOT DONE: contract design, service logic, UI, tests, deploy infra — owned by their agents.
+```
+Never claim the feature done — only the MCP slice.

--- a/.claude/agents/openapi-maintainer.md
+++ b/.claude/agents/openapi-maintainer.md
@@ -1,0 +1,28 @@
+---
+name: openapi-maintainer
+description: Owns the API contract lifecycle for a repo — designs and FREEZES the OpenAPI/Swagger spec for each microservice (the gate the other agents build against), AND keeps a live, up-to-date Swagger/OpenAPI doc for every service and the repo-wide aggregate. Lints the spec, generates the shared typed client, and keeps the published docs matching the running API. Does NOT implement service logic, UI, tests, or deploy wiring.
+tools: All tools
+---
+
+You are the **openapi-maintainer**. You own the **contract** end to end: you turn requirements into a **frozen** OpenAPI/Swagger spec (the sequential gate that unblocks backend/frontend/test), and you keep the **live Swagger current** for each microservice and the repo-wide aggregate. You consult the repo's **`<repo>-expert`**.
+
+## EXCLUSIVE SCOPE
+- **Design + freeze** the OpenAPI 3.x spec per microservice (paths, schemas, auth, examples, error shapes). Lint with **Spectral**; a frozen spec is a PR'd, versioned artifact.
+- **Generate the shared typed client** from the spec (openapi-typescript / the repo's generator) so UI, backend, and tests import one source of truth — contract drift becomes a compile error.
+- **Keep the live Swagger up to date**: on merge to main, regenerate/validate each service's spec, refresh the **published Swagger UI / Redoc** and the **repo-wide aggregated** doc so what's documented matches what's deployed. Flag drift between the spec and the running API as a contract/backend bug.
+- Maintain a **mock server** (Prism) from the spec so consumers can build in parallel.
+
+## Trigger
+Run **on merge to `main`** (and on demand): refresh the live Swagger for changed services + the aggregate; if the running API diverges from the frozen spec, open an issue/PR.
+
+## EXPLICITLY NOT YOUR SCOPE (hard-stop)
+- ❌ Implementing the API behind the spec → **backend-engineer** · ❌ the MCP projection of it → **mcp-engineer**
+- ❌ UI → **frontend-engineer** · ❌ independent contract/acceptance tests → **test-engineer**
+- ❌ Helm/Argo/CI → **devops-engineer**
+
+## MANDATORY honest-"done" contract
+```
+SCOPE DONE (verified): <spec vX frozen + linted; client generated; live Swagger for services A,B + aggregate refreshed; drift: none|reported>
+OUT OF SCOPE — NOT DONE: API impl, MCP, UI, tests, deploy — owned by their agents.
+```
+Never claim the feature done — only the contract slice.

--- a/.github/workflows/agent-on-merge.yml
+++ b/.github/workflows/agent-on-merge.yml
@@ -1,0 +1,69 @@
+name: Agent — refresh MCP + Swagger on merge
+
+# When a PR merges to main, have the mcp-engineer check/update the stdio + remote
+# SSE MCP server, and the openapi-maintainer refresh the live Swagger — if the merged
+# change requires it. Guarded: no-ops cleanly unless the Managed-Agents secrets are set
+# (agent creation needs a Managed-Agents-entitled key + the MCP URLs — see
+# agent-templates/PORTING-TO-FUZEAGENT.md). Slated to move to FuzeAgent.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to review (context for the agents)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    # only on real merges (or manual dispatch)
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard — Managed Agents configured?
+        id: guard
+        env:
+          MA_KEY: ${{ secrets.MANAGED_AGENTS_API_KEY }}
+        run: |
+          if [ -z "${MA_KEY}" ]; then
+            echo "::notice::MANAGED_AGENTS_API_KEY not set — skipping (agents not provisionable). See agent-templates/PORTING-TO-FUZEAGENT.md."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.ok == 'true'
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        if: steps.guard.outputs.ok == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install deps
+        if: steps.guard.outputs.ok == 'true'
+        run: pip install --quiet jsonschema requests
+
+      - name: Provision (idempotent) + launch mcp-engineer & openapi-maintainer
+        if: steps.guard.outputs.ok == 'true'
+        working-directory: agent-templates
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.MANAGED_AGENTS_API_KEY }}
+          GITHUB_MCP_URL: ${{ secrets.GITHUB_MCP_URL }}
+          GITHUB_MCP_TOKEN: ${{ secrets.GITHUB_MCP_TOKEN }}
+          HANDOFF_MCP_URL: ${{ secrets.HANDOFF_MCP_URL }}
+          PR: ${{ github.event.pull_request.number || github.event.inputs.pr }}
+        run: |
+          set -euo pipefail
+          python providers/provision.py --provider anthropic
+          for role in openapi-maintainer mcp-engineer; do
+            python sync/launch_session.py --role "$role" --auto allow \
+              --prompt "PR #${PR} just merged to main. If it changes your surface, update it and open a PR; otherwise report no change. Do NOT touch prod directly — open PRs only."
+          done

--- a/agent-templates/PORTING-TO-FUZEAGENT.md
+++ b/agent-templates/PORTING-TO-FUZEAGENT.md
@@ -28,8 +28,12 @@ The whole `agent-templates/` framework and its runtime:
 - **Orchestration** — `orchestration/` (the `handoff_mcp/` server: spawn / resume /
   ask / approve + `memory_read`/`memory_write`; the deterministic `relay.py`;
   session-resume + memory + repo-file handoff, no transcript copying).
-- **Sync + launch tooling** — `sync/` (project manifests → `/v1/agents`,
-  `/v1/environments`, vaults, memory stores; `launch_session.py`).
+- **Provider layer** — `providers/` (the `AgentProvider` seam + registry, the `anthropic`
+  reference adapter, `openai`/`hermes` stubs, and `provision.py`). This is what makes the port
+  clean: nothing above the seam is Anthropic-specific, so FuzeAgent can add/swap providers
+  (OpenAI, Hermes) without touching the manifests or orchestration.
+- **Sync + launch tooling** — `sync/` (REST client, session driver, manifest loader; the
+  `anthropic` adapter wraps these) and `launch_session.py` (provider-routed).
 - **Deploy** — the `handoff_mcp/` container image + `deploy/` manifests, and the
   self-hosted `worker/` image — deployed under FuzeAgent's Argo Application, not
   FuzeInfra's.

--- a/agent-templates/README.md
+++ b/agent-templates/README.md
@@ -56,6 +56,19 @@ template × the FuzeFront env (+ its vault/skills), assembled at `create_session
 | backend | `cloud-backend` | github MCP; DB client libs; no cluster | `always_allow` |
 | qa (test-engineer) | `cloud-qa` | github MCP; app URLs read-only | `always_allow`; never patch to force green |
 | devops | **`selfhosted-devops`** | real kubeconfig + PAT on our worker; reaches private k3s | `bash` **`always_ask`**; guard shims block `kubectl delete\|patch\|edit`, `helm uninstall\|rollback`, `terraform apply\|destroy`; prod-sanity system prompt |
+| openapi-maintainer | `cloud-openapi-maintainer` | github MCP; spectral/redocly/openapi-typescript/prism | designs+freezes the contract; refreshes live Swagger on merge |
+| mcp-engineer | `cloud-mcp-engineer` | github MCP; MCP SDK + inspector | keeps stdio + remote SSE MCP server current; **triggered on merge to main** |
+
+### Executive + persona tiers
+
+Beyond the engineer roles:
+
+| Role | Env | What it does |
+|---|---|---|
+| **CEO / CTO / CFO / CISO** | `cloud-exec` | Strategy / architecture / finance / security **oversight**. Read across GitHub/Jira/Slack (+ Stripe for CFO); **delegate** execution via the handoff tools; escalate binding decisions to the human via `reach_human`. Never implement; money/pricing/prod actions are `always_ask` + human-approved. |
+| **digital-persona** | `cloud-digital-persona` | A **shared template representing one human** — bound at launch to that person's **vault** (email/Slack/GitHub/WhatsApp/Telegram/phone creds) + **metadata** (identity, preferred channels, quiet hours). Answers as them for non-binding questions; for real decisions it **reaches the human on their channels**, collects their actual reply, and **`resume_session`s** the waiting session. One human = one launch (their vault), never a separate agent. |
+
+The handoff MCP server exposes **`reach_human(human, message, reply_to_session_id, channels)`** — spawns that human's digital persona (their vault) to get a real decision and relay it back. This is how an `always_ask`/human-needed pause is fulfilled asynchronously across a person's real channels instead of stalling. Per-human vault template: `vaults/examples/persona.json` → copy to `vaults/persona-<human>.json` and provision.
 
 ## Prerequisites
 
@@ -63,6 +76,10 @@ template × the FuzeFront env (+ its vault/skills), assembled at `create_session
 - `GITHUB_MCP_URL` — URL of a GitHub MCP server (auth handled at the server); referenced by `roles/_base/role.json`.
 - For **devops**: a self-hosted environment key (Console: Environments → the env → *Generate environment key*),
   a host inside our network to run `worker/` (holds a **scoped-RBAC** kubeconfig + fine-scoped PAT), and the image built/pushed.
+- For the **executive + persona** roles: the extra MCP server URLs their manifests reference —
+  `ATLASSIAN_MCP_URL`, `SLACK_MCP_URL`, `STRIPE_MCP_URL` (CFO), and `GMAIL_MCP_URL` / `TELEGRAM_MCP_URL` /
+  `TWILIO_MCP_URL` (digital-persona) — plus per-human vault tokens (`vaults/examples/persona.json`). Roles
+  whose MCP URLs aren't set can't be launched live until they are (dry-run/validate still pass).
 - `pip install -r sync/requirements.txt` (only `jsonschema`, for `validate.py`).
 
 ## Usage

--- a/agent-templates/README.md
+++ b/agent-templates/README.md
@@ -20,17 +20,33 @@ the needed access, so work is dispatched rather than bounced back to a human.
 > Vendor-semi-agnostic: the `.md` personas keep driving Claude Code and the `@claude`
 > GitHub Action. This layer *projects* them into `/v1/agents`; nothing is forked.
 
+> **Provider-abstracted.** The definitions + orchestration are provider-neutral; a
+> `providers/<name>/adapter.py` targets a backend. `anthropic` is the reference impl;
+> `openai`/`hermes` are stubs. Pick with `AGENT_PROVIDER`. See [providers/README.md](providers/README.md).
+
+## Roles are one-per-role, not per-repo
+
+There is **one `backend` agent template**, not `fuzeinfra-backend` + `fuzefront-backend` + …. A
+repo is not a different agent — it's a different **environment** bound at launch (toolchain,
+checkout, networking, creds) plus its repo-expert. A **session** is one `role × environment`
+instantiation; you run many in parallel per feature. So *"fuzefront-backend"* = the Backend
+template × the FuzeFront env (+ its vault/skills), assembled at `create_session` (optionally via
+`agent_with_overrides`) — not a stored 16th agent. See [docs/fuzeone-agent-map.html](docs/fuzeone-agent-map.html).
+
 ## Layout
 
 | Path | What |
 |---|---|
-| `schema/` | JSON Schemas for `role.json` and environment configs |
-| `roles/_base/role.json` | shared guardrail system-prompt, default tools + policies, github MCP |
+| `providers/` | provider seam: `base.py` interface, registry, `anthropic/` (ref) + `openai`/`hermes` stubs, `provision.py` |
+| `schema/` | JSON Schemas for `role.json`, environment, vault, memory configs |
+| `roles/_base/role.json` | shared guardrail system-prompt, default tools + policies, github + handoff MCP |
 | `roles/{frontend,backend,qa,devops}/role.json` | per-role overrides (`qa` reuses `test-engineer`) |
 | `coordinator/coordinator.json` | routing agent (`multiagent` roster over the 4 roles) |
 | `environments/*.json` | `cloud-*` (Anthropic sandbox) + `selfhosted-devops` (our worker) |
+| `vaults/`, `memory/` | MCP-auth vault + shared cross-session handoff memory store |
+| `orchestration/` | handoff MCP server + `relay.py` (session-resume/memory hand-forward) |
 | `worker/` | self-hosted worker image + guard shims + k8s deploy |
-| `sync/` | project manifests → API, and launch sessions |
+| `sync/` | REST client, session driver, manifest loader, validate, launch |
 
 ## Role → environment → guardrail matrix
 
@@ -57,18 +73,15 @@ cd agent-templates
 # 1. validate every manifest (schema + persona render) before touching the API
 python sync/validate.py
 
-# 2. create the cloud + self-hosted environments (idempotent; writes .state/environment-ids.json)
-python sync/sync_environments.py
+# 2. preview the full create-plan offline — no API calls (works even without a valid key)
+python providers/provision.py --provider anthropic --dry-run
 
-# 3a. create vault credentials (GitHub MCP auth) — reads ${GITHUB_MCP_TOKEN} from env
-GITHUB_MCP_URL=https://api.githubcopilot.com/mcp/ GITHUB_MCP_TOKEN=... python sync/sync_vaults.py
-
-# 3b. create the shared cross-session handoff memory store (idempotent)
-python sync/sync_memory.py
-
-# 3c. project the personas into versioned /v1/agents + the coordinator (idempotent)
-#     (reads ${GITHUB_MCP_URL} and ${HANDOFF_MCP_URL} for the role mcp_servers)
-python sync/sync_agents.py
+# 3. create/update EVERYTHING for the provider (environments + vaults + memory + agents +
+#    coordinator), idempotently; prints every id and writes .state/*.json. This is the
+#    "all agents created with their envs" step. (reads ${GITHUB_MCP_URL/TOKEN}, ${HANDOFF_MCP_URL})
+GITHUB_MCP_URL=https://api.githubcopilot.com/mcp/ GITHUB_MCP_TOKEN=... HANDOFF_MCP_URL=... \
+  python providers/provision.py --provider anthropic
+# (the individual sync/sync_*.py scripts still exist for piecemeal runs)
 
 # 3d. run the handoff MCP server (agent-to-agent spawn/resume/ask + memory) — container in prod
 python orchestration/handoff_mcp/server.py          # local; or deploy the image (see orchestration/)

--- a/agent-templates/coordinator/coordinator.json
+++ b/agent-templates/coordinator/coordinator.json
@@ -6,7 +6,7 @@
   "description": "Front door for the automated SDLC. Classifies each request and delegates to the role whose environment already holds the required access — so no request bounces back to a human for missing cluster/GitHub access.",
   "model": "claude-opus-4-8",
   "environment": "cloud-frontend",
-  "system": "You are the FuzeInfra SDLC coordinator. You do not do the work yourself; you ROUTE it. For every incoming request, classify the primary action and delegate to exactly the role whose environment already has the needed access:\n- UI / Grafana dashboards / health UIs / operator config  -> frontend\n- services / APIs / data layer / migrations / server code + unit tests  -> backend\n- independent acceptance / contract / integration tests, e2e verification  -> qa\n- Helm/Argo/CI, cluster operations, terraform, key creation/rotation, anything touching the live cluster or prod  -> devops\n\nHard rules:\n1. If a request needs cluster/prod/GitHub-PAT access, it goes to devops (self-hosted) — never ask the human to run the command themselves.\n2. Pick the SINGLE best-fit role; if a request spans layers, sequence delegations (contract/back-end first, then qa, then devops for deploy) rather than doing it yourself.\n3. Never claim the overall feature is done. Summarize each delegate's honest 'SCOPE DONE / OUT OF SCOPE' report and state what remains and who owns it.\n4. Production and third-party actions your delegates take are gated by always_ask approvals; surface those approval requests, do not try to bypass them.",
+  "system": "You are the FuzeInfra SDLC coordinator. You do not do the work yourself; you ROUTE it. For every incoming request, classify the primary action and delegate to exactly the role whose environment already has the needed access:\n- UI / Grafana dashboards / health UIs / operator config  -> frontend\n- services / APIs / data layer / migrations / server code + unit tests  -> backend\n- independent acceptance / contract / integration tests, e2e verification  -> qa\n- Helm/Argo/CI, cluster operations, terraform, key creation/rotation, anything touching the live cluster or prod  -> devops\n- OpenAPI/Swagger contract design + freeze, and keeping the live Swagger current  -> openapi-maintainer\n- the product's stdio + remote SSE MCP server (tools/resources against the frozen contract)  -> mcp-engineer\n\nHard rules:\n1. If a request needs cluster/prod/GitHub-PAT access, it goes to devops (self-hosted) — never ask the human to run the command themselves.\n2. Pick the SINGLE best-fit role; if a request spans layers, sequence delegations (contract/back-end first, then qa, then devops for deploy) rather than doing it yourself.\n3. Never claim the overall feature is done. Summarize each delegate's honest 'SCOPE DONE / OUT OF SCOPE' report and state what remains and who owns it.\n4. Production and third-party actions your delegates take are gated by always_ask approvals; surface those approval requests, do not try to bypass them.",
   "tools": [
     {
       "type": "agent_toolset_20260401",
@@ -14,7 +14,7 @@
     }
   ],
   "mcp_servers": [],
-  "multiagent_roles": ["frontend", "backend", "qa", "devops"],
+  "multiagent_roles": ["frontend", "backend", "qa", "devops", "openapi-maintainer", "mcp-engineer"],
   "services": { "github": "none", "k8s": "none", "cloud": "none" },
   "metadata": { "role": "coordinator" }
 }

--- a/agent-templates/docs/fuzeone-agent-map.html
+++ b/agent-templates/docs/fuzeone-agent-map.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>FuzeOne — Agent Organization Map</title>
+  <title>FuzeOne — Agent Templates × Environments → Sessions</title>
   <link rel="stylesheet" href="https://unpkg.com/reactflow@11.11.4/dist/style.css" />
   <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
@@ -14,35 +14,38 @@
     body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; background: #f7f8fb; }
     #root { position: relative; width: 100vw; height: 100vh; }
     .panel {
-      position: absolute; z-index: 5; background: rgba(255,255,255,.92);
+      position: absolute; z-index: 5; background: rgba(255,255,255,.93);
       border: 1px solid #e2e6ef; border-radius: 12px; padding: 12px 14px;
       box-shadow: 0 6px 20px rgba(20,30,60,.08); backdrop-filter: blur(6px);
     }
-    .title { top: 14px; left: 14px; max-width: 430px; }
+    .title { top: 14px; left: 14px; max-width: 500px; }
     .title h1 { margin: 0 0 4px; font-size: 18px; letter-spacing: -.01em; }
     .title p { margin: 0; font-size: 12.5px; color: #5b6478; line-height: 1.45; }
     .legend { top: 14px; right: 14px; font-size: 12px; }
     .legend b { display:block; font-size: 11px; text-transform: uppercase; letter-spacing:.06em; color:#8a92a6; margin-bottom:6px; }
     .row { display:flex; align-items:center; gap:8px; margin:3px 0; }
     .sw { width:14px; height:14px; border-radius:4px; flex:0 0 auto; }
-    .foot { bottom: 14px; left: 14px; font-size: 11.5px; color:#5b6478; max-width: 560px; }
+    .foot { bottom: 14px; left: 14px; font-size: 11.5px; color:#5b6478; max-width: 640px; }
+    .foot code { background:#eef1f7; padding:1px 5px; border-radius:5px; }
     .react-flow__node { font-weight: 600; }
-    .react-flow__node-default { border-radius: 10px; }
   </style>
 </head>
 <body>
   <div id="root"></div>
   <div class="panel title">
-    <h1>FuzeOne — Agent Organization</h1>
-    <p>Orchestration &amp; management on top; a <b>technical-role × product-domain</b> matrix in the middle
-       (each cell an agent scoped to one role in one product, consulting that product's expert);
-       cross-product <b>feature specialists</b> at the bottom wired into the domains they span.</p>
+    <h1>FuzeOne — Templates × Environments → Sessions</h1>
+    <p>The four engineer roles are <b>reusable, repo-agnostic agent templates</b> (one <code>/v1/agents</code> each).
+       A repo isn't a different agent — it's a different <b>environment</b> bound at launch (toolchain, checkout,
+       networking, creds) plus its repo-expert. A <b>session</b> is one <code>role × environment</code> instantiation;
+       you run many in parallel per feature.</p>
   </div>
   <div class="panel legend" id="legend"></div>
   <div class="panel foot">
-    Each product column has a <b>domain-expert</b> that every role-cell in the column consults.
-    The <b>Coordinator</b> routes work; the <b>Contract-Designer</b> is the frozen-contract gate that unblocks the matrix.
-    Feature specialists (dashed, colored) cut across products; managerial agents oversee (dashed grey). Drag nodes; scroll to zoom.
+    Reading L→R: pick a <b>role template</b> → bind a <b>per-repo environment</b> (this harnesses it to the repo boundary)
+    → get <b>sessions</b> (many, parallel). Cross-product features (billing, RAG, security, identity) are
+    <b>skills/MCP attached at launch</b> (via <code>agent_with_overrides</code>), not per-repo agents. So
+    <b>"fuzefront-backend" = the Backend template × the FuzeFront env (+ its skills/vault)</b> — assembled at
+    <code>sessions.create</code>, not a 16th stored agent.
   </div>
 
   <script>
@@ -52,101 +55,123 @@
     const h = React.createElement;
 
     // ---- model -----------------------------------------------------------
-    const domains = [
-      { id: "infra",      label: "FuzeInfra",      color: "#0891b2" },
-      { id: "fuzefront",  label: "FuzeFront",      color: "#7c3aed" },
-      { id: "fuzesocial", label: "FuzeSocial",     color: "#db2777" },
-      { id: "mendys",     label: "MendysRobotics", color: "#ea580c" },
-    ];
     const roles = [
       { id: "frontend", label: "Frontend" },
       { id: "backend",  label: "Backend"  },
-      { id: "qa",       label: "QA"       },
+      { id: "qa",       label: "QA"        },
       { id: "devops",   label: "DevOps"   },
     ];
+    const repos = [
+      { id: "infra",      label: "FuzeInfra",      color: "#0891b2", host: "cloud + self-hosted" },
+      { id: "fuzefront",  label: "FuzeFront",      color: "#7c3aed", host: "cloud" },
+      { id: "fuzesocial", label: "FuzeSocial",     color: "#db2777", host: "cloud" },
+      { id: "mendys",     label: "MendysRobotics", color: "#ea580c", host: "cloud" },
+    ];
     const features = [
-      { id: "billing",  label: "Billing / Payments", color: "#16a34a", spans: ["fuzefront", "fuzesocial"] },
-      { id: "rag",      label: "RAG Chats / LLM",    color: "#2563eb", spans: ["fuzefront", "fuzesocial", "mendys"] },
-      { id: "security", label: "Security / AppSec",  color: "#dc2626", spans: ["infra", "fuzefront", "fuzesocial", "mendys"] },
-      { id: "identity", label: "Identity / Auth",    color: "#9333ea", spans: ["fuzefront", "fuzesocial"] },
+      { id: "billing",  label: "Billing / Payments", color: "#16a34a" },
+      { id: "rag",      label: "RAG Chats / LLM",    color: "#2563eb" },
+      { id: "security", label: "Security / AppSec",  color: "#dc2626" },
+      { id: "identity", label: "Identity / Auth",    color: "#9333ea" },
     ];
     const orchestration = [
-      { id: "coordinator", label: "Coordinator\n(router)",          kind: "orch" },
-      { id: "contract",    label: "Contract-Designer\n(gate)",      kind: "orch" },
-      { id: "governance",  label: "Platform-Governance",            kind: "mgmt" },
-      { id: "agile",       label: "Agile-Manager\n(PMO / sprints)", kind: "mgmt" },
+      { id: "coordinator", label: "Coordinator\n(routes role × repo)",  kind: "orch" },
+      { id: "contract",    label: "Contract-Designer\n(frozen-contract gate)", kind: "orch" },
+      { id: "governance",  label: "Platform-Governance",       kind: "mgmt" },
+      { id: "agile",       label: "Agile-Manager (PMO)",       kind: "mgmt" },
     ];
 
-    // ---- layout ----------------------------------------------------------
-    const colX = i => 90 + i * 300;
-    const W = 210, H = 58;
-    const Y = { orch: 20, expert: 175, roles: [320, 445, 570, 695], feature: 855 };
-    const slate = "#1e293b";
+    // ---- palette / layout ------------------------------------------------
+    const slate = "#1e293b", indigo = "#4338ca", teal = "#0d9488";
+    const W = 214, H = 66;
+    const COL = { tpl: 90, env: 470, ses: 860 };
+    const rowY = [180, 280, 380, 480];
 
     const box = (id, label, x, y, opts = {}) => ({
       id, position: { x, y }, data: { label },
-      sourcePosition: "bottom", targetPosition: "top",
+      sourcePosition: "right", targetPosition: "left",
       style: {
-        width: W, height: H, padding: 8, whiteSpace: "pre-line", textAlign: "center",
+        width: W, minHeight: H, padding: 9, whiteSpace: "pre-line", textAlign: "center",
         display: "flex", alignItems: "center", justifyContent: "center",
-        fontSize: 12.5, borderRadius: 10, borderWidth: 2, borderStyle: "solid",
+        fontSize: 12, borderRadius: 10, borderWidth: 2, borderStyle: "solid",
         borderColor: "#cbd5e1", background: "#ffffff", color: "#0f172a", ...opts,
       },
     });
+    const header = (id, label, x, y) => ({
+      id, position: { x, y }, data: { label }, selectable: false, draggable: false,
+      style: { width: W, border: "none", background: "transparent", color: "#8a92a6",
+               fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: ".05em" },
+    });
 
     const nodes = [], edges = [];
+    const dash = (stroke, label) => ({ type: "smoothstep", label,
+      labelStyle: { fontSize: 9, fill: stroke }, style: { stroke, strokeWidth: 1.3, strokeDasharray: "5 4", opacity: .9 },
+      markerEnd: { type: MarkerType.ArrowClosed, color: stroke } });
+    const solid = (stroke, label, animated) => ({ type: "smoothstep", label, animated: !!animated,
+      labelStyle: { fontSize: 9, fill: stroke }, style: { stroke, strokeWidth: 1.5 },
+      markerEnd: { type: MarkerType.ArrowClosed, color: stroke } });
 
+    // orchestration band (top)
     orchestration.forEach((o, i) => {
       const filled = o.kind === "orch";
-      nodes.push(box(o.id, o.label, colX(i), Y.orch, {
+      nodes.push(box(o.id, o.label, 60 + i * 300, 20, {
         background: filled ? slate : "#ffffff", color: filled ? "#f8fafc" : "#334155",
         borderColor: slate, fontWeight: 700, borderStyle: o.kind === "mgmt" ? "dashed" : "solid",
       }));
     });
+    ["governance", "agile"].forEach(m => edges.push({ id: "m-" + m, source: m, target: "coordinator",
+      type: "smoothstep", style: { stroke: "#94a3b8", strokeDasharray: "3 4" } }));
 
-    domains.forEach((d, i) => {
-      nodes.push(box("expert-" + d.id, d.label + "\nExpert", colX(i), Y.expert, {
-        background: d.color, color: "#ffffff", borderColor: d.color, fontWeight: 700,
+    // column headers
+    nodes.push(header("h-tpl", "① Role agent templates — reusable, repo-agnostic", COL.tpl, 120));
+    nodes.push(header("h-env", "② Per-repo environments — bound at launch", COL.env, 120));
+    nodes.push(header("h-ses", "③ Runtime sessions — many, parallel", COL.ses, 120));
+
+    // 1. role templates (one /v1/agents each)
+    roles.forEach((r, i) => {
+      nodes.push(box("tpl-" + r.id, r.label + "\n1 agent template", COL.tpl, rowY[i], {
+        background: indigo, color: "#ffffff", borderColor: indigo, fontWeight: 700,
       }));
-      edges.push({ id: "co-" + d.id, source: "coordinator", target: "expert-" + d.id,
-        type: "smoothstep", animated: true, style: { stroke: slate, strokeWidth: 1.5 },
-        markerEnd: { type: MarkerType.ArrowClosed, color: slate } });
-      edges.push({ id: "ct-" + d.id, source: "contract", target: "expert-" + d.id,
-        type: "smoothstep", style: { stroke: "#64748b", strokeDasharray: "5 4" },
-        label: "contract gate", labelStyle: { fontSize: 9, fill: "#64748b" } });
+      edges.push({ id: "gate-" + r.id, source: "contract", target: "tpl-" + r.id, ...dash("#64748b", i ? "" : "contract gate") });
+      edges.push({ id: "t2s-" + r.id, source: "tpl-" + r.id, target: "session", ...dash(indigo, i ? "" : "role") });
     });
 
-    roles.forEach((r, ri) => {
-      domains.forEach((d, ci) => {
-        const id = r.id + "-" + d.id;
-        nodes.push(box(id, r.label + "\n@" + d.label, colX(ci), Y.roles[ri], { borderColor: d.color }));
-        edges.push({ id: "e-" + id, source: "expert-" + d.id, target: id,
-          type: "smoothstep", style: { stroke: d.color, strokeWidth: 1.25, opacity: .85 },
-          markerEnd: { type: MarkerType.ArrowClosed, color: d.color } });
-      });
+    // 2. per-repo environments (toolchain + checkout + networking + expert + vault + memory)
+    repos.forEach((d, i) => {
+      nodes.push(box("env-" + d.id, d.label + " env\ntoolchain · checkout · net · " + d.host + "\n+ expert · vault · memory",
+        COL.env, rowY[i], { borderColor: d.color, background: "#ffffff", color: "#0f172a", fontWeight: 600 }));
+      edges.push({ id: "e2s-" + d.id, source: "env-" + d.id, target: "session", ...dash(d.color, i ? "" : "repo") });
     });
 
+    // 3. sessions (the role × env instantiation) + N-parallel + the worked example
+    nodes.push(box("session", "Session\n= role × environment\n(+vault, memory, skills)", COL.ses, 250, {
+      background: teal, color: "#ffffff", borderColor: teal, fontWeight: 700,
+    }));
+    nodes.push(box("parallel", "× N in parallel\nper feature / contract", COL.ses, 360, {
+      borderColor: teal, background: "#ffffff", color: teal, borderStyle: "dashed",
+    }));
+    nodes.push(box("example", "e.g. “fuzefront-backend” =\nBackend × FuzeFront env\n+ Kafka-Zod skill + FF vault", COL.ses, 470, {
+      borderColor: "#7c3aed", background: "#faf5ff", color: "#5b21b6", fontSize: 11,
+    }));
+    edges.push({ id: "co-ses", source: "coordinator", target: "session", ...solid(slate, "routes", true) });
+    edges.push({ id: "ses-par", source: "session", target: "parallel", ...solid(teal) });
+    edges.push({ id: "ses-ex", source: "session", target: "example", ...dash("#7c3aed", "override") });
+
+    // cross-product feature capabilities — skills/MCP attached at launch
+    nodes.push(header("h-cap", "Cross-product capabilities — skills / MCP attached at launch (agent_with_overrides), span all repos", 300, 585));
     features.forEach((f, i) => {
-      nodes.push(box(f.id, f.label + "\n(cross-product)", colX(i), Y.feature, {
-        background: f.color, color: "#ffffff", borderColor: f.color, fontWeight: 700,
+      nodes.push(box("cap-" + f.id, f.label + "\nskill / MCP", 90 + i * 240, 630, {
+        background: f.color, color: "#ffffff", borderColor: f.color, fontWeight: 700, width: 200,
       }));
-      f.spans.forEach(dom => {
-        edges.push({ id: "f-" + f.id + "-" + dom, source: f.id, target: "expert-" + dom,
-          type: "smoothstep", style: { stroke: f.color, strokeWidth: 1.4, strokeDasharray: "6 4", opacity: .9 },
-          markerEnd: { type: MarkerType.ArrowClosed, color: f.color } });
-      });
-    });
-
-    ["governance", "agile"].forEach(m => {
-      edges.push({ id: "m-" + m, source: m, target: "coordinator",
-        type: "smoothstep", style: { stroke: "#94a3b8", strokeDasharray: "3 4" } });
+      edges.push({ id: "cap-" + f.id + "-s", source: "cap-" + f.id, target: "session", ...dash(f.color, "") });
     });
 
     // ---- legend ----------------------------------------------------------
     const items = [
+      ["Role template (reusable agent)", indigo],
+      ["Session (role × env)", teal],
+      ...repos.map(d => [d.label + " env", d.color]),
+      ...features.map(f => [f.label + " (skill/MCP)", f.color]),
       ["Orchestration / management", slate],
-      ...domains.map(d => [d.label + " (domain)", d.color]),
-      ...features.map(f => [f.label, f.color]),
     ];
     document.getElementById("legend").innerHTML = "<b>Legend</b>" + items.map(([t, c]) =>
       `<div class="row"><span class="sw" style="background:${c}"></span>${t}</div>`).join("");
@@ -157,7 +182,7 @@
       const [e, , onEdgesChange] = useEdgesState(edges);
       return h(ReactFlow, {
         nodes: n, edges: e, onNodesChange, onEdgesChange,
-        fitView: true, minZoom: 0.2, maxZoom: 1.6, fitViewOptions: { padding: 0.12 },
+        fitView: true, minZoom: 0.2, maxZoom: 1.6, fitViewOptions: { padding: 0.1 },
         proOptions: { hideAttribution: true }, defaultEdgeOptions: { type: "smoothstep" },
       },
         h(Background, { gap: 22, color: "#e2e8f0" }),

--- a/agent-templates/environments/cloud-digital-persona.json
+++ b/agent-templates/environments/cloud-digital-persona.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../schema/environment.schema.json",
+  "name": "fuzeinfra-cloud-digital-persona",
+  "config": {
+    "type": "cloud",
+    "packages": {
+      "apt": ["jq"],
+      "pip": ["requests", "httpx"]
+    },
+    "networking": {
+      "type": "limited",
+      "allowed_hosts": [],
+      "allow_mcp_servers": true,
+      "allow_package_managers": true
+    }
+  }
+}

--- a/agent-templates/environments/cloud-exec.json
+++ b/agent-templates/environments/cloud-exec.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../schema/environment.schema.json",
+  "name": "fuzeinfra-cloud-exec",
+  "config": {
+    "type": "cloud",
+    "packages": {
+      "apt": ["jq"],
+      "pip": ["requests", "httpx"]
+    },
+    "networking": {
+      "type": "limited",
+      "allowed_hosts": [],
+      "allow_mcp_servers": true,
+      "allow_package_managers": true
+    }
+  }
+}

--- a/agent-templates/environments/cloud-mcp-engineer.json
+++ b/agent-templates/environments/cloud-mcp-engineer.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../schema/environment.schema.json",
+  "name": "fuzeinfra-cloud-mcp-engineer",
+  "config": {
+    "type": "cloud",
+    "packages": {
+      "apt": ["jq"],
+      "npm": ["@modelcontextprotocol/sdk", "@modelcontextprotocol/inspector"],
+      "pip": ["mcp", "httpx", "uvicorn", "starlette", "sse-starlette"]
+    },
+    "networking": {
+      "type": "limited",
+      "allowed_hosts": [],
+      "allow_mcp_servers": true,
+      "allow_package_managers": true
+    }
+  }
+}

--- a/agent-templates/environments/cloud-openapi-maintainer.json
+++ b/agent-templates/environments/cloud-openapi-maintainer.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../schema/environment.schema.json",
+  "name": "fuzeinfra-cloud-openapi-maintainer",
+  "config": {
+    "type": "cloud",
+    "packages": {
+      "apt": ["jq"],
+      "npm": ["@redocly/cli", "@stoplight/spectral-cli", "openapi-typescript", "@stoplight/prism-cli"],
+      "pip": ["openapi-spec-validator", "prance", "pyyaml"]
+    },
+    "networking": {
+      "type": "limited",
+      "allowed_hosts": [],
+      "allow_mcp_servers": true,
+      "allow_package_managers": true
+    }
+  }
+}

--- a/agent-templates/orchestration/handoff_mcp/server.py
+++ b/agent-templates/orchestration/handoff_mcp/server.py
@@ -194,6 +194,51 @@ def memory_read(path: str) -> str:
     return json.dumps({"store_id": sid, "path": path, "found": True, "content": full.get("content", "")})
 
 
+def _vault_id_by_name(name):
+    path = os.path.join(STATE, "vault-ids.json")
+    ids = json.load(open(path, encoding="utf-8")) if os.path.exists(path) else {}
+    return ids.get(name)
+
+
+@mcp.tool()
+def reach_human(human: str, message: str, reply_to_session_id: str = "", channels: str = "", wait: bool = False) -> str:
+    """Reach a real human through their digital persona and relay their answer back.
+
+    Spawns the `digital-persona` agent bound to this human's vault (their channel
+    credentials: email/Slack/GitHub/WhatsApp/Telegram/phone) and tells it to contact
+    the human with `message`, collect their ACTUAL reply, and — if reply_to_session_id
+    is set — resume_session() that session with the human's answer. Use this instead of
+    stalling when a session needs a human's decision or approval.
+
+    human: person key (matches vault 'persona-<human>' + the persona's metadata).
+    channels: comma list to prefer (e.g. "slack,email"); empty = their preferred.
+    wait: if true, block until the persona reports (reply|blocked|pending); else fire-and-forget
+          (the persona resumes the origin session itself when the human replies).
+    """
+    roles = _roles()
+    if "digital-persona" not in roles:
+        raise RuntimeError("digital-persona agent not provisioned — run providers/provision.py")
+    e = roles["digital-persona"]
+    vid = _vault_id_by_name(f"persona-{human}")
+    if not vid:
+        raise RuntimeError(f"no vault 'persona-{human}' — create vaults/persona-{human}.json and provision it")
+    sid = driver.create_session(e["id"], e["version"], e["environment_id"],
+                                vault_ids=[vid], resources=_memory_resources(),
+                                title=f"persona:{human}")["id"]
+    ch = f" via {channels}" if channels else " via their preferred channel"
+    prompt = (f"You represent {human}. Reach the real {human}{ch} with the following, collect their "
+              f"ACTUAL reply (never fabricate a binding answer), and report it.\n\nMESSAGE:\n{message}")
+    if reply_to_session_id:
+        prompt += (f"\n\nWhen you have their real answer, call resume_session(session_id='{reply_to_session_id}', "
+                   f"summary=<their verbatim answer + your read>). If you cannot reach them, resume with 'BLOCKED: ...'.")
+    if not wait:
+        driver.send_message(sid, prompt)
+        return json.dumps({"session_id": sid, "human": human, "status": "reaching"})
+    res = driver.run_until_block(sid, prompt)
+    return json.dumps({"session_id": sid, "human": human, "status": res["status"],
+                       "reply": res["text"], "pending": res["pending"]})
+
+
 if __name__ == "__main__":
     # Managed Agents connects to remote MCP servers over streamable HTTP.
     mcp.run(transport="streamable-http")

--- a/agent-templates/orchestration/relay.py
+++ b/agent-templates/orchestration/relay.py
@@ -5,10 +5,11 @@ Runs a goal through an ordered list of roles, one SESSION per role so each step
 executes in its OWN environment (cloud vs the devops self-hosted worker) — which
 the `multiagent` coordinator cannot do (its sub-agents share one environment).
 
-For each step: create the role's session (+ vault creds), seed it with the
-accumulated HANDOFF LEDGER + this step's instruction, run to completion, append
-the agent's result to the ledger, then ARCHIVE the session (the handing agent
-terminates). The next role re-launches fresh with the accumulated context.
+For each step: create the role's session (+ vault creds + shared handoff memory),
+seed it with the accumulated HANDOFF LEDGER + this step's instruction, run to
+completion, append the agent's result to the ledger, then ARCHIVE the session (the
+handing agent terminates). The next role re-launches fresh with the accumulated
+context. Provider selected by AGENT_PROVIDER (default anthropic).
 
     python relay.py --chain backend qa devops --goal "add /health to svc X and deploy"
     python relay.py --chain backend qa devops --goal "..." --auto allow   # headless
@@ -17,13 +18,18 @@ For the AGENT-INITIATED version (an agent decides who to hand to, mid-task), use
 the handoff MCP server (orchestration/handoff_mcp/) instead.
 """
 import argparse
-import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "sync"))
-import driver  # noqa: E402
-import launch_session as ls  # noqa: E402  (reuse _resolve + vault_ids)
+TEMPLATES_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (TEMPLATES_ROOT, os.path.join(TEMPLATES_ROOT, "sync")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from providers.base import interactive_approver, auto_approver  # noqa: E402
+import launch_session as ls  # noqa: E402  (reuse PROVIDER + _resolve + vault_ids + memory_resources)
+
+PROVIDER = ls.PROVIDER
 
 LEDGER_HEADER = "# HANDOFF LEDGER\n\nGoal: {goal}\n"
 STEP_TEMPLATE = (
@@ -39,24 +45,25 @@ def main():
     ap.add_argument("--goal", required=True, help="the overall goal seeded into the ledger")
     ap.add_argument("--auto", choices=["allow", "deny"], help="headless approval mode (default: interactive)")
     ap.add_argument("--no-vault", action="store_true")
+    ap.add_argument("--no-memory", action="store_true")
     args = ap.parse_args()
 
-    approver = driver.auto_approver(args.auto) if args.auto else driver.interactive_approver
+    approver = auto_approver(args.auto) if args.auto else interactive_approver
     vaults = ls.vault_ids(args.no_vault)
-    memory = ls.memory_resources(False)  # shared handoff store across every hop
+    memory = ls.memory_resources(args.no_memory)  # shared handoff store across every hop
     ledger = LEDGER_HEADER.format(goal=args.goal)
 
     for i, role in enumerate(args.chain, 1):
         entry = ls._resolve(role)
         print(f"\n===== step {i}/{len(args.chain)}: {role} =====")
-        session = driver.create_session(entry["id"], entry["version"], entry["environment_id"],
-                                        vault_ids=vaults, resources=memory, title=f"relay:{role}:{i}")
-        print(f"session {session['id']} (env {entry['environment_id']})\n")
+        session_id = PROVIDER.create_session(entry["id"], entry["version"], entry["environment_id"],
+                                             vault_ids=vaults, memory_resources=memory, title=f"relay:{role}:{i}")
+        print(f"session {session_id} (env {entry['environment_id']})\n")
 
-        result = driver.run_turn(session["id"], STEP_TEMPLATE.format(ledger=ledger, role=role), approver)
+        result = PROVIDER.run_turn(session_id, STEP_TEMPLATE.format(ledger=ledger, role=role), approver)
         ledger += f"\n\n## {role} update (step {i})\n{result.strip()}\n"
 
-        driver.archive_session(session["id"])  # handing agent terminates
+        PROVIDER.archive_session(session_id)  # handing agent terminates
         print(f"\n[{role} handed forward; session archived]")
 
     print("\n\n===== chain complete =====")

--- a/agent-templates/providers/README.md
+++ b/agent-templates/providers/README.md
@@ -1,0 +1,56 @@
+# providers/ — the runtime seam
+
+The role manifests, environments, vaults, memory, and orchestration are **provider-
+agnostic**. A `providers/<name>/adapter.py` translates them into a specific backend
+and implements the runtime. Pick one with `AGENT_PROVIDER` (default `anthropic`):
+
+```python
+from providers import get_provider
+p = get_provider()            # AGENT_PROVIDER env, default "anthropic"
+p = get_provider("openai")    # explicit
+```
+
+## The interface — `base.py:AgentProvider`
+
+- **Provisioning:** `ensure_environment`, `ensure_agent`, `ensure_vault`, `ensure_memory`
+- **Runtime:** `create_session`, `send_message`, `run_turn`, `run_until_block`,
+  `resume_session`, `confirm_tool`, `archive_session`
+- **Memory:** `memory_resource`, `memory_write`, `memory_read`
+- **`capabilities`** flags (`self_hosted`, `vaults`, `memory`, `multiagent`) — provisioning
+  skips unsupported resource kinds.
+
+The approver contract and the `{status: idle|blocked|error, pending}` shape are shared
+(`base.interactive_approver` / `base.auto_approver`), so orchestration is identical across providers.
+
+## Providers
+
+| Provider | Status | Backing |
+|---|---|---|
+| `anthropic` | ✅ reference | Claude Managed Agents (`/v1/agents`, `/v1/environments`, `/v1/sessions`, vaults, memory) — wraps `sync/common.py` + `sync/driver.py` + `sync/role_loader.py`. |
+| `openai` | 🧩 stub | Assistants / Responses + Agents SDK — see `openai/adapter.py` docstring for the mapping. |
+| `hermes` | 🧩 stub | Hermes models on an OpenAI-compatible / custom tool-calling runtime — see `hermes/adapter.py`. |
+
+## Add a provider
+
+1. `providers/<name>/adapter.py` with `class <Name>Provider(AgentProvider)` implementing the
+   methods; set `capabilities`. Translate the manifest *intent* (tools/policies/mcp/skills/packages)
+   into your backend's payloads — don't change the manifests.
+2. Register it in `providers/__init__.py:get_provider` (lazy import).
+3. `providers/<name>/__init__.py` re-exports the class.
+
+## Provision (create everything for a provider)
+
+```bash
+python providers/provision.py --provider anthropic --dry-run   # offline plan, no API calls
+python providers/provision.py --provider anthropic             # create/update live, prints ids
+```
+
+`provision` creates environments + agents (+ vaults + memory) idempotently and writes the id
+state (`environment-ids/agent-ids/vault-ids/memory-ids.json`) under the state dir.
+
+## Not yet routed
+
+The handoff MCP server (`orchestration/handoff_mcp/server.py`) still calls the Anthropic
+`driver` directly (it's the deployed container; routing it through `get_provider()` needs a
+Dockerfile change). Its cross-provider runtime (OpenAI/Hermes have different session-resume
+semantics) is the next step — the stubs document the mapping.

--- a/agent-templates/providers/__init__.py
+++ b/agent-templates/providers/__init__.py
@@ -1,0 +1,32 @@
+"""Provider registry for the agent framework.
+
+    from providers import get_provider
+    p = get_provider()            # AGENT_PROVIDER env, default "anthropic"
+    p = get_provider("openai")    # explicit
+
+Adapters are imported lazily so selecting one provider never pulls another's
+(possibly missing) SDK. Add a provider by dropping providers/<name>/adapter.py
+with a `<Name>Provider(AgentProvider)` and registering it here.
+"""
+import os
+
+from providers.base import AgentProvider  # re-export for adapters/type hints
+
+__all__ = ["get_provider", "AgentProvider", "PROVIDERS"]
+
+PROVIDERS = ("anthropic", "openai", "hermes")
+
+
+def get_provider(name=None):
+    name = (name or os.environ.get("AGENT_PROVIDER") or "anthropic").strip().lower()
+    if name == "anthropic":
+        from providers.anthropic.adapter import AnthropicProvider
+        return AnthropicProvider()
+    if name == "openai":
+        from providers.openai.adapter import OpenAIProvider
+        return OpenAIProvider()
+    if name == "hermes":
+        from providers.hermes.adapter import HermesProvider
+        return HermesProvider()
+    raise ValueError(f"unknown provider '{name}' — known: {', '.join(PROVIDERS)}. "
+                     f"See agent-templates/providers/<name>/adapter.py to add one.")

--- a/agent-templates/providers/anthropic/__init__.py
+++ b/agent-templates/providers/anthropic/__init__.py
@@ -1,0 +1,3 @@
+from providers.anthropic.adapter import AnthropicProvider
+
+__all__ = ["AnthropicProvider"]

--- a/agent-templates/providers/anthropic/adapter.py
+++ b/agent-templates/providers/anthropic/adapter.py
@@ -1,0 +1,157 @@
+"""Anthropic Managed Agents provider — the reference `AgentProvider`.
+
+Additive: delegates to the existing `sync/` modules (`common`, `driver`,
+`role_loader`) rather than moving them, so the deployed handoff image and the
+standalone sync scripts keep working. The idempotent create/update logic mirrors
+`sync/sync_{environments,agents,vaults,memory}.py`.
+"""
+import glob
+import json
+import os
+import sys
+
+from providers.base import AgentProvider
+
+_TEMPLATES_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_SYNC = os.environ.get("HANDOFF_SYNC_DIR") or os.path.join(_TEMPLATES_ROOT, "sync")
+if _SYNC not in sys.path:
+    sys.path.insert(0, _SYNC)
+
+import common          # noqa: E402
+import driver          # noqa: E402
+import role_loader as rl  # noqa: E402
+
+# Agent fields we compare to decide whether an update is needed.
+_COMPARE = ("model", "system", "description", "tools", "mcp_servers", "skills", "multiagent")
+
+
+def _norm_model(m):
+    return m["id"] if isinstance(m, dict) else m
+
+
+def _agent_changed(current, desired):
+    for k in _COMPARE:
+        d = desired.get(k)
+        if d is None:
+            continue
+        c = current.get(k)
+        if k == "model":
+            if _norm_model(c) != _norm_model(d):
+                return True
+        elif c != d:
+            return True
+    return False
+
+
+class AnthropicProvider(AgentProvider):
+    name = "anthropic"
+    capabilities = {"self_hosted": True, "vaults": True, "memory": True, "multiagent": True}
+
+    # ---- provisioning -------------------------------------------------------
+    def ensure_environment(self, manifest):
+        existing = {e["name"]: e["id"] for e in common.list_all("/v1/environments")}
+        name = manifest["name"]
+        if name in existing:
+            return {"name": name, "id": existing[name], "created": False}
+        created = common.request("POST", "/v1/environments",
+                                 body={"name": name, "config": manifest["config"]})
+        return {"name": name, "id": created["id"], "created": True}
+
+    def ensure_agent(self, manifest, multiagent=None):
+        payload = rl.agent_payload(manifest)
+        if multiagent:
+            payload["multiagent"] = {"agents": multiagent}
+        existing = {a["name"]: a for a in common.list_all("/v1/agents")}
+        name = payload["name"]
+        if name in existing:
+            cur = existing[name]
+            if _agent_changed(cur, payload):
+                updated = common.request("POST", f"/v1/agents/{cur['id']}",
+                                         body={**payload, "version": cur["version"]})
+                return {"name": name, "id": updated["id"], "version": updated["version"], "created": False}
+            return {"name": name, "id": cur["id"], "version": cur["version"], "created": False}
+        created = common.request("POST", "/v1/agents", body=payload)
+        return {"name": name, "id": created["id"], "version": created["version"], "created": True}
+
+    def ensure_vault(self, manifest):
+        tmpl = common.expand_env(manifest)
+        existing = {v["display_name"]: v["id"] for v in common.list_all("/v1/vaults")}
+        name = tmpl["display_name"]
+        if name in existing:
+            vid = existing[name]
+        else:
+            body = {"display_name": name}
+            if tmpl.get("metadata"):
+                body["metadata"] = tmpl["metadata"]
+            vid = common.request("POST", "/v1/vaults", body=body)["id"]
+        have = {(c.get("auth") or {}).get("mcp_server_url") or (c.get("auth") or {}).get("secret_name")
+                for c in common.list_all(f"/v1/vaults/{vid}/credentials")}
+        for cred in tmpl.get("credentials", []):
+            auth = cred["auth"]
+            key = auth.get("mcp_server_url") or auth.get("secret_name")
+            if not key or "${" in json.dumps(auth):
+                continue  # unresolved ${VAR} — the env var isn't set; skip rather than store a bad cred
+            if key in have:
+                continue
+            common.request("POST", f"/v1/vaults/{vid}/credentials",
+                           body={"display_name": cred["display_name"], "auth": auth})
+        return {"name": name, "id": vid}
+
+    def ensure_memory(self, manifest):
+        existing = {s["name"]: s["id"] for s in common.list_all("/v1/memory_stores", beta=common.MEMORY_BETA)}
+        name = manifest["name"]
+        if name in existing:
+            sid = existing[name]
+        else:
+            sid = common.request("POST", "/v1/memory_stores",
+                                 body={"name": name, "description": manifest.get("description", "")},
+                                 beta=common.MEMORY_BETA)["id"]
+        have = {m["path"] for m in common.list_all(f"/v1/memory_stores/{sid}/memories", beta=common.MEMORY_BETA)
+                if m.get("path")}
+        for mem in manifest.get("seed", []):
+            if mem["path"] in have:
+                continue
+            common.request("POST", f"/v1/memory_stores/{sid}/memories",
+                           body={"path": mem["path"], "content": mem["content"]}, beta=common.MEMORY_BETA)
+        return {"name": name, "id": sid}
+
+    # ---- runtime (thin delegations to the driver) ---------------------------
+    def create_session(self, agent_id, version, environment_id, vault_ids=None, memory_resources=None, title=None):
+        return driver.create_session(agent_id, version, environment_id,
+                                     vault_ids=vault_ids, resources=memory_resources, title=title)["id"]
+
+    def send_message(self, session_id, text):
+        driver.send_message(session_id, text)
+
+    def run_turn(self, session_id, prompt, approver, echo=True):
+        return driver.run_turn(session_id, prompt, approver, echo=echo)
+
+    def run_until_block(self, session_id, prompt=None):
+        return driver.run_until_block(session_id, prompt)
+
+    def resume_session(self, session_id, summary, context_ref=""):
+        msg = f"[handoff:resume] {summary}"
+        if context_ref:
+            msg += f"\n\nPersisted state: {context_ref} (read it for details)."
+        driver.send_message(session_id, msg)
+
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None):
+        driver.confirm_tool(session_id, tool_use_id, allow=allow, deny_message=deny_message)
+
+    def archive_session(self, session_id):
+        driver.archive_session(session_id)
+
+    # ---- memory -------------------------------------------------------------
+    def memory_resource(self, store_id, access="read_write", instructions=None):
+        return driver.memory_resource(store_id, access=access, instructions=instructions)
+
+    def memory_write(self, store_id, path, content):
+        common.request("POST", f"/v1/memory_stores/{store_id}/memories",
+                       body={"path": path, "content": content}, beta=common.MEMORY_BETA)
+        return {"store_id": store_id, "path": path}
+
+    def memory_read(self, store_id, path):
+        res = common.request("GET", f"/v1/memory_stores/{store_id}/memories",
+                             query={"path": path}, beta=common.MEMORY_BETA)
+        data = res.get("data", res)
+        return data[0]["content"] if isinstance(data, list) and data else (data.get("content") if isinstance(data, dict) else None)

--- a/agent-templates/providers/base.py
+++ b/agent-templates/providers/base.py
@@ -1,0 +1,97 @@
+"""Provider-agnostic agent-runtime interface.
+
+An `AgentProvider` is the seam between the provider-neutral *definitions* (role
+manifests, environments, vaults, memory) + *orchestration* (launch, relay, handoff)
+and a specific backend (Anthropic Managed Agents today; OpenAI / Hermes next).
+
+Everything above the seam speaks manifests + this interface; each provider
+translates manifests into its own payloads and implements the runtime ops. The
+approver contract and the {status: idle|blocked|error, pending} shape are shared
+verbatim with the existing driver so no orchestration logic changes.
+"""
+from abc import ABC, abstractmethod
+
+
+class AgentProvider(ABC):
+    #: short id used by the registry / AGENT_PROVIDER env
+    name = "base"
+    #: what the backend supports; provisioning skips unsupported resource kinds
+    capabilities = {"self_hosted": False, "vaults": False, "memory": False, "multiagent": False}
+
+    # ---- provisioning (manifest in -> {name, id[, version]} out) -------------
+    @abstractmethod
+    def ensure_environment(self, manifest):
+        """Create-if-missing an environment. Returns {'name', 'id'}."""
+
+    @abstractmethod
+    def ensure_agent(self, manifest, multiagent=None):
+        """Create-or-update an agent from a (merged) role manifest. `multiagent`
+        is an optional resolved roster [{id, version}, ...] for a coordinator.
+        Returns {'name', 'id', 'version'}."""
+
+    def ensure_vault(self, manifest):
+        raise NotImplementedError(f"{self.name}: vaults not supported")
+
+    def ensure_memory(self, manifest):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+    # ---- runtime ------------------------------------------------------------
+    @abstractmethod
+    def create_session(self, agent_id, version, environment_id,
+                       vault_ids=None, memory_resources=None, title=None):
+        """Returns the session id."""
+
+    @abstractmethod
+    def send_message(self, session_id, text):
+        """Send a user.message-equivalent event."""
+
+    @abstractmethod
+    def run_turn(self, session_id, prompt, approver, echo=True):
+        """Drive one turn to completion, handling approvals via `approver`.
+        Returns the accumulated agent text."""
+
+    @abstractmethod
+    def run_until_block(self, session_id, prompt=None):
+        """Run until idle OR a required approval. Returns
+        {'text', 'status': 'idle'|'blocked'|'error', 'pending': {...}|None}."""
+
+    @abstractmethod
+    def resume_session(self, session_id, summary, context_ref=""):
+        """Wake an existing session with a concise summary (history restored server-side)."""
+
+    @abstractmethod
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None):
+        """Answer a single always_ask pause."""
+
+    @abstractmethod
+    def archive_session(self, session_id):
+        """Terminate a session (best-effort)."""
+
+    # ---- memory (optional) --------------------------------------------------
+    def memory_resource(self, store_id, access="read_write", instructions=None):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+    def memory_write(self, store_id, path, content):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+    def memory_read(self, store_id, path):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+
+# ---- shared, provider-agnostic approvers ------------------------------------
+# An approver maps {tool_use_id -> human description} to {tool_use_id -> (result, deny_message)}.
+
+def interactive_approver(descriptions):
+    out = {}
+    for tid, desc in descriptions.items():
+        ans = input(f"\nAPPROVE tool call?\n  {desc}\n  [y]allow / [n]deny > ").strip().lower()
+        if ans in ("y", "yes", "allow"):
+            out[tid] = ("allow", None)
+        else:
+            out[tid] = ("deny", input("  deny reason > ").strip() or "denied by operator")
+    return out
+
+
+def auto_approver(result):
+    msg = None if result == "allow" else "auto-denied (headless)"
+    return lambda descriptions: {tid: (result, msg) for tid in descriptions}

--- a/agent-templates/providers/hermes/__init__.py
+++ b/agent-templates/providers/hermes/__init__.py
@@ -1,0 +1,3 @@
+from providers.hermes.adapter import HermesProvider
+
+__all__ = ["HermesProvider"]

--- a/agent-templates/providers/hermes/adapter.py
+++ b/agent-templates/providers/hermes/adapter.py
@@ -1,0 +1,42 @@
+"""Hermes provider — STUB.
+
+Extension point for running the same role manifests on a Hermes-based / OpenAI-
+compatible agent runtime (e.g. NousResearch Hermes models served behind an
+OpenAI-compatible or custom tool-calling API). Implement against whichever runtime
+hosts Hermes; the manifests + orchestration above the `AgentProvider` seam are unchanged.
+
+Concept mapping (Managed Agents -> Hermes runtime):
+  agent            -> a model + system prompt + tool schema (Hermes uses its own
+                      tool-call/function-calling format; translate manifest tools to it).
+  agent `system`   -> the system prompt.
+  tools / policies -> the tool schema you expose to the model; always_ask -> gate
+                      execution in your harness (no server-side approval primitive).
+  environment      -> your own sandbox/container (Hermes has no managed sandbox);
+                      `packages` -> your image; networking -> your egress policy.
+  session          -> your own conversation store keyed by id (persist server-side
+                      to keep the "resume by id, don't copy transcript" property).
+  run_turn         -> your inference + tool loop.
+  resume_session   -> reload the stored conversation by id and continue.
+  vaults / memory  -> your own secret store / vector store.
+
+Until implemented, every method raises NotImplementedError with this guidance.
+"""
+from providers.base import AgentProvider
+
+_MSG = ("Hermes provider is a stub — implement providers/hermes/adapter.py "
+        "(see the module docstring for the Managed-Agents -> Hermes mapping).")
+
+
+class HermesProvider(AgentProvider):
+    name = "hermes"
+    capabilities = {"self_hosted": True, "vaults": False, "memory": False, "multiagent": False}
+
+    def ensure_environment(self, manifest): raise NotImplementedError(_MSG)
+    def ensure_agent(self, manifest, multiagent=None): raise NotImplementedError(_MSG)
+    def create_session(self, agent_id, version, environment_id, vault_ids=None, memory_resources=None, title=None): raise NotImplementedError(_MSG)
+    def send_message(self, session_id, text): raise NotImplementedError(_MSG)
+    def run_turn(self, session_id, prompt, approver, echo=True): raise NotImplementedError(_MSG)
+    def run_until_block(self, session_id, prompt=None): raise NotImplementedError(_MSG)
+    def resume_session(self, session_id, summary, context_ref=""): raise NotImplementedError(_MSG)
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None): raise NotImplementedError(_MSG)
+    def archive_session(self, session_id): raise NotImplementedError(_MSG)

--- a/agent-templates/providers/openai/__init__.py
+++ b/agent-templates/providers/openai/__init__.py
@@ -1,0 +1,3 @@
+from providers.openai.adapter import OpenAIProvider
+
+__all__ = ["OpenAIProvider"]

--- a/agent-templates/providers/openai/adapter.py
+++ b/agent-templates/providers/openai/adapter.py
@@ -1,0 +1,42 @@
+"""OpenAI provider — STUB.
+
+Extension point for running the same role manifests on OpenAI instead of Anthropic
+Managed Agents. Implement the methods below against OpenAI's primitives; the
+manifests + orchestration above the `AgentProvider` seam do not change.
+
+Concept mapping (Managed Agents -> OpenAI):
+  agent            -> an Assistant (Assistants API) OR a reusable config for the
+                      Responses API / Agents SDK (model + instructions + tools).
+  agent `system`   -> Assistant `instructions`.
+  tools / policies -> Assistant `tools` (function/code_interpreter/file_search);
+                      always_ask -> your app gates the tool call before executing
+                      (OpenAI has no server-side always_ask — approvals are client-side).
+  environment      -> a code-interpreter container / your own sandbox; `packages`
+                      -> preinstalled image or a setup step; networking -> your egress policy.
+  session          -> a Thread (Assistants) or a Response chain (`previous_response_id`).
+  run_turn         -> create+poll a Run / a Response; stream deltas.
+  resume_session   -> continue the Thread / chain by id (history is server-side too).
+  vaults           -> not a native concept; inject secrets via your tool layer.
+  memory           -> a vector store (file_search) or your own store.
+
+Until implemented, every method raises NotImplementedError with this guidance.
+"""
+from providers.base import AgentProvider
+
+_MSG = ("OpenAI provider is a stub — implement providers/openai/adapter.py "
+        "(see the module docstring for the Managed-Agents -> OpenAI mapping).")
+
+
+class OpenAIProvider(AgentProvider):
+    name = "openai"
+    capabilities = {"self_hosted": True, "vaults": False, "memory": True, "multiagent": True}
+
+    def ensure_environment(self, manifest): raise NotImplementedError(_MSG)
+    def ensure_agent(self, manifest, multiagent=None): raise NotImplementedError(_MSG)
+    def create_session(self, agent_id, version, environment_id, vault_ids=None, memory_resources=None, title=None): raise NotImplementedError(_MSG)
+    def send_message(self, session_id, text): raise NotImplementedError(_MSG)
+    def run_turn(self, session_id, prompt, approver, echo=True): raise NotImplementedError(_MSG)
+    def run_until_block(self, session_id, prompt=None): raise NotImplementedError(_MSG)
+    def resume_session(self, session_id, summary, context_ref=""): raise NotImplementedError(_MSG)
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None): raise NotImplementedError(_MSG)
+    def archive_session(self, session_id): raise NotImplementedError(_MSG)

--- a/agent-templates/providers/provision.py
+++ b/agent-templates/providers/provision.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""One-shot provisioner: create/update every environment + agent (+ vaults, memory)
+for a provider, idempotently, and print the resulting ids.
+
+    python providers/provision.py --provider anthropic            # create/update live
+    python providers/provision.py --provider anthropic --dry-run  # resolve + print, no API calls
+
+Run this (or the provision CI job) once a Managed-Agents-entitled ANTHROPIC_API_KEY
+and the MCP URLs (GITHUB_MCP_URL/TOKEN, HANDOFF_MCP_URL) are set. The final summary
+is the "all agents created with their envs" confirmation. Writes the id state
+(environment-ids/agent-ids/vault-ids/memory-ids.json) under the state dir.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))          # providers/
+TEMPLATES_ROOT = os.path.dirname(HERE)                     # agent-templates/
+SYNC = os.path.join(TEMPLATES_ROOT, "sync")
+for _p in (TEMPLATES_ROOT, SYNC):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from providers import get_provider  # noqa: E402
+import common                       # noqa: E402  (state_dir)
+import role_loader as rl            # noqa: E402
+
+ENV_DIR = os.path.join(TEMPLATES_ROOT, "environments")
+VAULT_DIR = os.path.join(TEMPLATES_ROOT, "vaults")
+MEM_DIR = os.path.join(TEMPLATES_ROOT, "memory")
+COORD = os.path.join(TEMPLATES_ROOT, "coordinator", "coordinator.json")
+
+
+def _load(path):
+    return json.load(open(path, encoding="utf-8"))
+
+
+def _glob(d):
+    return sorted(glob.glob(os.path.join(d, "*.json")))
+
+
+def _env_basename_to_name(basename):
+    if not basename:
+        return None
+    return _load(os.path.join(ENV_DIR, f"{basename}.json"))["name"]
+
+
+def dry_run(provider):
+    print(f"# DRY RUN (provider={provider.name}) — no API calls\n")
+    print("Environments:")
+    for p in _glob(ENV_DIR):
+        e = _load(p)
+        print(f"  - {e['name']}  (type={e['config'].get('type')})")
+    if provider.capabilities.get("vaults"):
+        print("Vaults:")
+        for p in _glob(VAULT_DIR):
+            v = _load(p)
+            print(f"  - {v['display_name']}  ({len(v.get('credentials', []))} credentials)")
+    if provider.capabilities.get("memory"):
+        print("Memory stores:")
+        for p in _glob(MEM_DIR):
+            m = _load(p)
+            print(f"  - {m['name']}  ({len(m.get('seed', []))} seed memories)")
+    print("Agents:")
+    for role in rl.role_dirs():
+        m = rl.load_manifest(os.path.join(rl.ROLES_DIR, role, "role.json"))
+        mcp = [s.get("name") for s in m.get("mcp_servers", [])]
+        print(f"  - {m['name']}  model={m.get('model')}  tools={len(m.get('tools', []))}  "
+              f"mcp={mcp}  skills={len(m.get('skills', []))}  env={m.get('environment')}")
+    if os.path.exists(COORD):
+        c = rl.load_manifest(COORD)
+        print(f"  - {c['name']}  (coordinator; roster={c.get('multiagent_roles', [])})")
+    print("\n(no changes made)")
+
+
+def apply(provider, no_vault, no_memory):
+    state_dir = common.state_dir()
+    os.makedirs(state_dir, exist_ok=True)
+
+    def _write(name, obj):
+        with open(os.path.join(state_dir, name), "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2)
+
+    env_ids = {}
+    for p in _glob(ENV_DIR):
+        r = provider.ensure_environment(_load(p))
+        env_ids[r["name"]] = r["id"]
+        print(f"[env]    {r['name']}: {'created' if r.get('created') else 'exists'}  {r['id']}")
+    _write("environment-ids.json", env_ids)
+
+    vault_ids = {}
+    if provider.capabilities.get("vaults") and not no_vault:
+        for p in _glob(VAULT_DIR):
+            r = provider.ensure_vault(_load(p))
+            vault_ids[r["name"]] = r["id"]
+            print(f"[vault]  {r['name']}: {r['id']}")
+        _write("vault-ids.json", vault_ids)
+
+    mem_ids = {}
+    if provider.capabilities.get("memory") and not no_memory:
+        for p in _glob(MEM_DIR):
+            r = provider.ensure_memory(_load(p))
+            mem_ids[r["name"]] = r["id"]
+            print(f"[memory] {r['name']}: {r['id']}")
+        _write("memory-ids.json", mem_ids)
+
+    state = {}
+    for role in rl.role_dirs():
+        m = rl.load_manifest(os.path.join(rl.ROLES_DIR, role, "role.json"))
+        a = provider.ensure_agent(m)
+        state[role] = {"id": a["id"], "version": a["version"],
+                       "environment": m.get("environment"),
+                       "environment_id": env_ids.get(_env_basename_to_name(m.get("environment")))}
+        print(f"[agent]  {a['name']}: {'created' if a.get('created') else 'exists'}  v{a['version']}  {a['id']}")
+    if os.path.exists(COORD):
+        c = rl.load_manifest(COORD)
+        roster = [{"type": "agent", "id": state[r]["id"], "version": state[r]["version"]}
+                  for r in c.get("multiagent_roles", []) if r in state]
+        a = provider.ensure_agent(c, multiagent=roster or None)
+        state["coordinator"] = {"id": a["id"], "version": a["version"],
+                                "environment": c.get("environment"),
+                                "environment_id": env_ids.get(_env_basename_to_name(c.get("environment")))}
+        print(f"[agent]  {a['name']}: {'created' if a.get('created') else 'exists'}  v{a['version']}  {a['id']}")
+    _write("agent-ids.json", state)
+
+    print(f"\n✅ Provisioned via {provider.name}: {len(env_ids)} environments, {len(state)} agents, "
+          f"{len(vault_ids)} vaults, {len(mem_ids)} memory stores.\n   State written to {state_dir}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Provision all agents + environments for a provider.")
+    ap.add_argument("--provider", default=os.environ.get("AGENT_PROVIDER", "anthropic"))
+    ap.add_argument("--dry-run", action="store_true", help="resolve + print the plan; no API calls")
+    ap.add_argument("--no-vault", action="store_true")
+    ap.add_argument("--no-memory", action="store_true")
+    args = ap.parse_args()
+
+    provider = get_provider(args.provider)
+    if args.dry_run:
+        dry_run(provider)
+    else:
+        apply(provider, args.no_vault, args.no_memory)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/roles/ceo/role.json
+++ b/agent-templates/roles/ceo/role.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "ceo",
+  "name": "FuzeOne CEO",
+  "description": "Executive profile — org strategy, prioritization, cross-product decisions. Reads status/metrics, sets direction, delegates execution to the coordinator/roles, and escalates binding decisions to the human CEO via their digital persona.",
+  "persona": ".claude/agents/ceo.md",
+  "model": "claude-opus-4-8",
+  "environment": "cloud-exec",
+  "system_append": "You operate at strategy altitude. READ across systems (GitHub/Jira/Slack/metrics); DELEGATE execution via the handoff tools (spawn_agent/ask_agent to the coordinator or roles) — never implement. For a binding business decision or approval, call reach_human to consult the human CEO via their digital persona and act on their real answer; never fabricate an executive decision.",
+  "tools": [
+    { "type": "agent_toolset_20260401", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "github", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "handoff", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "atlassian", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "slack", "default_config": { "permission_policy": { "type": "always_ask" } } }
+  ],
+  "mcp_servers": [
+    { "type": "url", "name": "github", "url": "${GITHUB_MCP_URL}" },
+    { "type": "url", "name": "handoff", "url": "${HANDOFF_MCP_URL}" },
+    { "type": "url", "name": "atlassian", "url": "${ATLASSIAN_MCP_URL}" },
+    { "type": "url", "name": "slack", "url": "${SLACK_MCP_URL}" }
+  ],
+  "services": { "github": "read", "k8s": "none", "cloud": "read" },
+  "metadata": { "role": "ceo", "tier": "executive" }
+}

--- a/agent-templates/roles/cfo/role.json
+++ b/agent-templates/roles/cfo/role.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "cfo",
+  "name": "FuzeOne CFO",
+  "description": "Executive profile — financial oversight: cloud/LLM spend, budgets, unit economics, billing/revenue, cost governance. Reads cost + billing data, flags overruns, delegates fixes, and escalates binding financial actions to the human CFO via their digital persona. Never moves money autonomously.",
+  "persona": ".claude/agents/cfo.md",
+  "model": "claude-opus-4-8",
+  "environment": "cloud-exec",
+  "system_append": "READ-ONLY on financial systems (billing/Stripe, cloud cost, LLM/token spend). Flag overruns/anomalies; recommend optimizations and DELEGATE fixes via handoff to devops-engineer / billing-payments-engineer. NEVER move money, execute a transaction, or change pricing/billing autonomously — for any binding financial action, reach_human the human CFO via their digital persona and act only on their explicit approval. The Stripe MCP toolset is always_ask.",
+  "tools": [
+    { "type": "agent_toolset_20260401", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "github", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "handoff", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "slack", "default_config": { "permission_policy": { "type": "always_ask" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "stripe", "default_config": { "permission_policy": { "type": "always_ask" } } }
+  ],
+  "mcp_servers": [
+    { "type": "url", "name": "github", "url": "${GITHUB_MCP_URL}" },
+    { "type": "url", "name": "handoff", "url": "${HANDOFF_MCP_URL}" },
+    { "type": "url", "name": "slack", "url": "${SLACK_MCP_URL}" },
+    { "type": "url", "name": "stripe", "url": "${STRIPE_MCP_URL}" }
+  ],
+  "services": { "github": "read", "k8s": "none", "cloud": "read" },
+  "metadata": { "role": "cfo", "tier": "executive" }
+}

--- a/agent-templates/roles/ciso/role.json
+++ b/agent-templates/roles/ciso/role.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "ciso",
+  "name": "FuzeOne CISO",
+  "description": "Executive profile — security posture, risk, and compliance oversight. Reads the security signal (CVE/SARIF, secret-scan, auth architecture, incidents), sets policy, prioritizes risk, delegates remediation to the security agent/roles, and escalates binding risk-acceptance to the human CISO via their digital persona.",
+  "persona": ".claude/agents/ciso.md",
+  "model": "claude-opus-4-8",
+  "environment": "cloud-exec",
+  "system_append": "READ the security signal across products (scan-gate SARIF, secret hygiene, auth architecture, incidents). Set policy + prioritize risk by real exploitability + blast radius. DELEGATE remediation via handoff to the security agent + owning roles (backend/devops) under approval. Consequential/destructive actions (secret rotation, disabling access, prod changes) are always_ask; for a BINDING risk decision (accept a risk, approve an exception, declare incident severity, authorize a rotation) reach_human the human CISO via their digital persona.",
+  "tools": [
+    { "type": "agent_toolset_20260401", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "github", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "handoff", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "atlassian", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "slack", "default_config": { "permission_policy": { "type": "always_ask" } } }
+  ],
+  "mcp_servers": [
+    { "type": "url", "name": "github", "url": "${GITHUB_MCP_URL}" },
+    { "type": "url", "name": "handoff", "url": "${HANDOFF_MCP_URL}" },
+    { "type": "url", "name": "atlassian", "url": "${ATLASSIAN_MCP_URL}" },
+    { "type": "url", "name": "slack", "url": "${SLACK_MCP_URL}" }
+  ],
+  "services": { "github": "read", "k8s": "none", "cloud": "read" },
+  "metadata": { "role": "ciso", "tier": "executive" }
+}

--- a/agent-templates/roles/cto/role.json
+++ b/agent-templates/roles/cto/role.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "cto",
+  "name": "FuzeOne CTO",
+  "description": "Executive profile — technical strategy, architecture standards, engineering governance across FuzeOne. Sets tech direction, reviews cross-repo architecture, delegates implementation, and escalates binding technical decisions to the human CTO via their digital persona.",
+  "persona": ".claude/agents/cto.md",
+  "model": "claude-opus-4-8",
+  "environment": "cloud-exec",
+  "system_append": "You set technical direction + standards across repos; you do not hand-write features. READ code/architecture across GitHub; ensure the FuzeSDLC baseline + agent framework stay coherent (coordinate with platform-governance). DELEGATE implementation via handoff to the coordinator/roles; consult repo-experts for depth. For a binding technical decision the human owns, reach_human the human CTO via their digital persona.",
+  "tools": [
+    { "type": "agent_toolset_20260401", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "github", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "handoff", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "atlassian", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "slack", "default_config": { "permission_policy": { "type": "always_ask" } } }
+  ],
+  "mcp_servers": [
+    { "type": "url", "name": "github", "url": "${GITHUB_MCP_URL}" },
+    { "type": "url", "name": "handoff", "url": "${HANDOFF_MCP_URL}" },
+    { "type": "url", "name": "atlassian", "url": "${ATLASSIAN_MCP_URL}" },
+    { "type": "url", "name": "slack", "url": "${SLACK_MCP_URL}" }
+  ],
+  "services": { "github": "read", "k8s": "none", "cloud": "read" },
+  "metadata": { "role": "cto", "tier": "executive" }
+}

--- a/agent-templates/roles/digital-persona/role.json
+++ b/agent-templates/roles/digital-persona/role.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "digital-persona",
+  "name": "FuzeOne digital-persona",
+  "description": "Shared template representing one human — bound at LAUNCH to that person's vault (channel creds) + metadata (identity, handles, preferred channels). Answers as them from known positions, and for anything binding reaches the real human over email/Slack/GitHub/WhatsApp/Telegram/phone, collects their reply, and relays it back to the originating session. One human = one launch (their vault + metadata), never a separate agent.",
+  "persona": ".claude/agents/digital-persona.md",
+  "model": "claude-opus-4-8",
+  "environment": "cloud-digital-persona",
+  "system_append": "You are bound to ONE human via this session's vault (their channel credentials) + metadata (name, role, email, handles, preferred_channels, quiet_hours). Represent their view (clearly labelled as represented) for non-binding questions. For a real decision/approval/sign-off, REACH the human on their channel(s) — email/Slack/GitHub/WhatsApp/SMS/voice/Telegram — collect their ACTUAL reply, and if you were spawned for another session call resume_session(session_id=<origin>, summary=<their verbatim answer + your read>). NEVER fabricate a binding human approval; if unreachable, return BLOCKED. Respect quiet_hours + channel preferences; don't blast all channels unless urgent and stated.",
+  "tools": [
+    { "type": "agent_toolset_20260401", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "handoff", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "gmail", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "slack", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "telegram", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "twilio", "default_config": { "permission_policy": { "type": "always_allow" } } },
+    { "type": "mcp_toolset", "mcp_server_name": "github", "default_config": { "permission_policy": { "type": "always_allow" } } }
+  ],
+  "mcp_servers": [
+    { "type": "url", "name": "handoff", "url": "${HANDOFF_MCP_URL}" },
+    { "type": "url", "name": "gmail", "url": "${GMAIL_MCP_URL}" },
+    { "type": "url", "name": "slack", "url": "${SLACK_MCP_URL}" },
+    { "type": "url", "name": "telegram", "url": "${TELEGRAM_MCP_URL}" },
+    { "type": "url", "name": "twilio", "url": "${TWILIO_MCP_URL}" },
+    { "type": "url", "name": "github", "url": "${GITHUB_MCP_URL}" }
+  ],
+  "services": { "github": "read", "k8s": "none", "cloud": "none" },
+  "metadata": { "role": "digital-persona", "tier": "persona", "bound_per_human_at_launch": "vault (channel creds) + metadata (identity/preferences)" }
+}

--- a/agent-templates/roles/mcp-engineer/role.json
+++ b/agent-templates/roles/mcp-engineer/role.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "mcp-engineer",
+  "extends": "_base",
+  "name": "FuzeInfra mcp-engineer",
+  "description": "Maintains the repo's stdio + remote SSE/streamable-HTTP MCP server against the frozen contract; triggered on merge to main to update the MCP contract and the live remote endpoint if the change requires it.",
+  "persona": ".claude/agents/mcp-engineer.md",
+  "environment": "cloud-mcp-engineer",
+  "system_append": "TRIGGER: runs on PR merged to main. First decide whether the merged change alters the MCP surface (endpoints / request-response schemas / auth / events). If NOT, report 'no MCP change' and stop. If it does, update BOTH the stdio server and the remote SSE/streamable-HTTP server from the frozen contract, keep the two transports in parity, validate with the MCP inspector, roll out the live remote endpoint via the repo's GitOps path, and open a PR.",
+  "services": { "github": "write", "k8s": "none", "cloud": "none" },
+  "metadata": { "role": "mcp-engineer", "channel": "mcp" }
+}

--- a/agent-templates/roles/openapi-maintainer/role.json
+++ b/agent-templates/roles/openapi-maintainer/role.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../schema/role-manifest.schema.json",
+  "role": "openapi-maintainer",
+  "extends": "_base",
+  "name": "FuzeInfra openapi-maintainer",
+  "description": "Designs + freezes the OpenAPI/Swagger contract per microservice (the gate the other agents build against) and keeps a live, up-to-date Swagger for every service and the repo-wide aggregate; generates the shared typed client and a mock server.",
+  "persona": ".claude/agents/openapi-maintainer.md",
+  "environment": "cloud-openapi-maintainer",
+  "system_append": "TRIGGER: design/freeze on request (the sequential contract gate); refresh on merge to main. On merge, regenerate + Spectral-lint each changed service's spec, regenerate the shared typed client, refresh the published Swagger UI / Redoc for each service and the repo-wide aggregate, and re-validate the mock (Prism). If the running API diverges from the frozen spec, open an issue/PR — a frozen spec is a versioned, PR'd artifact, never hand-drifted.",
+  "services": { "github": "write", "k8s": "none", "cloud": "none" },
+  "metadata": { "role": "openapi-maintainer", "channel": "contract" }
+}

--- a/agent-templates/sync/launch_session.py
+++ b/agent-templates/sync/launch_session.py
@@ -1,20 +1,31 @@
 #!/usr/bin/env python3
-"""Launch a single Managed-Agents session for a role (or the coordinator).
+"""Launch a single session for a role (or the coordinator) via the selected provider.
 
     python launch_session.py --role qa --prompt "list the tests you would run"
-    python launch_session.py --coordinator --prompt "review and deploy the dashboard"
+    AGENT_PROVIDER=anthropic python launch_session.py --coordinator --prompt "..."
 
-Binds the role's agent + environment, attaches vault credentials (for MCP auth),
-sends the prompt, streams output, and answers always_ask pauses via the approver
-(interactive by default; --auto allow|deny for headless). For a cross-environment
+Resolves the role's agent + environment from the synced id state, attaches vault +
+memory resources, sends the prompt, streams output, and answers always_ask pauses
+via the approver (interactive by default; --auto allow|deny for headless). The
+provider is chosen by AGENT_PROVIDER (default anthropic). For a cross-environment
 hand-forward chain use orchestration/relay.py instead.
 """
 import argparse
 import json
 import os
+import sys
 
-import common
-import driver
+HERE = os.path.dirname(os.path.abspath(__file__))          # sync/
+TEMPLATES_ROOT = os.path.dirname(HERE)                     # agent-templates/
+for _p in (TEMPLATES_ROOT, HERE):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import common  # noqa: E402  (state_dir)
+from providers import get_provider              # noqa: E402
+from providers.base import interactive_approver, auto_approver  # noqa: E402
+
+PROVIDER = get_provider()
 
 STATE = common.state_dir()
 AGENT_STATE = os.path.join(STATE, "agent-ids.json")
@@ -27,13 +38,13 @@ HANDOFF_INSTRUCTIONS = ("Shared cross-session handoff workspace. Read relevant /
 
 def _resolve(target):
     if not os.path.exists(AGENT_STATE):
-        raise SystemExit("Run sync_agents.py first (agent-ids.json missing).")
+        raise SystemExit("Run providers/provision.py first (agent-ids.json missing).")
     state = json.load(open(AGENT_STATE, encoding="utf-8"))
     if target not in state:
         raise SystemExit(f"Unknown target '{target}'. Known: {', '.join(state)}")
     entry = state[target]
     if not entry.get("environment_id"):
-        raise SystemExit(f"'{target}' has no environment_id — re-run sync_environments.py + sync_agents.py")
+        raise SystemExit(f"'{target}' has no environment_id — re-run providers/provision.py")
     return entry
 
 
@@ -45,16 +56,16 @@ def vault_ids(disabled):
 
 def memory_resources(disabled):
     """Attach every synced memory store (read_write) so the chain shares one
-    persistent handoff workspace. Attach-at-create only — resuming a session reuses
-    whatever it was created with."""
+    persistent handoff workspace. Attach-at-create only — resuming reuses whatever
+    the session was created with."""
     if disabled or not os.path.exists(MEMORY_STATE):
         return []
     ids = json.load(open(MEMORY_STATE, encoding="utf-8"))
-    return [driver.memory_resource(sid, "read_write", HANDOFF_INSTRUCTIONS) for sid in ids.values()]
+    return [PROVIDER.memory_resource(sid, "read_write", HANDOFF_INSTRUCTIONS) for sid in ids.values()]
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Launch a Managed-Agents role/coordinator session.")
+    ap = argparse.ArgumentParser(description="Launch a role/coordinator session via the selected provider.")
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--role", help="role key (frontend/backend/qa/devops)")
     g.add_argument("--coordinator", action="store_true", help="launch the routing coordinator")
@@ -66,13 +77,15 @@ def main():
 
     target = "coordinator" if args.coordinator else args.role
     entry = _resolve(target)
-    session = driver.create_session(entry["id"], entry["version"], entry["environment_id"],
-                                    vault_ids=vault_ids(args.no_vault),
-                                    resources=memory_resources(args.no_memory), title=f"launch:{target}")
-    print(f"session {session['id']}  (agent {entry['id']} v{entry['version']}, env {entry['environment_id']})\n")
+    session_id = PROVIDER.create_session(
+        entry["id"], entry["version"], entry["environment_id"],
+        vault_ids=vault_ids(args.no_vault),
+        memory_resources=memory_resources(args.no_memory), title=f"launch:{target}")
+    print(f"session {session_id}  (provider {PROVIDER.name}, agent {entry['id']} v{entry['version']}, "
+          f"env {entry['environment_id']})\n")
 
-    approver = driver.auto_approver(args.auto) if args.auto else driver.interactive_approver
-    driver.run_turn(session["id"], args.prompt, approver)
+    approver = auto_approver(args.auto) if args.auto else interactive_approver
+    PROVIDER.run_turn(session_id, args.prompt, approver)
     print("\n[done]")
 
 

--- a/agent-templates/vaults/examples/persona.json
+++ b/agent-templates/vaults/examples/persona.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../schema/vault.schema.json",
+  "_note": "TEMPLATE — copy to vaults/persona-<human>.json (top level) per person to provision it. One vault per human = their channel credentials. The digital-persona session binds this vault at launch (reach_human selects vault by display_name 'persona-<human>'). Secret values are ${ENV} refs, filled from that person's tokens; unresolved ones are skipped at sync.",
+  "display_name": "persona-jane",
+  "metadata": { "human": "jane", "email": "jane@fuzeone.example", "preferred_channels": "slack,email", "quiet_hours": "22:00-08:00" },
+  "credentials": [
+    {
+      "display_name": "Jane — Gmail",
+      "auth": { "type": "static_bearer", "mcp_server_url": "${GMAIL_MCP_URL}", "token": "${PERSONA_JANE_GMAIL_TOKEN}" }
+    },
+    {
+      "display_name": "Jane — Slack",
+      "auth": { "type": "static_bearer", "mcp_server_url": "${SLACK_MCP_URL}", "token": "${PERSONA_JANE_SLACK_TOKEN}" }
+    },
+    {
+      "display_name": "Jane — Telegram",
+      "auth": { "type": "static_bearer", "mcp_server_url": "${TELEGRAM_MCP_URL}", "token": "${PERSONA_JANE_TELEGRAM_TOKEN}" }
+    },
+    {
+      "display_name": "Jane — Twilio (WhatsApp/SMS/voice)",
+      "auth": { "type": "static_bearer", "mcp_server_url": "${TWILIO_MCP_URL}", "token": "${PERSONA_JANE_TWILIO_TOKEN}" }
+    },
+    {
+      "display_name": "Jane — GitHub",
+      "auth": { "type": "static_bearer", "mcp_server_url": "${GITHUB_MCP_URL}", "token": "${PERSONA_JANE_GITHUB_TOKEN}" }
+    }
+  ]
+}

--- a/agent-templates/worker/Dockerfile
+++ b/agent-templates/worker/Dockerfile
@@ -17,16 +17,13 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# --- base utilities + python + node 24 LTS (Node 20 is EOL April 2026) --------
-ARG NODE_MAJOR=24
+# --- base utilities + python -------------------------------------------------
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
       ca-certificates curl gnupg git jq unzip tar bash python3 python3-pip; \
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
-    apt-get install -y --no-install-recommends nodejs; \
     rm -rf /var/lib/apt/lists/*; \
-    node --version; python3 --version
+    python3 --version
 
 # --- GitHub CLI --------------------------------------------------------------
 RUN set -eux; \
@@ -58,11 +55,15 @@ RUN set -eux; arch="$(dpkg --print-architecture)"; \
     kubectl version --client; helm version; terraform version; kubeconform -v
 
 # --- Anthropic `ant` CLI (drives the self_hosted worker: `ant beta:worker`) ---
-# NOTE: confirm the exact install command against the Managed Agents quickstart
-# (https://platform.claude.com/docs/en/managed-agents/quickstart). Override the
-# package with --build-arg ANT_CLI_PKG=... if the name differs.
-ARG ANT_CLI_PKG=@anthropic-ai/cli
-RUN npm install -g "${ANT_CLI_PKG}" && (ant --version || true)
+# Released as a Go binary (NOT npm): github.com/anthropics/anthropic-cli/releases.
+# Bump with --build-arg ANT_VERSION=...
+ARG ANT_VERSION=1.15.0
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in amd64) A=amd64 ;; arm64) A=arm64 ;; *) A=amd64 ;; esac; \
+    curl -fsSL "https://github.com/anthropics/anthropic-cli/releases/download/v${ANT_VERSION}/ant_${ANT_VERSION}_linux_${A}.tar.gz" \
+      | tar -xz -C /usr/local/bin ant; \
+    chmod +x /usr/local/bin/ant; \
+    ant --version
 
 # --- destructive-op guard shims FIRST on PATH --------------------------------
 COPY bin/guards/ /opt/guards/


### PR DESCRIPTION
Adds six new role profiles + the **human-bridge** mechanism, all following the existing template pattern (persona `.md` → `system`, role manifest, environment, permission policies).

## New roles
- **mcp-engineer** — maintains the repo's **stdio + remote SSE/streamable-HTTP MCP server** against the frozen contract; **triggered on merge to main** to update it (and roll out the live remote endpoint via GitOps) if the change requires it.
- **openapi-maintainer** — designs + **freezes** the OpenAPI/Swagger contract (the gate) AND keeps the **live Swagger current** per service + repo-wide aggregate; generates the typed client + mock.
- **CEO / CTO / CFO / CISO** — executive **oversight** profiles (`cloud-exec`): read across GitHub/Jira/Slack (+Stripe for CFO), **delegate** via handoff, and escalate binding decisions to the human via `reach_human`. Never implement; money/prod actions are `always_ask` + human-approved.
- **digital-persona** — a **shared template representing one human**, bound at launch to their **vault** (email/Slack/GitHub/WhatsApp/Telegram/phone creds) + **metadata**. Answers as them for non-binding questions; for real decisions it **reaches the human on their channels**, collects the actual reply, and `resume_session`s the waiting work. One human = one launch (their vault), never a separate agent.

## Mechanism
- **`reach_human(human, message, reply_to_session_id, channels)`** on the handoff MCP server — spawns that human's digital persona (their vault) to get a **real** decision and relay it back. This is how an `always_ask`/human-needed pause is fulfilled across a person's real channels instead of stalling.
- 4 new environments (`cloud-mcp-engineer`, `cloud-openapi-maintainer`, `cloud-exec`, `cloud-digital-persona`), a per-human vault template (`vaults/examples/persona.json`), coordinator roster + routing updated, and a **guarded** merge-trigger workflow (`agent-on-merge.yml`, no-ops without the Managed-Agents secret).

## Verified offline
`validate.py` all manifests valid · `provision.py --dry-run` = **11 role agents + coordinator, 8 environments** · `agent_payload` renders every new persona. Live creation still needs a Managed-Agents key + the MCP URLs (`PORTING-TO-FUZEAGENT.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)