### PR TITLE
fix(provision): disable checkout credential persistence

### DIFF
--- a/.github/workflows/provision-fuzequality.yml
+++ b/.github/workflows/provision-fuzequality.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
 

--- a/tests/test_fuzequality_provisioning.py
+++ b/tests/test_fuzequality_provisioning.py
@@ -66,3 +66,7 @@ def test_infra_publisher_removes_checkout_token_override():
     text = WORKFLOW.read_text()
     assert "git config --local --unset-all http.https://github.com/.extraheader || true" in text
     assert text.count("gh auth setup-git") == 2
+
+def test_provision_checkout_does_not_persist_default_token():
+    text = WORKFLOW.read_text()
+    assert text.count("persist-credentials: false") == 1


### PR DESCRIPTION
Makes GH_TOKEN the sole Git publisher credential by disabling actions/checkout credential persistence. Adds a regression assertion. The unmatched FuzeFront ciphertext PR was closed and deleted.