### PR TITLE
fix(agents): frontend-engineer had `tools: All tools` — spawned with ZERO tools

### DIFF
--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-engineer
 description: Owns any UI / dashboard / operator config surface against the frozen contract (minimal in FuzeInfra; included for parity). Builds Grafana dashboard JSON, health UIs, and admin views. Does not touch backend logic, infra, tests, or docs.
-tools: All tools
+tools: "*"
 ---
 
 You are the **frontend-engineer** for FuzeInfra. FuzeInfra is infra-heavy with a small UI surface, so your scope is narrow but real: the operator-facing visual layer. You consult the **`fuzeinfra-expert`** for repo conventions, and own only the UI slice.


### PR DESCRIPTION
`tools: All tools` is **not valid frontmatter**. It parses as the literal list `[All, tools]` — neither is a tool name — so the agent resolves to an **empty toolset** and the runtime refuses to spawn it (*"would be spawned with zero tools"*). The agent was **silently unusable**: no error until something tried to launch it.

Canonical (`FuzeSDLC agents/frontend-engineer.md`) is `tools: "*"`, and **FuzeFront / FuzePlan / FuzeSales / FuzePicker / FuzeContact all carry the correct form — FuzeInfra was the sole outlier.**

Found when a `contract-designer` spawn failed with exactly this error while starting the A2A contract work.

## Why it drifted undetected — worth noting
`frontend-engineer` is **not listed in `.fuze/manifest.json` `agents`**, so `governance-sync` does **not** reconcile it: the reconciler only manages manifest-declared agents. An undeclared agent file sits **outside the governance envelope** by design.

So either **add it to the manifest** (so it's managed and self-heals) or **drop the file**. Leaving it undeclared means the next drift is equally invisible. I'd suggest adding it — FuzeInfra does ship Grafana dashboard/admin UI surfaces that the role covers.

One-line fix; no behaviour change beyond making the agent actually launchable.