### PR TITLE
chore(governance): declare frontend-engineer in the manifest (+ first live governance-sync canary)

### DIFF
--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -8,6 +8,7 @@
     "contract-designer",
     "backend-engineer",
     "database-engineer",
+    "frontend-engineer",
     "devops-engineer",
     "test-engineer",
     "docs-maintainer",
@@ -20,18 +21,41 @@
     "runtime": "managed-agents",
     "provider": "anthropic",
     "defined": [
-      "backend", "frontend", "qa", "devops",
-      "openapi-maintainer", "mcp-engineer", "mobile-engineer",
-      "product-manager", "ux-designer",
-      "sales-rep", "marketing", "support-rep",
-      "ceo", "cto", "cfo", "ciso", "digital-persona"
+      "backend",
+      "frontend",
+      "qa",
+      "devops",
+      "openapi-maintainer",
+      "mcp-engineer",
+      "mobile-engineer",
+      "product-manager",
+      "ux-designer",
+      "sales-rep",
+      "marketing",
+      "support-rep",
+      "ceo",
+      "cto",
+      "cfo",
+      "ciso",
+      "digital-persona"
     ],
     "environments": [
-      "cloud-backend", "cloud-frontend", "cloud-qa", "selfhosted-devops",
-      "cloud-openapi-maintainer", "cloud-mcp-engineer", "cloud-mobile-engineer",
-      "cloud-product", "cloud-gtm", "cloud-exec", "cloud-digital-persona"
+      "cloud-backend",
+      "cloud-frontend",
+      "cloud-qa",
+      "selfhosted-devops",
+      "cloud-openapi-maintainer",
+      "cloud-mcp-engineer",
+      "cloud-mobile-engineer",
+      "cloud-product",
+      "cloud-gtm",
+      "cloud-exec",
+      "cloud-digital-persona"
     ],
-    "coordinators": ["coordinator", "exec-coordinator"]
+    "coordinators": [
+      "coordinator",
+      "exec-coordinator"
+    ]
   },
   "hardening": {
     "ruleset": true,


### PR DESCRIPTION
`frontend-engineer` existed at `.claude/agents/frontend-engineer.md` but was **not listed in `.fuze/manifest.json` `agents`**. `governance_sync.py` only reconciles **manifest-declared** agents, so the file sat **outside the governance envelope** — which is exactly how it drifted to the invalid `tools: All tools` (spawning with **zero tools**) and stayed broken undetected until an agent launch failed on it (#307).

Declaring it closes the gap: the file is now reconciled to the FuzeSDLC canonical on every PR, so the **next** drift self-heals instead of going unnoticed. FuzeInfra ships Grafana dashboard/admin UI surfaces the role covers, so it belongs in the subset.

## Also: the first live `FUZESDLC_DEPLOY_KEY` canary
The read-only key is now provisioned on FuzeSDLC (`governance-sync-ro`, `read_only=true`) and distributed to **all 20 repos** (verified). Every governance-sync run so far took the *skip* path because no key existed — **this PR is the first exercise of the fetch path**.

Watch the `governance-sync` check here: it should now fetch the canonical and reconcile rather than skip. If the key is malformed or `actions/checkout` can't consume it, this is where it surfaces — deliberately on one PR rather than across 20 at once.