### PR TITLE
fix(argocd): hard refresh before production sync

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,6 +72,10 @@ jobs:
 
           # Kick an immediate sync so the rollout starts seconds after merge.
           for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets; do
+            # Ensure the sync renders this Git revision instead of reusing a
+            # cached Helm result whose reported revision has already advanced.
+            kubectl -n argocd annotate application "$app" \
+              argocd.argoproj.io/refresh=hard --overwrite
             kubectl -n argocd patch application "$app" --type merge \
               -p '{"operation":{"initiatedBy":{"username":"ci"},"sync":{}}}'
             echo "sync triggered for $app"


### PR DESCRIPTION
## Summary
Request an Argo CD hard refresh before every production sync so the applied Helm manifest is rendered from the reported Git revision.

## Production evidence
fuzeinfra-prod reports revision 4b7ff374, whose values contain repo_digester_ready, while the newly created hook pods still contain the cached prior value _repo_digester_ready.

## Validation
- git diff --check
- repository actionlint check