### PR TITLE
fix(argocd): select core-mode namespace

### DIFF
--- a/.github/workflows/recover-chromadb-rollout.yml
+++ b/.github/workflows/recover-chromadb-rollout.yml
@@ -46,6 +46,7 @@ jobs:
 
           if [ "$phase" = "Running" ] && [ "$operation_revision" != "$desired_revision" ]; then
             echo "Terminating stale Argo operation: $operation_revision (desired $desired_revision)"
+            kubectl config set-context --current --namespace=argocd
             /tmp/argocd app terminate-op "$app" --core
           fi
 


### PR DESCRIPTION
Set the kube-context namespace to argocd before invoking Argo CD core mode. This addresses the verified argocd-cm not found failure from recovery run 29728411962. Explicit namespaces remain on all other kubectl operations.