### PR TITLE
chore(governance): pin baselineRef to the v1 standard tag

### DIFF
--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -3,7 +3,7 @@
   "class": "oss-public",
   "tier": "infra",
   "expert": "fuzeinfra-expert",
-  "baselineRef": "main",
+  "baselineRef": "v1",
   "agents": [
     "contract-designer",
     "backend-engineer",


### PR DESCRIPTION
Was `main` — every merge to FuzeSDLC main propagated here on the next PR **with no version boundary**, so an unreviewed or breaking policy change would land automatically, and nothing recorded which standard this repo was actually on.

Now pins the **moving major tag `v1`** (FuzeSDLC `v1.0.0` @ `87f9ad3`):
- **Compatible updates still arrive automatically** — FuzeSDLC re-points `v1`, this repo reconciles on its next PR. No fan-out.
- **Breaking changes cannot silently land** — they become `v2`, opted into per repo.
- `baselineRef` is now an auditable answer to *which standard is this repo on*.

See FuzeSDLC `governance/versioning.md` §5.