### PR TITLE
fix(chroma): authenticate coordinated rotation pushes

### DIFF
--- a/.github/workflows/rotate-fuzequality-chroma.yml
+++ b/.github/workflows/rotate-fuzequality-chroma.yml
@@ -41,6 +41,7 @@ jobs:
           token=$(openssl rand -hex 32 | tr -d '[:space:]')
           echo "::add-mask::$token"
           printf '%s' "$token" > "$token_file"
+          gh auth setup-git
 
           bash scripts/seal-secret.sh fuzeinfra/fuzequality-chroma-credentials \
             "token=@${token_file}" \


### PR DESCRIPTION
Configure Git's credential helper from the masked GitHub token before cloning and pushing the coordinated FuzeFront rotation branch. The first run sealed both values but stopped before publishing any branch or PR, so production credentials remain unchanged.