### PR TITLE
fix(ca): correct V92 productSpecs to 4vCPU/8GB (GATE A live-verified)

### DIFF
--- a/cluster-autoscaler/contabo-externalgrpc/internal/provider/template.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/provider/template.go
@@ -35,7 +35,7 @@ var productSpecs = map[string]productSpec{
 	"V47": {VCPU: 10, MemGi: 32}, // VPS XL — best-effort; verify against catalog
 	// VDS product line
 	"V76": {VCPU: 6, MemGi: 16},  // VDS S — best-effort; verify against catalog
-	"V92": {VCPU: 12, MemGi: 48}, // VDS M — best-effort; verify against catalog
+	"V92": {VCPU: 4, MemGi: 8}, // verified against live Contabo instance via ca-cutover GATE A (was a wrong 12/48 guess)
 }
 
 // NodeGroupTemplateNodeInfo returns a synthetic Node describing the capacity,


### PR DESCRIPTION
The gated cutover dry-run (GATE A) verified the elastic SKU against a live Contabo instance: real spec is 4 vCPU/8GB, not the best-effort 12/48. Correcting productSpecs so CA's scale-from-zero simulation is accurate. Zero prod impact (stack disabled).