### PR TITLE
fix(provision): install GitHub CLI on staging runner

### DIFF
--- a/.github/workflows/provision-fuzequality.yml
+++ b/.github/workflows/provision-fuzequality.yml
@@ -45,6 +45,17 @@ jobs:
 
       - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
 
+      - name: Install GitHub CLI
+        run: |
+          set -euo pipefail
+          version=2.74.2
+          archive="gh_${version}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/cli/cli/releases/download/v${version}/${archive}"
+          curl -fsSLO "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_checksums.txt"
+          grep " ${archive}$" "gh_${version}_checksums.txt" | sha256sum -c -
+          tar -xzf "$archive"
+          sudo install -m0755 "gh_${version}_linux_amd64/bin/gh" /usr/local/bin/gh
+          gh --version
       - name: Install kubeseal
         run: |
           set -euo pipefail

--- a/tests/test_fuzequality_provisioning.py
+++ b/tests/test_fuzequality_provisioning.py
@@ -43,3 +43,11 @@ def test_verification_requires_immutable_commit_tag():
     assert '"$image" =~ :[0-9a-f]{12}$' in text
     assert 'image must use a non-latest 12-hex commit tag' in text
     assert 'case "$image" in *@sha256:*' not in text
+
+
+def test_bootstrap_installs_verified_github_cli_on_runner():
+    text = WORKFLOW.read_text()
+    assert 'name: Install GitHub CLI' in text
+    assert 'gh_${version}_checksums.txt' in text
+    assert 'sha256sum -c -' in text
+    assert 'gh --version' in text


### PR DESCRIPTION
Fixes the failed FuzeQuality provisioning run by installing a pinned GitHub CLI archive after verifying it against the upstream checksum manifest. Adds a regression test. No secret material is included.