### PR TITLE
fix(argocd): allow FuzeQuality namespace

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,6 +13,8 @@ on:
       - 'argocd/applications/fuzeinfra-prod.yaml'
       - 'argocd/applications/fuzeinfra-sealed-secrets.yaml'
       - 'argocd/applications/sealed-secrets.yaml'
+      - 'argocd/applications/fuzequality.yaml'
+      - 'argocd/projects/fuzefront.yaml'
       - '.github/workflows/deploy-prod.yml'
   workflow_dispatch:
 
@@ -60,6 +62,11 @@ jobs:
           echo "$KUBE_CONFIG" | base64 -d > /tmp/kubeconfig
           chmod 600 /tmp/kubeconfig
           export KUBECONFIG=/tmp/kubeconfig
+
+          # AppProjects are the destination/security boundary and must exist
+          # before their Applications are registered or synchronized.
+          kubectl apply -f argocd/projects/fuzefront.yaml
+          echo "registered fuzefront AppProject"
 
           # Register the standalone Application manifests idempotently on every prod
           # deploy. Terraform only applies them on first-provision, so on a VPS

--- a/argocd/projects/fuzefront.yaml
+++ b/argocd/projects/fuzefront.yaml
@@ -16,12 +16,16 @@ metadata:
   name: fuzefront
   namespace: argocd
 spec:
-  description: FuzeFront product (consumer of FuzeInfra) — may deploy ONLY into its own namespace.
+  description: FuzeFront products (consumers of FuzeInfra) — may deploy ONLY into their assigned namespaces.
   sourceRepos:
     - https://github.com/izzywdev/FuzeFront.git
   destinations:
     # The product's workloads.
     - namespace: fuzefront
+      server: https://kubernetes.default.svc
+    # FuzeQuality is maintained in the FuzeFront repository but has an isolated
+    # workload namespace and consumes shared infrastructure over service DNS.
+    - namespace: fuzequality
       server: https://kubernetes.default.svc
     # The app-of-apps creates child Application objects here.
     - namespace: argocd


### PR DESCRIPTION
## Summary
- allow the FuzeFront-owned FuzeQuality application to deploy only into its dedicated namespace
- apply the FuzeFront AppProject before registering and syncing applications
- trigger production deployment when either FuzeQuality registration or the project boundary changes

## Validation
- git diff --check
- kubectl apply --dry-run=client --validate=false -f argocd/projects/fuzefront.yaml