### PR TITLE
fix(governance-sync): use the self-contained shim (stop reddening every PR)

### DIFF
--- a/.github/workflows/governance-sync.yml
+++ b/.github/workflows/governance-sync.yml
@@ -1,23 +1,108 @@
 name: Governance Sync
 
-# Per-repo caller for the canonical, CI-time governance reconciliation (FuzeSDLC).
-# On every PR it fetches the FuzeSDLC canonical at this repo's baselineRef (via the
-# read-only FUZESDLC_DEPLOY_KEY secret) and reconciles this repo's managed files to it —
-# committing agent/framework drift back to the PR branch, failing on drift the token
-# cannot auto-fix. Keeps NO PR merging against stale policy.
+# Per-repo, CI-time governance reconciliation (stamped by sdlc-bootstrap).
 #
-# Prereqs: FuzeSDLC PR #41 merged (the reusable workflow) + the FUZESDLC_DEPLOY_KEY repo
-# secret set (scripts/setup-fuzesdlc-deploy-key.sh). Absent key -> the reusable workflow
-# SKIPS (never fails the PR), so this can land ahead of the key.
+# SELF-CONTAINED BY DESIGN — this deliberately does NOT `uses:` a reusable workflow from
+# FuzeSDLC. A cross-repo `uses:` against a PRIVATE FuzeSDLC fails to RESOLVE unless the hub's
+# Actions "access" setting allows it, and an unresolvable `uses:` fails the whole RUN before
+# any job (no `continue-on-error` can save it) => a red X on every PR in every repo. Fetching
+# the canonical with the read-only deploy key instead keeps the fleet independent of that org
+# setting. The RECONCILIATION LOGIC still lives in the hub (scripts/governance_sync.py,
+# fetched below) — only this thin shim is per-repo.
+#
+# Behaviour: fetch the FuzeSDLC canonical at this repo's baselineRef, reconcile the managed
+# files (the manifest's agent subset + the agent-templates FRAMEWORK), commit agent/framework
+# drift back to the PR branch, and fail-with-diff on drift the token cannot push
+# (.github/workflows/** or a fork PR). Concrete role/env/vault defs are never touched.
+#
+# No FUZESDLC_DEPLOY_KEY secret -> SKIPS with a notice (never red). Safe to land before the
+# key is distributed.
 
 on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: write   # commit reconciled managed files back to the PR branch
 
 jobs:
   governance-sync:
-    uses: izzywdev/FuzeSDLC/.github/workflows/governance-sync.yml@main
-    secrets:
-      FUZESDLC_DEPLOY_KEY: ${{ secrets.FUZESDLC_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (PR head)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Skip if not onboarded or key absent
+        id: guard
+        env:
+          KEY: ${{ secrets.FUZESDLC_DEPLOY_KEY }}
+        run: |
+          if [ ! -f .fuze/manifest.json ]; then
+            echo "::notice::no .fuze/manifest.json — repo not onboarded; skipping."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$KEY" ]; then
+            echo "::notice::FUZESDLC_DEPLOY_KEY not set — cannot fetch the canonical; skipping (set the read-only key to enable)."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve baselineRef
+        id: ref
+        if: steps.guard.outputs.ok == 'true'
+        run: |
+          BR=$(python3 -c "import json;print(json.load(open('.fuze/manifest.json')).get('baselineRef','main'))")
+          echo "ref=${BR:-main}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch FuzeSDLC canonical (read-only key)
+        if: steps.guard.outputs.ok == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: izzywdev/FuzeSDLC
+          ref: ${{ steps.ref.outputs.ref }}
+          ssh-key: ${{ secrets.FUZESDLC_DEPLOY_KEY }}
+          path: .fuzesdlc-canonical
+
+      - uses: actions/setup-python@v5
+        if: steps.guard.outputs.ok == 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Reconcile managed files
+        if: steps.guard.outputs.ok == 'true'
+        run: |
+          python3 .fuzesdlc-canonical/scripts/governance_sync.py \
+            --canonical .fuzesdlc-canonical --repo . --write --report .governance-sync-report.json
+
+      - name: Commit-back or fail-with-diff
+        if: steps.guard.outputs.ok == 'true'
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          report=.governance-sync-report.json
+          get() { python3 -c "import json;print(len(json.load(open('$report'))['$1']))"; }
+          committable=$(get committable); workflows=$(get workflows); missing=$(get missing)
+          rm -f "$report"
+          rm -rf .fuzesdlc-canonical
+          if [ "$committable" != "0" ]; then
+            if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+              echo "::error::$committable managed file(s) drifted but this is a fork PR — cannot commit back. Run scripts/sdlc-bootstrap.sh and push."
+              git --no-pager diff; exit 1
+            fi
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore(governance): reconcile managed files to FuzeSDLC ${{ steps.ref.outputs.ref }} [skip ci]"
+            git push origin "HEAD:${HEAD_REF}"
+            echo "::notice::Reconciled and pushed $committable managed file(s) to ${HEAD_REF}."
+          fi
+          if [ "$workflows" != "0" ] || [ "$missing" != "0" ]; then
+            echo "::error::Governance drift the token cannot auto-fix — $workflows workflow file(s), $missing missing file(s). Run scripts/sdlc-bootstrap.sh and open a PR."
+            git --no-pager diff; exit 1
+          fi
+          echo "Governance in sync with FuzeSDLC ${{ steps.ref.outputs.ref }}."


### PR DESCRIPTION
The caller added in #283 used `uses: izzywdev/FuzeSDLC/.github/workflows/governance-sync.yml@main`. FuzeSDLC is **private** with Actions `access_level=none`, so that ref **cannot resolve** — which fails the **whole run** before any job (no `continue-on-error` can save it), putting a **red X on every FuzeInfra PR**. It also never registered as a named check, which is why it slipped past `gh pr checks` when #283 was reported green.

Replaced with the canonical **self-contained shim** ([FuzeSDLC#42](https://github.com/izzywdev/FuzeSDLC/pull/42), merged `2cc4a24`): it fetches the canonical with the read-only `FUZESDLC_DEPLOY_KEY` and runs the hub's `scripts/governance_sync.py`. **The logic still lives in the hub** — only the thin shim is per-repo.

Result: **no cross-repo `uses:` anywhere in FuzeInfra's workflows**, so no run-level resolution failure is possible, and the `access_level` flip is no longer a prerequisite. With no key set it **skips with a notice** instead of failing.