### PR TITLE
fix(chroma): use valid sentinel collection names

### DIFF
--- a/docs/consuming-repos/CHROMADB_PROVISIONING.md
+++ b/docs/consuming-repos/CHROMADB_PROVISIONING.md
@@ -20,8 +20,8 @@ to this registry; the consuming service creates those on demand.
 
 | Repo / service | Tenant / database | Bootstrap collections | Dynamic collections |
 |---|---|---|---|
-| FuzePlan repo-digester | `fuzeplan` / `repo-digester` | `_repo_digester_ready` | `repo_<projectId>` (service-managed) |
-| FuzeQuality | `fuzequality` / `fuzequality` | `_fuzequality_ready` | service-managed |
+| FuzePlan repo-digester | `fuzeplan` / `repo-digester` | `repo_digester_ready` | `repo_<projectId>` (service-managed) |
+| FuzeQuality | `fuzequality` / `fuzequality` | `fuzequality_ready` | service-managed |
 
 ## Adding a new consumer
 

--- a/governance/datastore-allocations.md
+++ b/governance/datastore-allocations.md
@@ -34,8 +34,8 @@ DB index 0 is reserved for FuzeInfra platform services.
 
 | App | Tenant | Database | Bootstrap collection | Consumer repo | Status |
 |---|---|---|---|---|---|
-| FuzePlan repo-digester | `fuzeplan` | `repo-digester` | `_repo_digester_ready` | izzywdev/FuzePlan | declared (FuzeInfra#168 corrective follow-up) |
-| FuzeQuality | `fuzequality` | `fuzequality` | `_fuzequality_ready` | izzywdev/FuzeQuality | declared (FuzeInfra#168 corrective follow-up) |
+| FuzePlan repo-digester | `fuzeplan` | `repo-digester` | `repo_digester_ready` | izzywdev/FuzePlan | declared (FuzeInfra#168 corrective follow-up) |
+| FuzeQuality | `fuzequality` | `fuzequality` | `fuzequality_ready` | izzywdev/FuzeQuality | declared (FuzeInfra#168 corrective follow-up) |
 
 Each row has a unique sealed token and an explicit NetworkPolicy peer. Tenant
 and database binding is enforced by Chroma; collection prefixes are not an

--- a/helm/fuzeinfra/templates/service-chroma-provisioning.yaml
+++ b/helm/fuzeinfra/templates/service-chroma-provisioning.yaml
@@ -3,6 +3,13 @@
 {{- $enabled := list -}}
 {{- range .Values.serviceChromaCollections }}{{- if .enabled }}{{- $enabled = append $enabled . }}{{- end }}{{- end }}
 {{- if $enabled }}
+{{- range $allocation := $enabled }}
+{{- range $collection := ($allocation.collections | default list) }}
+{{- if not (regexMatch "^[A-Za-z0-9][A-Za-z0-9_-]{1,61}[A-Za-z0-9]$" $collection) }}
+{{- fail (printf "serviceChromaCollections[%s] collection %q must be 3-63 characters, start/end alphanumeric, and contain only alphanumeric, underscore, or hyphen characters" $allocation.name $collection) }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -303,7 +303,7 @@ serviceChromaCollections:
       podLabels:
         app.kubernetes.io/name: repo-digester
     collections:
-      - _repo_digester_ready
+      - repo_digester_ready
   - name: fuzequality
     enabled: true
     tenant: fuzequality
@@ -316,4 +316,4 @@ serviceChromaCollections:
       podLabels:
         app.kubernetes.io/name: fuzequality
     collections:
-      - _fuzequality_ready
+      - fuzequality_ready

--- a/tests/test_chroma_helm_security.py
+++ b/tests/test_chroma_helm_security.py
@@ -24,8 +24,15 @@ def test_chroma_provisioning_keeps_security_checks():
         "foreign.list_collections",
         "cross_tenant_must_be_denied",
         "SECURITY FAILURE",
+        "must be 3-63 characters",
     ):
         assert required in template
+
+    values = (ROOT / "helm/fuzeinfra/values-contabo.yaml").read_text()
+    assert "_repo_digester_ready" not in values
+    assert "_fuzequality_ready" not in values
+    assert "repo_digester_ready" in values
+    assert "fuzequality_ready" in values
 
 
 def test_chroma_server_requires_auth_and_disables_reset():


### PR DESCRIPTION
## Summary
- rename FuzePlan and FuzeQuality sentinel collections to valid Chroma identifiers
- reject invalid configured collection names during Helm rendering
- update allocation and consumer documentation

## Production evidence
The PostSync job rejected _repo_digester_ready because Chroma collection names must start and end with an alphanumeric character.

## Validation
- git diff --check
- helm lint helm/fuzeinfra -f helm/fuzeinfra/values-contabo.yaml
- python -m pytest tests/test_chroma_helm_security.py -q (4 passed)