### PR TITLE
fix(helm): mongo-provision hook OOMs (exit 137) — raise mongosh memory limit

### DIFF
--- a/helm/fuzeinfra/templates/service-mongo-provisioning.yaml
+++ b/helm/fuzeinfra/templates/service-mongo-provisioning.yaml
@@ -143,7 +143,14 @@ spec:
 
               echo "All MongoDB users provisioned."
           resources:
-            requests: { cpu: 50m, memory: 64Mi }
-            limits:   { cpu: 250m, memory: 128Mi }
+            # mongosh (the mongo:7 client) is a Node.js/V8 process and needs
+            # substantial heap headroom even for a trivial `ping`/`createUser`.
+            # A 128Mi limit reliably OOM-kills it (exit 137) before the admin
+            # auth handshake completes — the Job then loops "Waiting for
+            # MongoDB ..." and the PostSync hook never finishes, blocking the
+            # whole Argo sync. This was misdiagnosed as credential drift; the
+            # admin credentials authenticate fine. Give mongosh real headroom.
+            requests: { cpu: 50m, memory: 128Mi }
+            limits:   { cpu: 250m, memory: 512Mi }
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Prod incident: Argo \`fuzeinfra-prod\` sync stuck on failing PostSync hooks

The Argo sync was blocked ~waiting on two per-service provisioning hook Jobs. This PR fixes the **mongo** one. (The **chroma** one was a genuine credential-drift issue, fixed operationally — see below.)

### Root cause (mongo) — NOT credential drift
- The admin creds in \`fuzeinfra-secrets\` **authenticate to the live mongod fine** — verified from an identical ephemeral \`mongo:7\` pod on-cluster (\`db.adminCommand({ping:1}).ok == 1\`), and the pod-env password hash matches the current secret.
- The \`fuzeinfra-service-mongo-provision\` Job pods were exiting **137 (SIGKILL) ~7s after start** — not the "auth loops forever" signature. \`mongosh\` (a Node.js/V8 client) exceeds the Job's **128Mi** memory limit and is **OOM-killed before the admin \`ping\` completes**, so the wait loop only ever logs \`Waiting for MongoDB ...\`.
- Reproduced deterministically: \`mongosh\` under a 128Mi cap → \`OOMKilled\`; unbounded → succeeds.

### Fix
Raise the hook container to **requests 128Mi / limits 512Mi** (cpu unchanged). Short-lived hook on an 8GB node; request stays low so scheduling is unaffected.

### Chroma (handled operationally, no code change here)
\`fuzeinfra-chromadb-0\` (up 2d, never restarted) had baked its in-memory \`/auth/credentials.yaml\` from the secrets as they were at pod-start (2026-07-20 08:42Z); a per-service token (FuzeQuality) was **rotated at 21:18Z**, after. Provisioner + Git hold the rotated tokens → the hook's admin client got \`403 Forbidden\` on \`/auth/identity\`. Recovered by deleting the pod (StatefulSet self-heals; the \`render-auth-config\` init container re-renders the token file from current secrets — no spec edit). Recommend a follow-up: add a secret-rotation checksum annotation to the chromadb pod template so rotations auto-roll the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)