### PR TITLE
fix(chroma): normalize sealed secret tokens

### DIFF
--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -513,13 +513,20 @@ spec:
           args:
             - |
               import os
+              import string
               from pathlib import Path
 
+              def token(name):
+                  value = os.environ[name].strip()
+                  if not value or any(char not in string.printable or char.isspace() for char in value):
+                      raise ValueError(f"{name} must contain printable, non-whitespace ASCII characters only")
+                  return value
+
               users = [
-                  {"id": "fuzeinfra-chroma-admin", "role": "admin", "tenant": "*", "databases": ["*"], "token": os.environ["CHROMA_ADMIN_TOKEN"]},
+                  {"id": "fuzeinfra-chroma-admin", "role": "admin", "tenant": "*", "databases": ["*"], "token": token("CHROMA_ADMIN_TOKEN")},
               {{- range .Values.serviceChromaCollections }}
               {{- if .enabled }}
-                  {"id": {{ .name | quote }}, "role": "write", "tenant": {{ required (printf "serviceChromaCollections[%s].tenant is required" .name) .tenant | quote }}, "databases": [{{ required (printf "serviceChromaCollections[%s].database is required" .name) .database | quote }}], "token": os.environ[{{ printf "TOKEN_%s" (.name | upper | replace "-" "_") | quote }}]},
+                  {"id": {{ .name | quote }}, "role": "write", "tenant": {{ required (printf "serviceChromaCollections[%s].tenant is required" .name) .tenant | quote }}, "databases": [{{ required (printf "serviceChromaCollections[%s].database is required" .name) .database | quote }}], "token": token({{ printf "TOKEN_%s" (.name | upper | replace "-" "_") | quote }})},
               {{- end }}
               {{- end }}
               ]

--- a/helm/fuzeinfra/templates/service-chroma-provisioning.yaml
+++ b/helm/fuzeinfra/templates/service-chroma-provisioning.yaml
@@ -57,14 +57,14 @@ spec:
               host, port = os.environ["CHROMA_HOST"], int(os.environ["CHROMA_PORT"])
               allocations = [
               {{- range $enabled }}
-                  {"name": {{ .name | quote }}, "tenant": {{ required (printf "serviceChromaCollections[%s].tenant is required" .name) .tenant | quote }}, "database": {{ required (printf "serviceChromaCollections[%s].database is required" .name) .database | quote }}, "collections": {{ .collections | default list | toJson }}, "token": os.environ[{{ printf "TOKEN_%s" (.name | upper | replace "-" "_") | quote }}]},
+                  {"name": {{ .name | quote }}, "tenant": {{ required (printf "serviceChromaCollections[%s].tenant is required" .name) .tenant | quote }}, "database": {{ required (printf "serviceChromaCollections[%s].database is required" .name) .database | quote }}, "collections": {{ .collections | default list | toJson }}, "token": os.environ[{{ printf "TOKEN_%s" (.name | upper | replace "-" "_") | quote }}].strip()},
               {{- end }}
               ]
 
               def settings(token):
                   return Settings(chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider", chroma_client_auth_credentials=token)
 
-              admin_settings = settings(os.environ["CHROMA_ADMIN_TOKEN"])
+              admin_settings = settings(os.environ["CHROMA_ADMIN_TOKEN"].strip())
               admin_settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
               admin_settings.chroma_server_host = host
               admin_settings.chroma_server_http_port = port

--- a/tests/test_chroma_helm_security.py
+++ b/tests/test_chroma_helm_security.py
@@ -38,3 +38,13 @@ def test_chroma_server_requires_auth_and_disables_reset():
     assert "self._sysdb.get_collections" in provider
     assert "resource_tenant == user.tenant" in provider
     assert "resource_database == user.databases[0]" in provider
+
+
+def test_chroma_tokens_are_normalized_at_secret_boundaries():
+    server = (ROOT / "helm/fuzeinfra/templates/databases.yaml").read_text()
+    provisioner = (ROOT / "helm/fuzeinfra/templates/service-chroma-provisioning.yaml").read_text()
+
+    assert "value = os.environ[name].strip()" in server
+    assert "printable, non-whitespace ASCII characters only" in server
+    assert 'os.environ["CHROMA_ADMIN_TOKEN"].strip()' in provisioner
+    assert '].strip()' in provisioner


### PR DESCRIPTION
## Summary
- strip transport newlines from SealedSecret-backed Chroma tokens before rendering auth config
- validate server tokens are printable, non-whitespace ASCII
- apply identical normalization in the tenant/database provisioner

## Production evidence
The Chroma 0.5.23 server rejected the rendered token with: Invalid token. Must contain only ASCII letters, digits, and punctuation.

## Validation
- git diff --check
- helm lint helm/fuzeinfra -f helm/fuzeinfra/values-contabo.yaml
- python -m pytest tests/test_chroma_helm_security.py -q (4 passed)