### PR TITLE
fix(provision): publish infra branch with GH_TOKEN

### DIFF
--- a/.github/workflows/provision-fuzequality.yml
+++ b/.github/workflows/provision-fuzequality.yml
@@ -162,6 +162,8 @@ jobs:
           remaining_disabled=$(grep -A1 -- '- name: fuzequality' "$config" | grep -c 'enabled: false' || true)
           test "$remaining_disabled" -eq 0 || { echo '::error::fuzequality PostgreSQL gate remains disabled'; exit 1; }
           infra_branch="provision/fuzequality-db-$run_id"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          gh auth setup-git
           git config user.name 'FuzeInfra Provisioning'
           git config user.email 'provisioning@fuzeinfra'
           git checkout -b "$infra_branch"

--- a/tests/test_fuzequality_provisioning.py
+++ b/tests/test_fuzequality_provisioning.py
@@ -60,3 +60,9 @@ def test_bootstrap_has_no_ruby_runner_dependency():
     assert "fuzequality PostgreSQL gate remains disabled" in text
     assert "grep -c 'enabled: false'" in text
 
+
+
+def test_infra_publisher_removes_checkout_token_override():
+    text = WORKFLOW.read_text()
+    assert "git config --local --unset-all http.https://github.com/.extraheader || true" in text
+    assert text.count("gh auth setup-git") == 2


### PR DESCRIPTION
Removes the checkout-local github-actions HTTP credential override and reconfigures Git from GH_TOKEN before publishing the FuzeInfra branch. Adds a regression assertion. The incomplete application-secret PR was closed and deleted.