### PR TITLE
fix(provision): scope PostgreSQL gate validation

### DIFF
--- a/.github/workflows/provision-fuzequality.yml
+++ b/.github/workflows/provision-fuzequality.yml
@@ -159,8 +159,8 @@ jobs:
           before=$(grep -A1 -- '- name: fuzequality' "$config" | grep -c 'enabled: false' || true)
           test "$before" -eq 1 || { echo '::error::unique disabled fuzequality database gate missing'; exit 1; }
           sed -i '/- name: fuzequality/{n;s/enabled: false/enabled: true/;}' "$config"
-          after=$(grep -A1 -- '- name: fuzequality' "$config" | grep -c 'enabled: true' || true)
-          test "$after" -eq 1 || { echo '::error::fuzequality database gate was not enabled'; exit 1; }
+          remaining_disabled=$(grep -A1 -- '- name: fuzequality' "$config" | grep -c 'enabled: false' || true)
+          test "$remaining_disabled" -eq 0 || { echo '::error::fuzequality PostgreSQL gate remains disabled'; exit 1; }
           infra_branch="provision/fuzequality-db-$run_id"
           git config user.name 'FuzeInfra Provisioning'
           git config user.email 'provisioning@fuzeinfra'

--- a/tests/test_fuzequality_provisioning.py
+++ b/tests/test_fuzequality_provisioning.py
@@ -57,4 +57,4 @@ def test_bootstrap_has_no_ruby_runner_dependency():
     text = WORKFLOW.read_text()
     assert "ruby -e" not in text
     assert "sed -i '/- name: fuzequality/{n;s/enabled: false/enabled: true/;}'" in text
-    assert "fuzequality database gate was not enabled" in text
+    assert "fuzequality PostgreSQL gate remains disabled" in text`n    assert 'grep -c ''enabled: false''' in text

--- a/tests/test_fuzequality_provisioning.py
+++ b/tests/test_fuzequality_provisioning.py
@@ -57,4 +57,6 @@ def test_bootstrap_has_no_ruby_runner_dependency():
     text = WORKFLOW.read_text()
     assert "ruby -e" not in text
     assert "sed -i '/- name: fuzequality/{n;s/enabled: false/enabled: true/;}'" in text
-    assert "fuzequality PostgreSQL gate remains disabled" in text`n    assert 'grep -c ''enabled: false''' in text
+    assert "fuzequality PostgreSQL gate remains disabled" in text
+    assert "grep -c 'enabled: false'" in text
+


### PR DESCRIPTION
Narrows post-edit validation to require zero remaining disabled FuzeQuality PostgreSQL gates. The separate enabled Chroma allocation no longer creates a false failure. The incomplete application-secret PR was closed and deleted.