### PR TITLE
ci(fuzequality): diagnose workload rollout failures

### DIFF
--- a/.github/workflows/provision-fuzequality.yml
+++ b/.github/workflows/provision-fuzequality.yml
@@ -214,6 +214,8 @@ jobs:
             fi
             jq -r '.status.conditions[]? | "condition: \(.type): \(.message)"' "$app_json"
             jq -r '.status.resources[]? | select((.status // "Unknown") != "Synced") | "out-of-sync resource: \(.kind)/\(.name) namespace=\(.namespace // "cluster") status=\(.status // "Unknown") health=\(.health.status // "Unknown")"' "$app_json"
+            kubectl -n fuzequality get deployments -l app.kubernetes.io/name=fuzequality -o json | jq -r '.items[]? | .metadata.name as $name | "deployment: \($name) desired=\(.spec.replicas // 0) ready=\(.status.readyReplicas // 0) available=\(.status.availableReplicas // 0) unavailable=\(.status.unavailableReplicas // 0)", (.status.conditions[]? | select(.status != "True" or .type == "Progressing") | "deployment condition: \($name) \(.type)=\(.status) reason=\(.reason // "") message=\(.message // "")")'
+            kubectl -n fuzequality get pods -l app.kubernetes.io/name=fuzequality -o json | jq -r '.items[]? | "workload pod: \(.metadata.name) component=\(.metadata.labels["app.kubernetes.io/component"] // "unknown") phase=\(.status.phase // "Unknown")", (.status.containerStatuses[]? | "workload container: \(.name) ready=\(.ready) waiting=\(.state.waiting.reason // "none") waitingMessage=\(.state.waiting.message // "") terminated=\(.state.terminated.reason // "none") exitCode=\(.state.terminated.exitCode // "none") restarts=\(.restartCount)")'
             echo "::error::FuzeQuality Argo application is not Synced (actual: $sync_status)"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- report desired/ready/available replica counts when FuzeQuality remains OutOfSync
- report workload Pod/container wait and termination states

This extends the FQ-59 verifier after the migration hook succeeded but three application Deployments remained unhealthy.