### PR TITLE
fix(ca): Contabo x-request-id must be UUID (provider + cutover) — dry-run catch

### DIFF
--- a/.github/workflows/ca-cutover.yml
+++ b/.github/workflows/ca-cutover.yml
@@ -230,7 +230,7 @@ jobs:
           #     instance whose productId == our SKU (the current baseline nodes
           #     typically already run it).
           RESP="$(mktemp)"; trap 'rm -f "$RESP"' EXIT
-          REQ_ID="$(openssl rand -hex 16 2>/dev/null || date +%s%N)"
+          REQ_ID="$(cat /proc/sys/kernel/random/uuid)"  # Contabo requires x-request-id to be a UUID
           HTTP_CODE=$(curl -sS -o "$RESP" -w '%{http_code}' \
             -H "Authorization: Bearer ${CONTABO_TOKEN}" \
             -H "x-request-id: ${REQ_ID}" \
@@ -299,9 +299,11 @@ jobs:
           [ -n "$NODE_SSH_PUBLIC_KEY" ] || { echo "::error::NODE_SSH_PUBLIC_KEY secret is empty. Fail-closed."; exit 1; }
 
           # --- image exists (read-only GET) ---------------------------------
+          # Contabo requires x-request-id to be a UUID on every compute call.
           IMG_RESP="$(mktemp)"
           IMG_CODE=$(curl -sS -o "$IMG_RESP" -w '%{http_code}' \
             -H "Authorization: Bearer ${CONTABO_TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
             "https://api.contabo.com/v1/compute/images/${IMAGE_ID}")
           if [ "$IMG_CODE" != "200" ]; then
             echo "::error::GATE B: imageId=${IMAGE_ID} lookup failed (HTTP $IMG_CODE) via GET /v1/compute/images/{id}. Fail-closed — the image must exist before it's referenced in values-contabo.yaml."
@@ -315,6 +317,7 @@ jobs:
           KEYS_RESP="$(mktemp)"
           KEYS_CODE=$(curl -sS -o "$KEYS_RESP" -w '%{http_code}' \
             -H "Authorization: Bearer ${CONTABO_TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
             "https://api.contabo.com/v1/compute/ssh-keys")
           if [ "$KEYS_CODE" != "200" ]; then
             echo "::error::GATE B: SSH key list failed (HTTP $KEYS_CODE) via GET /v1/compute/ssh-keys. Fail-closed. NOTE: current Contabo docs reference a 'Secrets Management API' for SSH keys — if this consistently 404s, the endpoint may have moved to /v1/secrets; update this gate accordingly."

--- a/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,10 +81,15 @@ func (c *HTTPClient) invalidateToken() {
 func newRequestID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		// Fallback: on error, use a timestamp-free counter (but crypto/rand effectively never fails)
-		return fmt.Sprintf("req-%d", time.Now().UnixNano())
+		// Fallback (crypto/rand effectively never fails). Still a valid UUID
+		// shape — Contabo's API rejects a non-UUID x-request-id with HTTP 400.
+		return fmt.Sprintf("00000000-0000-4000-8000-%012d", time.Now().UnixNano()%1_000_000_000_000)
 	}
-	return hex.EncodeToString(b)
+	// Contabo requires x-request-id to be a UUID; format 16 random bytes as
+	// UUID v4 (raw hex is rejected with HTTP 400 on the compute API).
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10x
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 // token returns a valid OAuth2 bearer token, refreshing if necessary.


### PR DESCRIPTION
The gated dry-run caught that Contabo 400s a non-UUID x-request-id. The provider's newRequestID() used raw hex → the deployed autoscaler would 400 on every Contabo call (non-functional). Fix newRequestID() to emit UUID v4 + UUID in GATE A/B curls. Zero prod impact (stack still disabled). Follow-up to #345.