### PR TITLE
ops(chroma): add guarded rollout recovery

### DIFF
--- a/.github/workflows/recover-chromadb-rollout.yml
+++ b/.github/workflows/recover-chromadb-rollout.yml
@@ -1,0 +1,51 @@
+name: Recover ChromaDB StatefulSet rollout
+
+# A StatefulSet can retain an unhealthy pod from currentRevision while a fixed
+# updateRevision is waiting. This narrowly-scoped, audited operation recycles
+# only that pod; its PVC and all declarative resources remain untouched.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  recover:
+    runs-on: staging
+    environment: production
+    steps:
+      - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+      - name: Configure kubectl
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          test -n "$KUBE_CONFIG" || { echo "::error::KUBE_CONFIG unset"; exit 1; }
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBE_CONFIG" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Recycle only a stale unhealthy ChromaDB pod
+        run: |
+          set -euo pipefail
+          namespace=fuzeinfra
+          statefulset=fuzeinfra-chromadb
+          pod=fuzeinfra-chromadb-0
+
+          current=$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.status.currentRevision}')
+          update=$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.status.updateRevision}')
+          ready=$(kubectl -n "$namespace" get pod "$pod" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+
+          if [ "$current" = "$update" ]; then
+            echo "No stale ChromaDB revision; nothing to recover."
+            exit 0
+          fi
+          if [ "$ready" = "True" ]; then
+            echo "::error::$pod is healthy; refusing to recycle it."
+            exit 1
+          fi
+
+          echo "Recycling unhealthy $pod: $current -> $update"
+          kubectl -n "$namespace" delete pod "$pod" --wait=true --timeout=2m
+          kubectl -n "$namespace" rollout status statefulset/"$statefulset" --timeout=5m


### PR DESCRIPTION
## Summary
- add an audited production workflow for the known StatefulSet stale-unhealthy-pod deadlock
- refuse recovery unless Chroma currentRevision differs from updateRevision and the pod is unready
- recycle only fuzeinfra-chromadb-0 and preserve its PVC
- wait for the fixed StatefulSet revision to become ready

## Current production state
- currentRevision: fuzeinfra-chromadb-6776994878
- updateRevision: fuzeinfra-chromadb-75db4d7665
- pod Ready: false

## Validation
- git diff --check
- repository actionlint check