### PR TITLE
fix(argocd): use v3 core-mode flags

### DIFF
--- a/.github/workflows/recover-chromadb-rollout.yml
+++ b/.github/workflows/recover-chromadb-rollout.yml
@@ -46,7 +46,7 @@ jobs:
 
           if [ "$phase" = "Running" ] && [ "$operation_revision" != "$desired_revision" ]; then
             echo "Terminating stale Argo operation: $operation_revision (desired $desired_revision)"
-            /tmp/argocd app terminate-op "$app" --core --app-namespace argocd
+            /tmp/argocd app terminate-op "$app" --core
           fi
 
           for _ in $(seq 1 60); do


### PR DESCRIPTION
Argo CD 3.4.4 core mode defaults to the argocd namespace and no longer accepts --app-namespace. Remove the obsolete flag observed in recovery run 29728214460. Validation: git diff --check; repository actionlint.