### PR TITLE
feat(agent-templates): auto-sync agent definitions to deployed providers on merge

### DIFF
--- a/.github/workflows/provision-sync.yml
+++ b/.github/workflows/provision-sync.yml
@@ -1,0 +1,44 @@
+name: Sync Managed Agents on merge
+
+# Reconcile agent-definition changes into their DEPLOYED counterparts (agents +
+# environments + vaults + memory) on every merge to main that touches a definition,
+# for each provider the fleet is deployed to. Idempotent: providers/provision.py only
+# updates an agent/environment when its config actually changed (a no-op otherwise), so
+# unchanged definitions are left alone and changed ones get a new version.
+#
+# Editing a persona (.claude/agents/*.md) changes the agent `system` -> re-synced.
+# Editing a role.json (tools/policies/mcp/env) -> re-synced. Adding a role -> created.
+# (Removals are NOT pruned here — archiving an orphaned agent is a separate, deliberate
+# step; provisioning only creates/updates.)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agent-templates/roles/**"
+      - "agent-templates/environments/**"
+      - "agent-templates/vaults/**"
+      - "agent-templates/memory/**"
+      - "agent-templates/coordinator/**"
+      - "agent-templates/providers/**"
+      - "agent-templates/sync/**"
+      - ".claude/agents/**"
+      - ".github/workflows/provision.yml"
+      - ".github/workflows/provision-sync.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Providers the agents are deployed to. Add "openai" / "hermes" once their
+        # providers/<name>/adapter.py is implemented (they are stubs today).
+        provider: [anthropic]
+    uses: ./.github/workflows/provision.yml
+    secrets: inherit
+    with:
+      provider: ${{ matrix.provider }}
+      dry_run: false

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,13 +1,19 @@
 name: Provision Managed Agents
 
-# One-click "get all agents ready on Anthropic". Creates/updates every environment +
-# agent (+ vaults, memory) idempotently for the selected provider and uploads the id
-# state (agent-ids/environment-ids/vault-ids/memory-ids.json) as an artifact — that
-# state becomes the `handoff-state` ConfigMap the handoff MCP server mounts.
+# Creates/updates every environment + agent (+ vaults, memory) idempotently for the
+# selected provider and uploads the id state (agent-ids/environment-ids/vault-ids/
+# memory-ids.json) as an artifact — that state becomes the `handoff-state` ConfigMap
+# the handoff MCP server mounts.
 #
-# Requires a **Managed-Agents-entitled** key as the MANAGED_AGENTS_API_KEY secret
-# (a Console API key with the managed-agents beta — NOT a Claude Code token) plus the
-# MCP server URLs / tokens the role manifests reference. Slated to move to FuzeAgent.
+# Two ways in:
+#   - workflow_dispatch: manual "provision everything now" (choose provider / dry-run).
+#   - workflow_call: reusable — provision-sync.yml calls this per provider on merge so
+#     agent-definition changes reconcile into their deployed counterparts automatically.
+#
+# Requires a Managed-Agents-entitled key as MANAGED_AGENTS_API_KEY (a Console API key
+# with the managed-agents beta — NOT a Claude Code token) + the MCP URLs/tokens the role
+# manifests reference. If the key is absent the job SKIPS (does not fail). Slated to
+# move to FuzeAgent.
 
 on:
   workflow_dispatch:
@@ -21,6 +27,14 @@ on:
         description: "Dry run (resolve + print only, no API calls)"
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      provider:
+        type: string
+        default: "anthropic"
+      dry_run:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -29,29 +43,36 @@ jobs:
   provision:
     runs-on: ubuntu-latest
     steps:
-      - name: Guard — Managed Agents key present (unless dry-run)
+      - name: Guard — Managed Agents key present
         id: guard
         env:
           MA_KEY: ${{ secrets.MANAGED_AGENTS_API_KEY }}
         run: |
           if [ "${{ inputs.dry_run }}" != "true" ] && [ -z "${MA_KEY}" ]; then
-            echo "::error::MANAGED_AGENTS_API_KEY secret is not set — cannot create agents. Add a Console API key with the managed-agents beta."
-            exit 1
+            echo "::notice::MANAGED_AGENTS_API_KEY not set — skipping provisioning for ${{ inputs.provider }}."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v7
+      - if: steps.guard.outputs.ok == 'true'
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - if: steps.guard.outputs.ok == 'true'
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - run: pip install --quiet jsonschema requests
+      - if: steps.guard.outputs.ok == 'true'
+        run: pip install --quiet jsonschema requests
 
       - name: Validate manifests
+        if: steps.guard.outputs.ok == 'true'
         working-directory: agent-templates
         run: python sync/validate.py
 
-      - name: Provision
+      - name: Provision (${{ inputs.provider }})
+        if: steps.guard.outputs.ok == 'true'
         working-directory: agent-templates
         env:
           ANTHROPIC_API_KEY: ${{ secrets.MANAGED_AGENTS_API_KEY }}
@@ -77,9 +98,9 @@ jobs:
           fi
 
       - name: Upload id state (for the handoff-state ConfigMap)
-        if: ${{ inputs.dry_run != true }}
+        if: steps.guard.outputs.ok == 'true' && inputs.dry_run != true
         uses: actions/upload-artifact@v4
         with:
-          name: managed-agents-state
+          name: managed-agents-state-${{ inputs.provider }}
           path: agent-templates/sync/.state/*.json
           if-no-files-found: warn

--- a/agent-templates/orchestration/handoff_mcp/deploy/README.md
+++ b/agent-templates/orchestration/handoff_mcp/deploy/README.md
@@ -26,7 +26,7 @@ the gate). **Prod is GitOps — never `kubectl apply` by hand; land everything v
    (Synced by the existing `fuzeinfra-sealed-secrets` Argo app.)
 
 3. **Populate the id-state** and **flip the gate** — in the SAME PR as the sealed secret:
-   - download the `managed-agents-state` artifact from the latest **Provision Managed Agents** run (or run `providers/provision.py` locally) → commit its `*.json` into `helm/fuzeinfra/files/handoff-state/`.
+   - download the `managed-agents-state-anthropic` artifact from the latest **Provision Managed Agents** / **Sync Managed Agents on merge** run (or run `providers/provision.py` locally) → commit its `*.json` into `helm/fuzeinfra/files/handoff-state/`.
    - set `handoffMcp.enabled: true` in `helm/fuzeinfra/values-contabo.yaml`.
    - **verify GHCR visibility**: make `ghcr.io/izzywdev/fuzeinfra/agent-handoff` public, or set `handoffMcp.imagePullSecrets` + add a ghcr pull secret to `fuzeinfra` (see `argocd/cluster-config/ghcr-pull-secret-*.yaml`).
    Merge → Argo syncs the Deployment/Service/Ingress/ConfigMap.

--- a/agent-templates/providers/README.md
+++ b/agent-templates/providers/README.md
@@ -48,6 +48,18 @@ python providers/provision.py --provider anthropic             # create/update l
 `provision` creates environments + agents (+ vaults + memory) idempotently and writes the id
 state (`environment-ids/agent-ids/vault-ids/memory-ids.json`) under the state dir.
 
+## Auto-sync on merge
+
+Agent-definition changes reconcile into their **deployed** counterparts automatically.
+`.github/workflows/provision-sync.yml` triggers on every merge to `main` that touches a
+definition (`roles/`, `environments/`, `vaults/`, `memory/`, `coordinator/`, `providers/`,
+`sync/`, or the personas in `.claude/agents/`) and calls the reusable `provision.yml` **per
+provider** (matrix — currently `[anthropic]`; add `openai`/`hermes` when implemented). Because
+`provision.py` only updates an agent/environment when its config actually changed, unchanged
+definitions are no-ops and changed ones get a new version. Editing a persona `.md` re-syncs the
+agent's `system`; editing a `role.json` re-syncs its tools/policies/mcp/env; a new role is
+created. (Removed roles are **not** pruned — archiving an orphaned agent is a separate step.)
+
 ## Not yet routed
 
 The handoff MCP server (`orchestration/handoff_mcp/server.py`) still calls the Anthropic

--- a/helm/fuzeinfra/files/handoff-state/README.md
+++ b/helm/fuzeinfra/files/handoff-state/README.md
@@ -1,3 +1,3 @@
 This directory holds the handoff MCP id-state as ConfigMap source (helm/fuzeinfra/templates/handoff-mcp.yaml renders `handoff-state` from *.json here).
 
-These are NON-secret ids (agent/env/vault/memory), produced by the provision job (agent-templates/providers/provision.py -> sync/.state/*.json). Populate them (download the "managed-agents-state" artifact from the Provision Managed Agents workflow, or run provision locally) and commit them here in the SAME PR that flips handoffMcp.enabled=true and lands deploy/sealed-secrets/handoff-mcp-secret.yaml.
+These are NON-secret ids (agent/env/vault/memory), produced by the provision job (agent-templates/providers/provision.py -> sync/.state/*.json). Populate them (download the "managed-agents-state-anthropic" artifact from the Provision / Sync Managed Agents workflow, or run provision locally) and commit them here in the SAME PR that flips handoffMcp.enabled=true and lands deploy/sealed-secrets/handoff-mcp-secret.yaml.


### PR DESCRIPTION
Closes the gap: agent-definition changes now reconcile into their **deployed** Managed-Agents counterparts automatically, per provider.

- **`provision.yml`** is now a reusable (`workflow_call`) engine (still manually dispatchable), with a **skip-not-fail** guard (a missing `MANAGED_AGENTS_API_KEY` never reds a merge) and a per-provider artifact name.
- **`provision-sync.yml`** triggers on every merge to `main` that touches an agent definition (`roles/`, `environments/`, `vaults/`, `memory/`, `coordinator/`, `providers/`, `sync/`, or the personas in `.claude/agents/`) and calls `provision.py` in a **provider matrix** (currently `[anthropic]`; add `openai`/`hermes` when their adapters exist).

Idempotent: `provision.py` only updates an agent/environment when its config actually changed — unchanged defs are no-ops, changed ones get a new version. Editing a persona `.md` re-syncs the agent's `system`; editing a `role.json` re-syncs its tools/policies/mcp/env; a new role is created. (Removed roles are **not** pruned — archiving an orphaned agent is a separate step.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)