### PR TITLE
feat(argocd): register FuzeQuality application

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -65,13 +65,13 @@ jobs:
           # deploy. Terraform only applies them on first-provision, so on a VPS
           # rebuild (or if one was never registered — e.g. sealed-secrets, #88) they
           # would silently go missing. apply -f makes the repo the source of truth.
-          for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets; do
+          for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets fuzequality; do
             kubectl apply -f "argocd/applications/$app.yaml"
             echo "registered $app"
           done
 
           # Kick an immediate sync so the rollout starts seconds after merge.
-          for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets; do
+          for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets fuzequality; do
             # Ensure the sync renders this Git revision instead of reusing a
             # cached Helm result whose reported revision has already advanced.
             kubectl -n argocd annotate application "$app" \

--- a/argocd/applications/fuzequality.yaml
+++ b/argocd/applications/fuzequality.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzequality
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    path: FuzeQuality/deploy/helm/fuzequality
+    helm:
+      releaseName: fuzequality
+      valueFiles:
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzequality
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m


### PR DESCRIPTION
## Summary
- register the FuzeQuality Helm chart as a standalone Argo CD Application
- include it in idempotent production registration, hard refresh, and sync
- deploy into the dedicated uzequality namespace under the existing FuzeFront Argo project

This activates the already-merged consumer SealedSecret and intelligence-worker Chroma readiness wiring.