### PR TITLE
feat(governance): governance-sync caller + roles drift + read-key helper

### DIFF
--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -18,8 +18,20 @@
   "roles": {
     "source": "agent-templates/",
     "runtime": "managed-agents",
-    "defined": ["frontend", "backend", "qa", "devops", "coordinator"],
-    "environments": ["cloud-frontend", "cloud-backend", "cloud-qa", "selfhosted-devops"]
+    "provider": "anthropic",
+    "defined": [
+      "backend", "frontend", "qa", "devops",
+      "openapi-maintainer", "mcp-engineer", "mobile-engineer",
+      "product-manager", "ux-designer",
+      "sales-rep", "marketing", "support-rep",
+      "ceo", "cto", "cfo", "ciso", "digital-persona"
+    ],
+    "environments": [
+      "cloud-backend", "cloud-frontend", "cloud-qa", "selfhosted-devops",
+      "cloud-openapi-maintainer", "cloud-mcp-engineer", "cloud-mobile-engineer",
+      "cloud-product", "cloud-gtm", "cloud-exec", "cloud-digital-persona"
+    ],
+    "coordinators": ["coordinator", "exec-coordinator"]
   },
   "hardening": {
     "ruleset": true,

--- a/.github/workflows/governance-nightly.yml
+++ b/.github/workflows/governance-nightly.yml
@@ -46,9 +46,12 @@ jobs:
             3. OPEN ISSUES — drive each to a concrete next step: close ones demonstrably resolved (with
                evidence), open a PR or delegate small actionable ones via an @claude comment with a STATE
                block, and summarize decision-needing ones for the human.
-            4. DRIFT — compare .claude/agents + CLAUDE.md + the workflow stack against the expectation in
-               .fuze/manifest.json and the FuzeSDLC canonical; open a fix PR for mechanical drift, flag
-               judgment calls.
+            4. DRIFT — compare .claude/agents + CLAUDE.md + the workflow stack AND the managed-agents
+               ROLES framework (agent-templates/{schema,roles/_base,sync,providers} + the `roles` block
+               in .fuze/manifest.json vs the actual agent-templates/roles|environments|coordinator) against
+               the expectation in .fuze/manifest.json and the FuzeSDLC canonical; open a fix PR for
+               mechanical drift, flag judgment calls. (The deterministic governance-sync check is the
+               per-PR gate for the framework files; this nightly is the floor + catches manifest/roster drift.)
 
             Then open or UPDATE a single issue titled "Governance reconciliation — <today's date>"
             (label: governance) with: branch actions, per-PR blocker+next-action, per-issue disposition,

--- a/.github/workflows/governance-sync.yml
+++ b/.github/workflows/governance-sync.yml
@@ -1,0 +1,23 @@
+name: Governance Sync
+
+# Per-repo caller for the canonical, CI-time governance reconciliation (FuzeSDLC).
+# On every PR it fetches the FuzeSDLC canonical at this repo's baselineRef (via the
+# read-only FUZESDLC_DEPLOY_KEY secret) and reconciles this repo's managed files to it —
+# committing agent/framework drift back to the PR branch, failing on drift the token
+# cannot auto-fix. Keeps NO PR merging against stale policy.
+#
+# Prereqs: FuzeSDLC PR #41 merged (the reusable workflow) + the FUZESDLC_DEPLOY_KEY repo
+# secret set (scripts/setup-fuzesdlc-deploy-key.sh). Absent key -> the reusable workflow
+# SKIPS (never fails the PR), so this can land ahead of the key.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  governance-sync:
+    uses: izzywdev/FuzeSDLC/.github/workflows/governance-sync.yml@main
+    secrets:
+      FUZESDLC_DEPLOY_KEY: ${{ secrets.FUZESDLC_DEPLOY_KEY }}

--- a/agent-templates/PROPAGATION.md
+++ b/agent-templates/PROPAGATION.md
@@ -1,0 +1,52 @@
+# Propagation — how these agent-templates spread across the Fuze/Mendys family
+
+FuzeInfra was the **prototype home** (richest, cluster-capable example: 17 roles, 11
+environments, exec + persona + GTM tiers, secured handoff MCP on Contabo k3s). The generic
+**pattern** now lives in the **FuzeSDLC L0 baseline** and the orchestration **runtime** moves
+to **FuzeAgent**. This file records the split and the propagation mechanics.
+
+## The split
+
+| Layer | Canonical home | What |
+|---|---|---|
+| **Framework / pattern** | **FuzeSDLC** `agent-templates/{schema,roles/_base,sync,providers}` | schemas, genericized `_base`, REST client + manifest loader + validate, provider seam (`anthropic` ref + `openai`/`hermes` stubs + `provision.py`) |
+| **Concrete definitions** | **this repo** `agent-templates/{roles,environments,vaults,memory,coordinator}` | the 17 roles / 11 environments / vaults / coordinators — declared in `.fuze/manifest.json` `roles` |
+| **Orchestration runtime** | **FuzeAgent** | the deployed handoff MCP server, `relay.py`, the self-hosted worker image + its Contabo/CF deploy — see `PORTING-TO-FUZEAGENT.md` |
+
+FuzeInfra is now a **consumer** of the framework: its `schema/roles/_base/sync/providers`
+files are canonical in FuzeSDLC and are reconciled to it (see below); its concrete roles are
+its own.
+
+## How updates propagate (CI-time pull, not fan-out)
+
+1. **`governance-sync.yml`** (per-repo caller → FuzeSDLC reusable): on every PR, fetch the
+   FuzeSDLC canonical at this repo's `baselineRef` via the read-only **`FUZESDLC_DEPLOY_KEY`**,
+   reconcile the framework files (commit-back / fail-with-diff). No PR merges against stale
+   policy. Deterministic — the hard per-PR gate.
+2. **`governance-nightly.yml`**: the floor — LLM-driven nightly drift sweep that also covers
+   the `roles` framework + roster (manifest `roles` vs the actual `roles`/`environments`/
+   `coordinator` on disk).
+3. **`provision-sync.yml`** (per-repo caller → FuzeSDLC reusable `provision.yml`): on merges
+   to `main` touching a definition, reconcile agents/environments/vaults/memory into their
+   deployed counterparts (idempotent; never prunes).
+
+## Onboarding another repo
+
+Clone it and run the **incremental** bootstrapper from FuzeSDLC:
+
+```bash
+scripts/sdlc-bootstrap.sh --canonical <FuzeSDLC-checkout> --repo . --set-secret
+```
+
+It stamps the workflow stack incl. the `governance-sync` caller (ref-pinned to `baselineRef`),
+the agent subset, and — if the manifest declares `roles` — the framework + `provision-sync`
+caller, and sets `FUZESDLC_DEPLOY_KEY`. Re-running on an already-onboarded repo adds only the
+new pieces. `mendys*` repos are ordinary consumers (same path).
+
+## Credentials
+
+One **read-only** key (`FUZESDLC_DEPLOY_KEY`) grants read to FuzeSDLC only — provisioned +
+distributed by `scripts/setup-fuzesdlc-deploy-key.sh` (run by a human; it modifies access
+controls). No cross-repo write credentials anywhere.
+
+> Tracking: FuzeSDLC #38 (framework lift) / FuzeSDLC PR #41 (framework + governance-sync).

--- a/scripts/setup-fuzesdlc-deploy-key.sh
+++ b/scripts/setup-fuzesdlc-deploy-key.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Provision the ONE read-only FuzeSDLC deploy key and distribute it to consuming repos.
+#
+# ⚠️  RUN THIS YOURSELF — it modifies access controls (registers a deploy key on FuzeSDLC)
+#     and sets repo secrets. It is intentionally NOT run by automation.
+#
+# Trust model (min-privilege, max-decoupling): a SINGLE read-only deploy key grants read to
+# izzywdev/FuzeSDLC ONLY. Its private half is distributed as the `FUZESDLC_DEPLOY_KEY` secret
+# to each consuming repo, whose governance-sync.yml uses it to fetch the FuzeSDLC canonical.
+# No repo ever gets write to another; each repo reconciles with its OWN GITHUB_TOKEN + this
+# shared read key. FuzeSDLC never needs write to any consumer (no fan-out).
+#
+# Prereqs: `gh` authenticated as an owner/admin of izzywdev/FuzeSDLC and the target repos;
+# `ssh-keygen` available. Also enable, once, in FuzeSDLC settings → Actions → General →
+# "Access": *Allow repositories owned by izzywdev to use this repository's workflows* (so the
+# consumers' `uses: izzywdev/FuzeSDLC/...` resolves for a private FuzeSDLC).
+#
+# Usage:
+#   scripts/setup-fuzesdlc-deploy-key.sh <repo> [<repo> ...]
+#   e.g. scripts/setup-fuzesdlc-deploy-key.sh izzywdev/FuzeInfra izzywdev/FuzePicker
+set -euo pipefail
+
+SDLC_REPO="izzywdev/FuzeSDLC"
+[ $# -ge 1 ] || { echo "usage: $0 <owner/repo> [<owner/repo> ...]"; exit 2; }
+
+command -v gh >/dev/null || { echo "gh CLI required"; exit 1; }
+command -v ssh-keygen >/dev/null || { echo "ssh-keygen required"; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+key="$tmp/fuzesdlc_ro"
+ssh-keygen -t ed25519 -N "" -C "fuzesdlc-governance-sync-ro" -f "$key" >/dev/null
+echo ">> generated ephemeral ed25519 keypair (private half never leaves this run except as repo secrets)"
+
+# 1) Register the PUBLIC half as a READ-ONLY deploy key on FuzeSDLC.
+if gh api "repos/$SDLC_REPO/keys" --jq '.[].title' 2>/dev/null | grep -qx "governance-sync-ro"; then
+  echo ">> a 'governance-sync-ro' deploy key already exists on $SDLC_REPO."
+  echo "   To rotate: delete it in FuzeSDLC → Settings → Deploy keys, then re-run this script."
+else
+  gh api "repos/$SDLC_REPO/keys" -f title="governance-sync-ro" -f key="$(cat "$key.pub")" -F read_only=true >/dev/null
+  echo ">> registered READ-ONLY deploy key 'governance-sync-ro' on $SDLC_REPO"
+fi
+
+# 2) Distribute the PRIVATE half as FUZESDLC_DEPLOY_KEY to each consuming repo.
+for repo in "$@"; do
+  gh secret set FUZESDLC_DEPLOY_KEY -R "$repo" < "$key"
+  echo ">> set FUZESDLC_DEPLOY_KEY on $repo"
+done
+
+echo ">> DONE. Governance-sync on the target repos can now fetch the FuzeSDLC canonical."
+echo "   Verify (min-privilege): the key reads $SDLC_REPO only — it cannot write, and cannot read another repo."


### PR DESCRIPTION
Makes FuzeInfra the **first consumer** of the FuzeSDLC agent-framework propagation ([FuzeSDLC#41](https://github.com/izzywdev/FuzeSDLC/pull/41)). FuzeInfra keeps its concrete roles/personas but consumes the **framework** (`schema`/`roles/_base`/`sync`/`providers`) from the L0 baseline, reconciled at CI time.

## Changes
- **`.github/workflows/governance-sync.yml`** — per-PR caller of the FuzeSDLC reusable `governance-sync` (`@main`). Reconciles managed files to the canonical via the read-only `FUZESDLC_DEPLOY_KEY`; **skips cleanly until that key is set** (won't break CI).
- **`.fuze/manifest.json`** — `roles` block made accurate + schema-conformant: full roster (**17 defined, 11 environments, 2 coordinators**) + `provider: anthropic`.
- **`governance-nightly.yml`** — drift step now also covers the managed-agents **roles framework + roster** (manifest `roles` vs the actual `roles`/`environments`/`coordinator` on disk).
- **`scripts/setup-fuzesdlc-deploy-key.sh`** — human-run helper to provision the **one** read-only FuzeSDLC deploy key and distribute it as `FUZESDLC_DEPLOY_KEY` (min-privilege; it modifies access controls, so a person runs it, not automation).
- **`agent-templates/PROPAGATION.md`** — documents the split (pattern→FuzeSDLC, runtime→FuzeAgent) + the CI-time-pull propagation mechanics.

## Prereqs / sequencing
Gated on **FuzeSDLC#41 merged** (the reusable workflow must exist on `@main`) + the **deploy key set** (`scripts/setup-fuzesdlc-deploy-key.sh`). Both are prereqs; the caller **no-ops until then**, so this is safe to land first.

Also enable once in FuzeSDLC → Settings → Actions → "Allow repositories owned by izzywdev to use this repository's workflows" so the `uses:` resolves for the private FuzeSDLC.