### PR TITLE
fix(ca): GATE A verifies productSpecs via live instance (not /v1/pricing 404)

### DIFF
--- a/.github/workflows/ca-cutover.yml
+++ b/.github/workflows/ca-cutover.yml
@@ -206,51 +206,13 @@ jobs:
       # -----------------------------------------------------------------
       # 5. GATE A — productSpecs match (definitive, non-destructive).
       # -----------------------------------------------------------------
-      - name: GATE A — productSpecs match (live catalog vs template.go)
+      - name: GATE A — productSpecs match (live instance spec vs template.go)
         run: |
           set -euo pipefail
           : "${CONTABO_TOKEN:?Contabo auth step must run first}"
-          RESP="$(mktemp)"; trap 'rm -f "$RESP"' EXIT
-          REQ_ID="$(openssl rand -hex 16 2>/dev/null || date +%s%N)"
-          HTTP_CODE=$(curl -sS -o "$RESP" -w '%{http_code}' \
-            -H "Authorization: Bearer ${CONTABO_TOKEN}" \
-            -H "x-request-id: ${REQ_ID}" \
-            "https://api.contabo.com/v1/pricing?productId=${PRODUCT_ID}")
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::GATE A: Contabo pricing lookup for productId=${PRODUCT_ID} failed (HTTP $HTTP_CODE) via GET /v1/pricing. Fail-closed — refusing to proceed without a verified live spec."
-            exit 1
-          fi
 
-          # Contabo's product/pricing payload should carry hardware specs on the
-          # matched product entry. Field names follow Contabo's established
-          # instance-resource convention (cpuCores/ramMb) with a couple of
-          # defensive aliases, since the exact /v1/pricing schema for spec
-          # fields is not published in a stable OpenAPI doc as of writing. If
-          # NONE of these match, we FAIL CLOSED rather than guess — the raw
-          # (non-secret, public-catalog) response is dumped to the job summary
-          # so the field-candidate list below can be extended to match reality.
-          LIVE_VCPU=$(jq -r --arg pid "$PRODUCT_ID" '
-            [.. | objects | select((.productId? // .id? // empty) == $pid)][0] as $p
-            | ($p.cpuCores // $p.vCpuCores // $p.specs.cpuCores // $p.cpu // empty)
-          ' "$RESP")
-          LIVE_RAM_MB=$(jq -r --arg pid "$PRODUCT_ID" '
-            [.. | objects | select((.productId? // .id? // empty) == $pid)][0] as $p
-            | ($p.ramMb // $p.memoryMb // $p.specs.ramMb // $p.ram // empty)
-          ' "$RESP")
-          if [ -z "$LIVE_VCPU" ] || [ -z "$LIVE_RAM_MB" ] || [ "$LIVE_VCPU" = "null" ] || [ "$LIVE_RAM_MB" = "null" ]; then
-            {
-              echo "### GATE A — FAILED (schema extraction)"
-              echo "Could not extract cpuCores/ramMb for productId=\`${PRODUCT_ID}\` from the live Contabo pricing response. Raw matched entry (non-secret catalog data):"
-              echo '```json'
-              jq -c --arg pid "$PRODUCT_ID" '[.. | objects | select((.productId? // .id? // empty) == $pid)][0] // .' "$RESP" | head -c 4000
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::GATE A: could not extract cpuCores/ramMb for productId=${PRODUCT_ID}. Fail-closed — see the job summary for the raw response and extend the jq field candidates in this step."
-            exit 1
-          fi
-          LIVE_RAM_GI=$(( (LIVE_RAM_MB + 1023) / 1024 ))
-          echo "GATE A: live catalog for ${PRODUCT_ID}: vCPU=${LIVE_VCPU} RAM=${LIVE_RAM_GI}Gi (raw ${LIVE_RAM_MB}MB)"
-
+          # (a) STATIC, always-enforced: the SKU MUST be declared in productSpecs,
+          #     else NodeGroupTemplateNodeInfo refuses and CA can't scale from zero.
           LINE=$(grep -E "\"${PRODUCT_ID}\":[[:space:]]*\{VCPU:" "$TEMPLATE_GO_PATH" || true)
           if [ -z "$LINE" ]; then
             echo "::error::GATE A: productId=${PRODUCT_ID} is NOT present in productSpecs (${TEMPLATE_GO_PATH}). Add it there first — an unlisted SKU makes NodeGroupTemplateNodeInfo refuse, and Cluster Autoscaler cannot scale from zero for it. Fail-closed."
@@ -260,18 +222,54 @@ jobs:
           CODE_RAM_GI=$(echo "$LINE" | sed -E 's/.*MemGi:[[:space:]]*([0-9]+).*/\1/')
           echo "GATE A: coded productSpecs[${PRODUCT_ID}] = vCPU=${CODE_VCPU} MemGi=${CODE_RAM_GI}"
 
+          # (b) LIVE verification against a REAL instance of the same SKU.
+          #     Contabo exposes no per-SKU pricing/spec endpoint (GET /v1/pricing
+          #     404s), but every instance object carries cpuCores/ramMb, and the
+          #     provider itself already reads GET /v1/compute/instances — so that
+          #     is the reliable source of truth. Read the spec from any existing
+          #     instance whose productId == our SKU (the current baseline nodes
+          #     typically already run it).
+          RESP="$(mktemp)"; trap 'rm -f "$RESP"' EXIT
+          REQ_ID="$(openssl rand -hex 16 2>/dev/null || date +%s%N)"
+          HTTP_CODE=$(curl -sS -o "$RESP" -w '%{http_code}' \
+            -H "Authorization: Bearer ${CONTABO_TOKEN}" \
+            -H "x-request-id: ${REQ_ID}" \
+            "https://api.contabo.com/v1/compute/instances?size=200")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::GATE A: listing instances failed (HTTP $HTTP_CODE) via GET /v1/compute/instances. Fail-closed — cannot verify the live spec."
+            exit 1
+          fi
+          LIVE_VCPU=$(jq -r --arg pid "$PRODUCT_ID" '[.data[]? | select(.productId==$pid)][0].cpuCores // empty' "$RESP")
+          LIVE_RAM_MB=$(jq -r --arg pid "$PRODUCT_ID" '[.data[]? | select(.productId==$pid)][0].ramMb // empty' "$RESP")
+
+          if [ -z "$LIVE_VCPU" ] || [ "$LIVE_VCPU" = "null" ] || [ -z "$LIVE_RAM_MB" ] || [ "$LIVE_RAM_MB" = "null" ]; then
+            # No running instance of this SKU to compare against. NOT fatal:
+            # ca-spike-test.yml validates the FIRST real elastic node's actual
+            # k8s-reported capacity and AUTO-ROLLS-BACK on mismatch — that is the
+            # authoritative capacity gate. Warn and proceed.
+            {
+              echo "### GATE A — WARN (no live instance of this SKU to verify against)"
+              echo "No existing Contabo instance has productId=\`${PRODUCT_ID}\`, so the coded spec (vCPU=${CODE_VCPU}, RAM=${CODE_RAM_GI}Gi) could not be pre-verified against a live node. This is NOT fatal — ca-spike-test.yml checks the first real elastic node's actual capacity and auto-rolls-back on mismatch. Proceeding."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::GATE A: no existing instance of SKU ${PRODUCT_ID} to verify against; deferring to the spike test's real-node capacity check. Proceeding."
+            echo "GATE A RESULT: WARN (deferred to spike test)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          LIVE_RAM_GI=$(( (LIVE_RAM_MB + 1023) / 1024 ))
+          echo "GATE A: live instance of ${PRODUCT_ID}: vCPU=${LIVE_VCPU} RAM=${LIVE_RAM_GI}Gi (raw ${LIVE_RAM_MB}MB)"
           {
             echo "### GATE A — productSpecs match"
             echo "productId=\`${PRODUCT_ID}\`: live vCPU=${LIVE_VCPU} RAM=${LIVE_RAM_GI}Gi vs coded vCPU=${CODE_VCPU} RAM=${CODE_RAM_GI}Gi"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$LIVE_VCPU" != "$CODE_VCPU" ] || [ "$LIVE_RAM_GI" != "$CODE_RAM_GI" ]; then
-            echo "::error::GATE A FAILED — live Contabo catalog for ${PRODUCT_ID} (vCPU=${LIVE_VCPU}, RAM=${LIVE_RAM_GI}Gi) does NOT match the coded productSpecs entry (vCPU=${CODE_VCPU}, RAM=${CODE_RAM_GI}Gi) in ${TEMPLATE_GO_PATH}. A mismatch here means Cluster Autoscaler's scale-from-zero simulation lies about node capacity. Fix productSpecs (or the product_id input) and re-run. Refusing to proceed."
+            echo "::error::GATE A FAILED — a live Contabo instance of ${PRODUCT_ID} (vCPU=${LIVE_VCPU}, RAM=${LIVE_RAM_GI}Gi) does NOT match the coded productSpecs entry (vCPU=${CODE_VCPU}, RAM=${CODE_RAM_GI}Gi) in ${TEMPLATE_GO_PATH}. A mismatch here means Cluster Autoscaler's scale-from-zero simulation lies about node capacity. Fix productSpecs (or the product_id input) and re-run. Refusing to proceed."
             echo "GATE A RESULT: FAIL" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
           echo "GATE A RESULT: PASS" >> "$GITHUB_STEP_SUMMARY"
-          echo "GATE A PASSED: live catalog matches coded productSpecs for ${PRODUCT_ID}."
+          echo "GATE A PASSED: live instance spec matches coded productSpecs for ${PRODUCT_ID}."
 
       # -----------------------------------------------------------------
       # 6. GATE B — API sanity (non-destructive). imageId exists; a Contabo


### PR DESCRIPTION
Dry-run of ca-cutover.yml caught GATE A's /v1/pricing endpoint 404ing (fail-closed, zero prod impact). Rewrites GATE A to read specs from an existing instance of the SKU; warn-not-fail when none exists (spike test is the authoritative capacity gate). Follow-up to #343.