### PR TITLE
fix(ci): let Codex revise existing implementation PRs

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -20,12 +20,46 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
-      - name: Checkout default branch
+      - name: Resolve requested pull-request branch
+        id: target
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const match = context.payload.comment.body.match(/\bPR\s+#(\d+)\b/i);
+            if (!match) {
+              core.setOutput('ref', context.payload.repository.default_branch);
+              return;
+            }
+            const pull_number = Number(match[1]);
+            const {data: pull} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+            });
+            if (pull.head.repo?.full_name !== context.payload.repository.full_name) {
+              throw new Error('Refusing to check out a pull request from a fork');
+            }
+            core.setOutput('ref', pull.head.ref);
+
+      - name: Checkout requested branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ steps.target.outputs.ref }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Checkout FuzeSDLC guidance
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: izzywdev/FuzeSDLC
+          path: .fuze-sdlc
+          token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
+
+      - name: Keep guidance checkout out of the implementation patch
+        run: echo '/.fuze-sdlc/' >> .git/info/exclude
 
       - name: Build issue task prompt
         env:
@@ -40,7 +74,7 @@ jobs:
             (.issue.body // "") + "\n\n" +
             "Delegating comment:\n" + (.comment.body // "") + "\n\n" +
             "Required delivery contract:\n" +
-            "- Read CLAUDE.md and the referenced FuzeSDLC baseline before changing files.\n" +
+            "- Read CLAUDE.md and .fuze-sdlc/CLAUDE.baseline.md before changing files. The private baseline has already been checked out without persisting its credential.\n" +
             "- Implement and validate the issue; do not mutate the live production cluster.\n" +
             "- Modify the working tree only. Do not commit, push, open a pull request, or use GitHub credentials; a separate publisher job handles delivery.\n" +
             "- Never print or persist credentials.\n" +
@@ -109,17 +143,25 @@ jobs:
         run: |
           set -euo pipefail
           branch="codex/issue-${ISSUE_NUMBER}"
-          git switch -c "$branch"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch"
+            git switch --create "$branch" --track "origin/$branch"
+          else
+            git switch -c "$branch"
+          fi
           git apply --index /tmp/codex-result/codex.patch
           git config user.name "codex[bot]"
           git config user.email "codex[bot]@users.noreply.github.com"
           git commit -m "feat: implement issue #${ISSUE_NUMBER}"
           git push --set-upstream origin "$branch"
-          pr_url=$(gh pr create \
-            --base "${{ github.event.repository.default_branch }}" \
-            --head "$branch" \
-            --title "$ISSUE_TITLE" \
-            --body "Implemented by the FuzeInfra @codex cloud handler.\n\nCloses #${ISSUE_NUMBER}")
+          pr_url=$(gh pr list --head "$branch" --state open --json url --jq '.[0].url')
+          if [ -z "$pr_url" ]; then
+            pr_url=$(gh pr create \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$branch" \
+              --title "$ISSUE_TITLE" \
+              --body "Implemented by the FuzeInfra @codex cloud handler.\n\nCloses #${ISSUE_NUMBER}")
+          fi
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
   report:


### PR DESCRIPTION
Provides the required private FuzeSDLC baseline through a credential-clean checkout, resolves an explicitly referenced same-repository PR branch, and updates that existing branch/PR through the isolated publisher job. The Codex process still receives no GitHub write credential.