### PR TITLE
fix(ca): GATE A drop ?size=200 (Contabo 400)

### DIFF
--- a/.github/workflows/ca-cutover.yml
+++ b/.github/workflows/ca-cutover.yml
@@ -234,7 +234,7 @@ jobs:
           HTTP_CODE=$(curl -sS -o "$RESP" -w '%{http_code}' \
             -H "Authorization: Bearer ${CONTABO_TOKEN}" \
             -H "x-request-id: ${REQ_ID}" \
-            "https://api.contabo.com/v1/compute/instances?size=200")
+            "https://api.contabo.com/v1/compute/instances")
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::error::GATE A: listing instances failed (HTTP $HTTP_CODE) via GET /v1/compute/instances. Fail-closed — cannot verify the live spec."
             exit 1


### PR DESCRIPTION
Second dry-run caught GET /v1/compute/instances?size=200 returning 400. Match the provider's paramless call. Also surfaced: elastic SKU is V92 (coded 12vCPU/48Gi, best-effort) — GATE A verifies it live.