### PR TITLE
feat(postgres): provision FuzeQuality database

### DIFF
--- a/deploy/sealed-secrets/fuzequality-db-credentials.yaml
+++ b/deploy/sealed-secrets/fuzequality-db-credentials.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: fuzequality-db-credentials
+  namespace: fuzeinfra
+spec:
+  encryptedData:
+    password: AgB+QIoGNdmPyJumlFQQB0Ec50pN/mn46u6w+I1efElcxNVzJDxN8//E2BIyvk1KJOObL/4X3h7hJ+VmweelptA5TvcmQ98Y4jRJ1giwhGJy6TBvpBU5OenTJbJ2ux6pAYoUgw+ZFWBvYuNuGbIgs8mYKHuXBU5G7OlAOv1YIq8cBb3oJgK0TdOaGh9OAKPUvBOeheFHhCRZd0r71odPHaTyFlBNrKTjfu3VOaIVh5xAqeGBEUuu1vehaeXbToYlk7fI+51B++r81bC2ZWkcjlpaNtjY0c1yCJoroDKe4nuTOYGQC5OSL6jF3PKReX/CBYQtJlw/0Ri406sRlNdMjj992L1tbfCOLGw67yUHI/VeMIoW6aI47hDL3SylgR4pVSjPwmDgnUKY/qn2IhhUo7gf8wImocUBoDGsjz1yQn3iO/znK8htQVeh8CWzuVGczFpUk4uTZHRw+NC2+SeVB4cp6lCyPzH6fs5bi2wivQ2u5RjdBHhUgwu9EeBDIZ4eBYMtqJ2i3xKaajk457JvPROJczMZMFlxoobheb2MDwj53xFGRnSzDSggn2Co+W/4GQCdIn0+Yk721fCUXJlF9Y8xmJ0v8aL40gNhKGrvq5DA4dbnEgJ8XKzsdzDth0Sspc4h1SMb0dUcURXkYpsSuekuh/zcVmEgHCZOtYe4OnZVYXM+MkWGWiR15J9cHYyuTCXrycmICKG/ZA48Wem2vaQt1MKspHrrheYBuZFPiHlBu7zZmvA4YOzwN69NcKwm3Ak=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: fuzequality-db-credentials
+      namespace: fuzeinfra
+    type: Opaque

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -246,7 +246,7 @@ serviceDatabases:
   # The provisioning workflow flips this gate only in the same PR that adds
   # the strict-scoped fuzeinfra password SealedSecret.
   - name: fuzequality
-    enabled: false
+    enabled: true
     role: fuzequality_user
     database: fuzequality
     passwordSecret:


### PR DESCRIPTION
Adds the strict-scoped ciphertext input and enables the declarative PostgreSQL allocation in the same PR. Argo provisions role `fuzequality_user` and database `fuzequality`. Merge this PR before the companion FuzeFront bootstrap PR. No plaintext secret material is present. Closes #316.