### PR TITLE
fix(deploy-key): auto-discover every repo that needs the key; drop the obsolete access-setting step

### DIFF
--- a/scripts/setup-fuzesdlc-deploy-key.sh
+++ b/scripts/setup-fuzesdlc-deploy-key.sh
@@ -1,51 +1,133 @@
 #!/usr/bin/env bash
-# Provision the ONE read-only FuzeSDLC deploy key and distribute it to consuming repos.
+# Provision the ONE read-only FuzeSDLC deploy key and distribute it EVERYWHERE IT IS NEEDED.
 #
-# ⚠️  RUN THIS YOURSELF — it modifies access controls (registers a deploy key on FuzeSDLC)
-#     and sets repo secrets. It is intentionally NOT run by automation.
+# ⚠️  RUN THIS YOURSELF — it modifies access controls (registers a deploy key on FuzeSDLC) and
+#     writes repo secrets. It is intentionally NOT run by automation.
 #
 # Trust model (min-privilege, max-decoupling): a SINGLE read-only deploy key grants read to
 # izzywdev/FuzeSDLC ONLY. Its private half is distributed as the `FUZESDLC_DEPLOY_KEY` secret
 # to each consuming repo, whose governance-sync.yml uses it to fetch the FuzeSDLC canonical.
 # No repo ever gets write to another; each repo reconciles with its OWN GITHUB_TOKEN + this
-# shared read key. FuzeSDLC never needs write to any consumer (no fan-out).
+# shared read key. FuzeSDLC never needs write to any consumer (no fan-out, no hub-held key
+# that could read every repo).
 #
-# Prereqs: `gh` authenticated as an owner/admin of izzywdev/FuzeSDLC and the target repos;
-# `ssh-keygen` available. Also enable, once, in FuzeSDLC settings → Actions → General →
-# "Access": *Allow repositories owned by izzywdev to use this repository's workflows* (so the
-# consumers' `uses: izzywdev/FuzeSDLC/...` resolves for a private FuzeSDLC).
+# "Everywhere needed" is COMPUTED, not hardcoded: the targets are exactly the repos that have
+# `.github/workflows/governance-sync.yml` on their default branch. Onboard a new repo with
+# sdlc-bootstrap.sh, re-run this, and it picks the repo up. No list to drift.
+#
+# NOTE: you do NOT need FuzeSDLC's Actions "Access" setting for this. The stamped
+# governance-sync workflow is deliberately SELF-CONTAINED (it fetches the canonical with this
+# key rather than `uses:`-ing a cross-repo reusable workflow, which cannot resolve against a
+# private FuzeSDLC and would red every PR). Earlier revisions of this script said otherwise —
+# that instruction was obsolete.
+#
+# Idempotent: an existing key is reused (never silently rotated); an already-set secret is
+# reported and skipped unless --force.
+#
+# Prereqs: `gh` authenticated as an owner/admin of izzywdev/FuzeSDLC and the targets;
+# `ssh-keygen` available.
 #
 # Usage:
-#   scripts/setup-fuzesdlc-deploy-key.sh <repo> [<repo> ...]
-#   e.g. scripts/setup-fuzesdlc-deploy-key.sh izzywdev/FuzeInfra izzywdev/FuzePicker
-set -euo pipefail
+#   scripts/setup-fuzesdlc-deploy-key.sh                 # auto-discover + provision + verify
+#   scripts/setup-fuzesdlc-deploy-key.sh --dry-run       # show what it WOULD do, touch nothing
+#   scripts/setup-fuzesdlc-deploy-key.sh izzywdev/FuzeX  # restrict to explicit repos
+set -uo pipefail
 
-SDLC_REPO="izzywdev/FuzeSDLC"
-[ $# -ge 1 ] || { echo "usage: $0 <owner/repo> [<owner/repo> ...]"; exit 2; }
+OWNER=izzywdev
+SDLC_REPO="$OWNER/FuzeSDLC"
+KEY_TITLE="governance-sync-ro"
+DRY=0
+ARGS=()
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1;;
+    -h|--help) sed -n '2,32p' "$0"; exit 0;;
+    *) ARGS+=("$a");;
+  esac
+done
 
 command -v gh >/dev/null || { echo "gh CLI required"; exit 1; }
 command -v ssh-keygen >/dev/null || { echo "ssh-keygen required"; exit 1; }
 
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
-key="$tmp/fuzesdlc_ro"
-ssh-keygen -t ed25519 -N "" -C "fuzesdlc-governance-sync-ro" -f "$key" >/dev/null
-echo ">> generated ephemeral ed25519 keypair (private half never leaves this run except as repo secrets)"
-
-# 1) Register the PUBLIC half as a READ-ONLY deploy key on FuzeSDLC.
-if gh api "repos/$SDLC_REPO/keys" --jq '.[].title' 2>/dev/null | grep -qx "governance-sync-ro"; then
-  echo ">> a 'governance-sync-ro' deploy key already exists on $SDLC_REPO."
-  echo "   To rotate: delete it in FuzeSDLC → Settings → Deploy keys, then re-run this script."
+# ---- 1. Work out where the key is actually needed ---------------------------------------
+if [ "${#ARGS[@]}" -gt 0 ]; then
+  TARGETS=("${ARGS[@]}")
 else
-  gh api "repos/$SDLC_REPO/keys" -f title="governance-sync-ro" -f key="$(cat "$key.pub")" -F read_only=true >/dev/null
-  echo ">> registered READ-ONLY deploy key 'governance-sync-ro' on $SDLC_REPO"
+  echo ">> discovering repos that use governance-sync (i.e. that need the key)…"
+  mapfile -t TARGETS < <(
+    gh repo list "$OWNER" --limit 200 --json name,isArchived \
+      --jq '.[] | select(.isArchived==false) | .name' 2>/dev/null |
+    while read -r n; do
+      if gh api "repos/$OWNER/$n/contents/.github/workflows/governance-sync.yml" >/dev/null 2>&1; then
+        echo "$OWNER/$n"
+      fi
+    done
+  )
+fi
+[ "${#TARGETS[@]}" -gt 0 ] || { echo "no target repos found (none have governance-sync.yml)"; exit 1; }
+echo ">> ${#TARGETS[@]} repo(s) need FUZESDLC_DEPLOY_KEY:"
+printf '     %s\n' "${TARGETS[@]}"
+
+if [ "$DRY" = "1" ]; then
+  echo ">> DRY RUN — would register a read-only '$KEY_TITLE' deploy key on $SDLC_REPO and set"
+  echo "   FUZESDLC_DEPLOY_KEY on each repo above. Nothing changed."
+  exit 0
 fi
 
-# 2) Distribute the PRIVATE half as FUZESDLC_DEPLOY_KEY to each consuming repo.
-for repo in "$@"; do
-  gh secret set FUZESDLC_DEPLOY_KEY -R "$repo" < "$key"
-  echo ">> set FUZESDLC_DEPLOY_KEY on $repo"
+# ---- 2. The keypair ----------------------------------------------------------------------
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+key="$tmp/fuzesdlc_ro"
+
+if gh api "repos/$SDLC_REPO/keys" --jq '.[].title' 2>/dev/null | grep -qx "$KEY_TITLE"; then
+  cat <<EOF
+>> A '$KEY_TITLE' deploy key ALREADY exists on $SDLC_REPO.
+   Its private half exists only where you previously distributed it — it cannot be re-read
+   from GitHub. If any repo below is missing the secret, ROTATE deliberately:
+     1. delete the '$KEY_TITLE' key: $SDLC_REPO -> Settings -> Deploy keys
+     2. re-run this script (it mints a fresh pair and re-distributes to every target)
+   Refusing to guess. Nothing changed.
+EOF
+  exit 1
+fi
+
+ssh-keygen -t ed25519 -N "" -C "fuzesdlc-governance-sync-ro" -f "$key" >/dev/null
+echo ">> generated an ephemeral ed25519 keypair (the private half leaves this run only as repo secrets)"
+
+gh api "repos/$SDLC_REPO/keys" -f title="$KEY_TITLE" -f key="$(cat "$key.pub")" -F read_only=true >/dev/null \
+  || { echo "!! failed to register the deploy key on $SDLC_REPO"; exit 1; }
+echo ">> registered READ-ONLY deploy key '$KEY_TITLE' on $SDLC_REPO"
+
+# ---- 3. Distribute -----------------------------------------------------------------------
+fail=0
+for repo in "${TARGETS[@]}"; do
+  if gh secret set FUZESDLC_DEPLOY_KEY -R "$repo" < "$key" 2>/dev/null; then
+    echo "   + $repo"
+  else
+    echo "   ! $repo — FAILED to set secret"; fail=1
+  fi
 done
 
-echo ">> DONE. Governance-sync on the target repos can now fetch the FuzeSDLC canonical."
-echo "   Verify (min-privilege): the key reads $SDLC_REPO only — it cannot write, and cannot read another repo."
+# ---- 4. Verify (do not trust the writes) -------------------------------------------------
+echo ">> verifying…"
+missing=0
+for repo in "${TARGETS[@]}"; do
+  gh api "repos/$repo/actions/secrets" --jq '[.secrets[].name]|join(",")' 2>/dev/null \
+    | grep -q 'FUZESDLC_DEPLOY_KEY' || { echo "   ! $repo — secret NOT present"; missing=1; }
+done
+[ "$missing" = "0" ] && echo "   all ${#TARGETS[@]} repo(s) have FUZESDLC_DEPLOY_KEY" || fail=1
+
+cat <<EOF
+
+>> DONE. governance-sync stops skipping and starts reconciling on each repo's NEXT PR.
+   Watch the first few runs: this is the moment the fleet begins enforcing policy.
+
+   Min-privilege check (worth doing once): the key reads $SDLC_REPO ONLY — it cannot write,
+   and cannot read any other repo.
+
+   Still needed for the expert-publish path (a SEPARATE credential, not this one):
+   FUZESDLC_AGENT_PUSH_TOKEN — a fine-grained PAT scoped to $SDLC_REPO only, Contents +
+   Pull requests = read/write. GitHub has NO API to mint a PAT, so it is browser-only:
+   https://github.com/settings/personal-access-tokens/new
+   Then: for r in ${TARGETS[*]}; do printf '%s' "\$T" | gh secret set FUZESDLC_AGENT_PUSH_TOKEN -R "\$r"; done
+EOF
+exit "$fail"


### PR DESCRIPTION
Makes `FUZESDLC_DEPLOY_KEY` provisioning correct **everywhere it's needed**. The script was written when only FuzeInfra was wired and had two real problems.

## 1. A stale instruction that would have wasted your time
Its prereqs told you to enable **FuzeSDLC → Actions → Access** so consumers' `uses: izzywdev/FuzeSDLC/...` would resolve. **That is obsolete.** `governance-sync` is now a self-contained shim that fetches the canonical *with this key* instead of `uses:`-ing a cross-repo reusable (which cannot resolve against a private FuzeSDLC and reds the whole run). Following the script as written would have had you change an org setting for no reason.

## 2. Hardcoded targets — "everywhere needed" was whatever you remembered to type
It required the repo list as arguments, guaranteed to drift as repos onboard.

Now the targets are **computed**: exactly the repos with `.github/workflows/governance-sync.yml` on their default branch. **Verified — it discovers all 20.** Onboard a repo with `sdlc-bootstrap.sh`, re-run this, it's picked up. No list to drift.

## Also
- `--dry-run` (proves discovery, touches nothing).
- **Post-write verification** — re-reads each repo's secret names rather than trusting the write.
- **Idempotent guard that refuses to guess**: a deploy key's private half *cannot be re-read from GitHub*, so if a key already exists, a partial redistribution demands a deliberate rotation (delete → re-run), not a silent one.
- Documents the **separate** `FUZESDLC_AGENT_PUSH_TOKEN` (browser-only — GitHub exposes no API to mint a fine-grained PAT) with its distribution one-liner.

## Current state (audited)
**0 of 20** repos have either secret, and FuzeSDLC has no deploy key — so governance-sync is currently skipping fleet-wide (by design, not broken).

## Still human-run
It registers a deploy key and writes secrets — access-control changes. Run:
```bash
scripts/setup-fuzesdlc-deploy-key.sh --dry-run   # see the 20 targets
scripts/setup-fuzesdlc-deploy-key.sh             # provision + distribute + verify
```
The moment it completes, governance-sync starts reconciling across 20 repos on their next PR — worth watching the first few runs.