### PR TITLE
fix(ca): provider Contabo OAuth2 token() flow (live 404 fix)

### DIFF
--- a/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -107,36 +109,28 @@ func (c *HTTPClient) token(ctx context.Context) (string, error) {
 		return c.tok, nil
 	}
 
-	// Determine auth endpoint
+	// Determine auth endpoint. Contabo's OAuth2 token endpoint is a Keycloak
+	// realm endpoint that is used DIRECTLY (no "/oauth/token" suffix) and
+	// expects a form-urlencoded password grant — NOT JSON. Using the wrong
+	// URL/body shape returns HTTP 404.
 	authURL := c.cfg.AuthURL
 	if authURL == "" {
-		authURL = c.cfg.BaseURL
+		authURL = "https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token"
 	}
 
-	// Build request body with real credentials
-	credBody := struct {
-		ClientID     string `json:"clientId"`
-		ClientSecret string `json:"clientSecret"`
-		Username     string `json:"username"`
-		Password     string `json:"password"`
-	}{
-		ClientID:     c.cfg.ClientID,
-		ClientSecret: c.cfg.ClientSecret,
-		Username:     c.cfg.User,
-		Password:     c.cfg.Pass,
-	}
-	reqBody, err := json.Marshal(credBody)
-	if err != nil {
-		return "", fmt.Errorf("marshal token request: %w", err)
-	}
+	// Build the form-urlencoded password-grant body with real credentials.
+	form := url.Values{}
+	form.Set("client_id", c.cfg.ClientID)
+	form.Set("client_secret", c.cfg.ClientSecret)
+	form.Set("username", c.cfg.User)
+	form.Set("password", c.cfg.Pass)
+	form.Set("grant_type", "password")
 
-	// POST password grant to /oauth/token
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL+"/oauth/token", bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("create token request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-request-id", newRequestID())
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.hc.Do(req)
 	if err != nil {

--- a/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client_test.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client_test.go
@@ -19,7 +19,7 @@ func TestListByTag(t *testing.T) {
 		w.Write([]byte(`{"access_token":"tok","expires_in":300}`)) // token endpoint
 	}))
 	defer srv.Close()
-	c := NewClient(Config{BaseURL: srv.URL})
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
 	got, err := c.ListByTag(context.Background(), "fuzeinfra-elastic")
 	if err != nil {
 		t.Fatal(err)
@@ -53,7 +53,7 @@ func TestCreateAndDelete(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	c := NewClient(Config{BaseURL: srv.URL})
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
 	inst, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-1", ProductID: "V45", ImageID: "img", Region: "EU", UserData: "#cloud-config", Tags: []string{"fuzeinfra-elastic"}})
 	if err != nil || inst.ID != 99 {
 		t.Fatalf("create: %v %+v", err, inst)
@@ -87,7 +87,7 @@ func TestCreate_SSHKeysOmittedWhenZero(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	c := NewClient(Config{BaseURL: srv.URL})
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
 	if _, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-2", ProductID: "V45", ImageID: "img", Region: "EU", UserData: "#cloud-config"}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestCreate_SSHKeysPresentWhenPositive(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	c := NewClient(Config{BaseURL: srv.URL})
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
 	if _, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-3", ProductID: "V45", ImageID: "img", Region: "EU", SSHKeyID: 777, UserData: "#cloud-config"}); err != nil {
 		t.Fatalf("create: %v", err)
 	}


### PR DESCRIPTION
Deployed provider 404s on Contabo token requests — token() used the wrong URL+JSON body. Use the Keycloak endpoint + form-urlencoded grant (matches the working cutover-workflow auth). Last runtime blocker for functional autoscaling.