### PR TITLE
fix(chroma): match hook finalizer JSON

### DIFF
--- a/.github/workflows/recover-chromadb-bootstrap.yml
+++ b/.github/workflows/recover-chromadb-bootstrap.yml
@@ -51,7 +51,7 @@ jobs:
             deleting=$(kubectl -n "$namespace" get job "$job" -o jsonpath='{.metadata.deletionTimestamp}')
             finalizers=$(kubectl -n "$namespace" get job "$job" -o jsonpath='{.metadata.finalizers}')
             [ -n "$deleting" ] || { echo "::error::$job is not deleting; refusing finalizer recovery"; exit 1; }
-            [ "$finalizers" = '[argocd.argoproj.io/hook-finalizer]' ] || {
+            [ "$finalizers" = '["argocd.argoproj.io/hook-finalizer"]' ] || {
               echo "::error::unexpected finalizers on $job: $finalizers"; exit 1;
             }
             kubectl -n "$namespace" patch job "$job" --type merge -p '{"metadata":{"finalizers":null}}'


### PR DESCRIPTION
Correct the guarded recovery's exact comparison to the JSON representation emitted by kubectl. The recovery still permits only the single Argo hook finalizer on a failed, unsucceeded, deleting Job.

Validation: git diff --check; prior production run demonstrated the guard refuses any non-matching representation.