### PR TITLE
fix(ca): use Contabo /v1/tags assignment API (per-instance tag-assignments + DELETE both 404)

### DIFF
--- a/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -66,13 +67,26 @@ type HTTPClient struct {
 	mu        sync.Mutex
 	tok       string
 	tokExpiry time.Time
+
+	// tagCache memoizes tag name -> Contabo tagId lookups (see resolveTagID)
+	// so a create loop doesn't re-resolve/re-create the same tag on every
+	// call.
+	tagCacheMu sync.Mutex
+	tagCache   map[string]int64
 }
+
+// tagColor is the color assigned to any tag this client creates. Contabo
+// requires a 4-7 character hex value on POST /v1/tags; the value itself is
+// cosmetic (shown in the Contabo control panel) and has no functional
+// effect on tag-assignment/lookup.
+const tagColor = "#0A78C3"
 
 // NewClient creates a new Contabo API client.
 func NewClient(cfg Config) *HTTPClient {
 	return &HTTPClient{
-		cfg: cfg,
-		hc:  &http.Client{Timeout: 30 * time.Second},
+		cfg:      cfg,
+		hc:       &http.Client{Timeout: 30 * time.Second},
+		tagCache: make(map[string]int64),
 	}
 }
 
@@ -162,11 +176,39 @@ func (c *HTTPClient) token(ctx context.Context) (string, error) {
 	return c.tok, nil
 }
 
-// ListByTag lists all instances with the given tag.
+// ListByTag lists all instances carrying the given tag name.
+//
+// Contabo's compute-instance resource (GET /v1/compute/instances) does not
+// carry its own assigned tags — tags are a separate first-class resource
+// with their own Tag Assignments API
+// (https://api.contabo.com/#tag/Tag-Assignments). Membership is therefore
+// resolved via that API instead of trusting an `.tags[]` field on the
+// instance object:
+//  1. resolve the tag id for `tag` (GET /v1/tags?name=...)
+//  2. GET /v1/tags/{tagId}/assignments to collect the assigned instance ids
+//  3. GET /v1/compute/instances (known-good, used elsewhere) for
+//     Name/Status/PrivateIP, filtered down to the assigned id set
 func (c *HTTPClient) ListByTag(ctx context.Context, tag string) ([]Instance, error) {
 	tok, err := c.token(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get token: %w", err)
+	}
+
+	tagID, err := c.lookupTagID(ctx, tok, tag)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tag %q: %w", tag, err)
+	}
+	if tagID == 0 {
+		// The tag has never been created, so nothing can be assigned to it.
+		return nil, nil
+	}
+
+	assignedIDs, err := c.listAssignedInstanceIDs(ctx, tok, tagID)
+	if err != nil {
+		return nil, fmt.Errorf("list assignments for tag %q (id=%d): %w", tag, tagID, err)
+	}
+	if len(assignedIDs) == 0 {
+		return nil, nil
 	}
 
 	// GET /v1/compute/instances
@@ -179,10 +221,12 @@ func (c *HTTPClient) ListByTag(ctx context.Context, tag string) ([]Instance, err
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
+		log.Printf("contabo: GET /v1/compute/instances failed: %v", err)
 		return nil, fmt.Errorf("instances request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	log.Printf("contabo: GET /v1/compute/instances -> %d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("instances request failed with status %d: %s", resp.StatusCode, string(body))
@@ -198,29 +242,17 @@ func (c *HTTPClient) ListByTag(ctx context.Context, tag string) ([]Instance, err
 					IP string `json:"ip"`
 				} `json:"private"`
 			} `json:"addresses"`
-			Tags []struct {
-				Name string `json:"name"`
-			} `json:"tags"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode instances response: %w", err)
 	}
 
-	// Filter instances by tag
+	// Filter instances down to the ones the Tag Assignments API reported as
+	// carrying `tag`.
 	var instances []Instance
 	for _, inst := range result.Data {
-		// Check if instance has the requested tag
-		hasTag := false
-		var tags []string
-		for _, t := range inst.Tags {
-			tags = append(tags, t.Name)
-			if t.Name == tag {
-				hasTag = true
-			}
-		}
-
-		if !hasTag {
+		if !assignedIDs[inst.InstanceID] {
 			continue
 		}
 
@@ -235,11 +267,244 @@ func (c *HTTPClient) ListByTag(ctx context.Context, tag string) ([]Instance, err
 			Name:      inst.DisplayName,
 			Status:    inst.Status,
 			PrivateIP: privateIP,
-			Tags:      tags,
+			Tags:      []string{tag},
 		})
 	}
 
 	return instances, nil
+}
+
+// listAssignedInstanceIDs returns the set of instance ids that GET
+// /v1/tags/{tagId}/assignments reports as carrying tagID, restricted to
+// resourceType=instance assignments.
+//
+// NOTE: this issues a single page request (size=100). Contabo's assignments
+// endpoint is paginated; if the elastic fleet ever exceeds ~100 tagged
+// instances (far beyond anything FuzeInfra's autoscaler config allows today)
+// this needs real page-walking. A mismatch between totalElements and the
+// number of ids collected is logged loudly so that's visible before it
+// silently drops nodes from tracking.
+func (c *HTTPClient) listAssignedInstanceIDs(ctx context.Context, tok string, tagID int64) (map[int64]bool, error) {
+	path := fmt.Sprintf("/v1/tags/%d/assignments?resourceType=instance&size=100", tagID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.BaseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create list-assignments request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("x-request-id", newRequestID())
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		log.Printf("contabo: GET %s failed: %v", path, err)
+		return nil, fmt.Errorf("list-assignments request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("contabo: GET %s -> %d", path, resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list-assignments request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Data []struct {
+			ResourceType string `json:"resourceType"`
+			ResourceID   string `json:"resourceId"`
+		} `json:"data"`
+		Pagination struct {
+			TotalElements int `json:"totalElements"`
+		} `json:"_pagination"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode list-assignments response: %w", err)
+	}
+
+	if result.Pagination.TotalElements > len(result.Data) {
+		log.Printf("contabo: WARNING GET %s returned %d/%d assignments (pagination not implemented) — some tagged instances may be missed", path, len(result.Data), result.Pagination.TotalElements)
+	}
+
+	ids := make(map[int64]bool, len(result.Data))
+	for _, a := range result.Data {
+		if a.ResourceType != "instance" {
+			continue
+		}
+		id, err := strconv.ParseInt(a.ResourceID, 10, 64)
+		if err != nil {
+			log.Printf("contabo: skipping assignment with non-numeric resourceId %q: %v", a.ResourceID, err)
+			continue
+		}
+		ids[id] = true
+	}
+	return ids, nil
+}
+
+// lookupTagID looks up an existing tag's id by exact name via GET /v1/tags.
+// Returns (0, nil) — not an error — if no tag with that exact name exists;
+// Contabo's `name` query parameter is a substring filter, so results are
+// re-checked for an exact match client-side.
+func (c *HTTPClient) lookupTagID(ctx context.Context, tok, name string) (int64, error) {
+	u := c.cfg.BaseURL + "/v1/tags?name=" + url.QueryEscape(name) + "&size=100"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create list-tags request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("x-request-id", newRequestID())
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		log.Printf("contabo: GET /v1/tags failed: %v", err)
+		return 0, fmt.Errorf("list-tags request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("contabo: GET /v1/tags?name=%s -> %d", name, resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("list-tags request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Data []struct {
+			TagID int64  `json:"tagId"`
+			Name  string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode list-tags response: %w", err)
+	}
+	for _, t := range result.Data {
+		if t.Name == name {
+			return t.TagID, nil
+		}
+	}
+	return 0, nil
+}
+
+// createTag creates a new Contabo tag named `name` via POST /v1/tags and
+// returns its id. If a concurrent caller already created the same tag
+// (HTTP 409 Conflict), it falls back to looking the tag up instead of
+// failing.
+func (c *HTTPClient) createTag(ctx context.Context, tok, name string) (int64, error) {
+	reqBody, err := json.Marshal(struct {
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	}{Name: name, Color: tagColor})
+	if err != nil {
+		return 0, fmt.Errorf("marshal create-tag request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.BaseURL+"/v1/tags", bytes.NewReader(reqBody))
+	if err != nil {
+		return 0, fmt.Errorf("create create-tag request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-request-id", newRequestID())
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		log.Printf("contabo: POST /v1/tags failed: %v", err)
+		return 0, fmt.Errorf("create-tag request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("contabo: POST /v1/tags (name=%s) -> %d", name, resp.StatusCode)
+
+	if resp.StatusCode == http.StatusConflict {
+		// Another caller created this tag between our GET and this POST.
+		return c.lookupTagID(ctx, tok, name)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("create-tag request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			TagID int64 `json:"tagId"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode create-tag response: %w", err)
+	}
+	if len(result.Data) == 0 {
+		return 0, errors.New("create-tag response contains no tag data")
+	}
+	return result.Data[0].TagID, nil
+}
+
+// resolveTagID returns the Contabo tag id for `name`, creating the tag if
+// it doesn't already exist. Results are memoized on the client (tagCache)
+// so a create-heavy scale-up loop doesn't re-resolve the same tag on every
+// instance.
+func (c *HTTPClient) resolveTagID(ctx context.Context, tok, name string) (int64, error) {
+	c.tagCacheMu.Lock()
+	if id, ok := c.tagCache[name]; ok {
+		c.tagCacheMu.Unlock()
+		return id, nil
+	}
+	c.tagCacheMu.Unlock()
+
+	id, err := c.lookupTagID(ctx, tok, name)
+	if err != nil {
+		return 0, err
+	}
+	if id == 0 {
+		id, err = c.createTag(ctx, tok, name)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	c.tagCacheMu.Lock()
+	c.tagCache[name] = id
+	c.tagCacheMu.Unlock()
+	return id, nil
+}
+
+// assignTag assigns tagID to instanceID via
+// POST /v1/tags/{tagId}/assignments/instance/{instanceId} (no request
+// body). See https://api.contabo.com/#tag/Tag-Assignments.
+func (c *HTTPClient) assignTag(ctx context.Context, tok string, tagID, instanceID int64) error {
+	path := fmt.Sprintf("/v1/tags/%d/assignments/instance/%d", tagID, instanceID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.BaseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("create tag-assignment request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("x-request-id", newRequestID())
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		log.Printf("contabo: POST %s failed: %v", path, err)
+		return fmt.Errorf("tag-assignment request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("contabo: POST %s -> %d", path, resp.StatusCode)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		log.Printf("contabo: tag assignment (tagId=%d instanceId=%d) failed with status %d: %s", tagID, instanceID, resp.StatusCode, string(body))
+		return fmt.Errorf("tag-assignment request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// applyTags resolves (creating if necessary) and assigns every tag name in
+// `tags` to instanceID, stopping at the first failure.
+func (c *HTTPClient) applyTags(ctx context.Context, tok string, instanceID int64, tags []string) error {
+	for _, name := range tags {
+		tagID, err := c.resolveTagID(ctx, tok, name)
+		if err != nil {
+			return fmt.Errorf("resolve tag %q: %w", name, err)
+		}
+		if err := c.assignTag(ctx, tok, tagID, instanceID); err != nil {
+			return fmt.Errorf("assign tag %q (id=%d) to instance %d: %w", name, tagID, instanceID, err)
+		}
+	}
+	return nil
 }
 
 // Create creates a new instance.
@@ -322,44 +587,26 @@ func (c *HTTPClient) Create(ctx context.Context, req CreateReq) (Instance, error
 
 		inst := result.Data[0]
 
-		// Apply tags via a separate API call if tags are provided
+		// Apply tags via the Tag Assignments API (see applyTags/assignTag).
+		// FuzeInfra's whole tracking model is tag-based (ListByTag is how CA
+		// finds existing elastic nodes), so an instance that got created but
+		// NOT tagged is worse than an outright create failure: it becomes an
+		// invisible zombie that (a) counts against the account/product quota
+		// and (b) permanently blocks any future create using the same
+		// displayName ("There is already an instance with the same display
+		// name", HTTP 400) without ever showing up in ListByTag for CA to
+		// retry against. So on tag failure we roll the instance back
+		// (best-effort delete) rather than returning it as a success — the
+		// instance must end up either tagged, or gone.
 		if len(req.Tags) > 0 {
-			tok, err := c.token(ctx)
-			if err != nil {
-				// Log but don't fail if tag assignment fails
-				log.Printf("warning: failed to refresh token for tag assignment: %v", err)
-			} else {
-				// POST /v1/compute/instances/{id}/tag-assignments
-				tagBody := struct {
-					Tags []string `json:"tags"`
-				}{
-					Tags: req.Tags,
+			tagErr := c.applyTags(ctx, tok, inst.InstanceID, req.Tags)
+			if tagErr != nil {
+				log.Printf("contabo: instance %d (%s) created but tagging failed (%v); rolling back", inst.InstanceID, inst.DisplayName, tagErr)
+				if delErr := c.Delete(ctx, inst.InstanceID); delErr != nil {
+					log.Printf("contabo: rollback delete of untagged instance %d also failed: %v — instance may be LEAKED, needs manual cleanup", inst.InstanceID, delErr)
+					return Instance{}, false, fmt.Errorf("tag instance %d: %w (rollback delete also failed: %v)", inst.InstanceID, tagErr, delErr)
 				}
-				tagBodyBytes, err := json.Marshal(tagBody)
-				if err != nil {
-					log.Printf("warning: failed to marshal tag request: %v", err)
-				} else {
-					tagReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
-						fmt.Sprintf("%s/v1/compute/instances/%d/tag-assignments", c.cfg.BaseURL, inst.InstanceID),
-						bytes.NewReader(tagBodyBytes))
-					if err != nil {
-						log.Printf("warning: failed to create tag request: %v", err)
-					} else {
-						tagReq.Header.Set("Authorization", "Bearer "+tok)
-						tagReq.Header.Set("Content-Type", "application/json")
-						tagReq.Header.Set("x-request-id", newRequestID())
-						tagResp, err := c.hc.Do(tagReq)
-						if err != nil {
-							log.Printf("warning: tag assignment request failed: %v", err)
-						} else {
-							if tagResp.StatusCode < 200 || tagResp.StatusCode >= 300 {
-								body, _ := io.ReadAll(tagResp.Body)
-								log.Printf("warning: tag assignment failed with status %d: %s", tagResp.StatusCode, string(body))
-							}
-							tagResp.Body.Close()
-						}
-					}
-				}
+				return Instance{}, false, fmt.Errorf("tag instance %d: %w (instance rolled back)", inst.InstanceID, tagErr)
 			}
 		}
 
@@ -393,34 +640,78 @@ func (c *HTTPClient) Create(ctx context.Context, req CreateReq) (Instance, error
 	return inst, err
 }
 
-// Delete deletes an instance.
+// Delete removes an instance via POST /v1/compute/instances/{id}/cancel.
+//
+// There is NO DELETE /v1/compute/instances/{id} endpoint — a live spike
+// test against a real running instance confirmed that returns HTTP 404
+// ("Cannot DELETE /v1/compute/instances/{id}"). Contabo's InstancesApi only
+// exposes cancel/create/patch/reinstall/retrieve/upgrade
+// (https://api.contabo.com/#tag/Instances — see also
+// https://github.com/p-fruck/python-contabo/blob/main/docs/InstancesApi.md,
+// and contabo/terraform-provider-contabo's resourceInstanceDelete, which
+// also calls CancelInstance). The correct call is
+// POST /v1/compute/instances/{id}/cancel with a JSON body (an empty object
+// is accepted — Contabo's own Go/Python/Terraform clients send no
+// meaningful fields either).
+//
+// IMPORTANT scale-down semantics caveat: per Contabo's docs
+// (https://help.contabo.com/.../how-do-i-cancel-a-service-) cancellation is
+// NOT immediate — "[y]our service will remain active until the displayed
+// cancellation date," i.e. cancel just schedules removal at the end of the
+// current billing period (returned here as data[0].cancelDate, logged for
+// visibility). The instance keeps running — and keeps being returned by
+// GET /v1/compute/instances, and therefore keeps showing up in ListByTag,
+// since its tag assignment is untouched — until that date. CA's
+// NodeGroupTargetSize/NodeGroupNodes (internal/provider/size.go) derive
+// purely from ListByTag, so immediately after a scale-down the "removed"
+// node will still be counted/listed; there's no documented Contabo API for
+// a hard, immediate terminate. Fully closing this gap (e.g. also stripping
+// the elastic tag on cancel so ListByTag reflects the scale-down instantly)
+// needs Delete to know the tag name, which the Client interface
+// deliberately doesn't expose today — left as a flagged follow-up rather
+// than widening the interface here.
 func (c *HTTPClient) Delete(ctx context.Context, id int64) error {
-	// Helper to perform the actual delete request
+	path := fmt.Sprintf("/v1/compute/instances/%d/cancel", id)
+
+	// Helper to perform the actual cancel request
 	doDelete := func(tok string) (bool, error) {
-		// DELETE /v1/compute/instances/{id}
-		req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-			fmt.Sprintf("%s/v1/compute/instances/%d", c.cfg.BaseURL, id), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.BaseURL+path, bytes.NewReader([]byte("{}")))
 		if err != nil {
-			return false, fmt.Errorf("create delete request: %w", err)
+			return false, fmt.Errorf("create cancel request: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("x-request-id", newRequestID())
 
 		resp, err := c.hc.Do(req)
 		if err != nil {
-			return false, fmt.Errorf("delete request failed: %w", err)
+			log.Printf("contabo: POST %s failed: %v", path, err)
+			return false, fmt.Errorf("cancel request failed: %w", err)
 		}
 		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		log.Printf("contabo: POST %s -> %d: %s", path, resp.StatusCode, string(body))
 
 		// On 401, signal to retry with a fresh token
 		if resp.StatusCode == http.StatusUnauthorized {
 			return true, errors.New("unauthorized")
 		}
 
-		// Accept both 200 and 204 as success
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-			body, _ := io.ReadAll(resp.Body)
-			return false, fmt.Errorf("delete request failed with status %d: %s", resp.StatusCode, string(body))
+		// Accept 200/201/204 as success (docs specify 201; tolerate the
+		// others in case Contabo's actual behavior differs slightly).
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+			return false, fmt.Errorf("cancel request failed with status %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result struct {
+			Data []struct {
+				InstanceID int64  `json:"instanceId"`
+				CancelDate string `json:"cancelDate"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &result); err == nil && len(result.Data) > 0 {
+			log.Printf("contabo: instance %d scheduled for cancellation on %s (NOT immediate — remains running/billed until then)", id, result.Data[0].CancelDate)
 		}
 
 		return false, nil

--- a/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client_test.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/contabo/client_test.go
@@ -10,13 +10,26 @@ import (
 	"testing"
 )
 
+// tokenResponse is what the mock AuthURL returns for every request that
+// doesn't match a more specific route below (mirrors the real Keycloak
+// password-grant response shape).
+const tokenResponse = `{"access_token":"tok","expires_in":300}`
+
 func TestListByTag(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/v1/compute/instances") {
-			w.Write([]byte(`{"data":[{"instanceId":42,"displayName":"fuzeinfra-elastic-0","status":"running","addresses":{"private":[{"ip":"10.0.0.5"}]},"tags":[{"name":"fuzeinfra-elastic"}]}]}`))
-			return
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/tags":
+			if r.URL.Query().Get("name") != "fuzeinfra-elastic" {
+				t.Errorf("expected name filter fuzeinfra-elastic, got %q", r.URL.Query().Get("name"))
+			}
+			w.Write([]byte(`{"data":[{"tagId":7,"name":"fuzeinfra-elastic","color":"#0A78C3"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/tags/7/assignments":
+			w.Write([]byte(`{"data":[{"tagId":7,"tagName":"fuzeinfra-elastic","resourceType":"instance","resourceId":"42","resourceName":"fuzeinfra-elastic-0"}],"_pagination":{"totalElements":1}}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/compute/instances"):
+			w.Write([]byte(`{"data":[{"instanceId":42,"displayName":"fuzeinfra-elastic-0","status":"running","addresses":{"private":[{"ip":"10.0.0.5"}]}},{"instanceId":43,"displayName":"other-untagged","status":"running","addresses":{"private":[{"ip":"10.0.0.6"}]}}]}`))
+		default:
+			w.Write([]byte(tokenResponse)) // token endpoint
 		}
-		w.Write([]byte(`{"access_token":"tok","expires_in":300}`)) // token endpoint
 	}))
 	defer srv.Close()
 	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
@@ -24,6 +37,8 @@ func TestListByTag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Instance 43 is NOT in the tag-assignments response, so it must be
+	// excluded even though it appears in GET /v1/compute/instances.
 	if len(got) != 1 || got[0].ID != 42 || got[0].Name != "fuzeinfra-elastic-0" {
 		t.Fatalf("unexpected: %+v", got)
 	}
@@ -35,21 +50,71 @@ func TestListByTag(t *testing.T) {
 	}
 }
 
-func TestCreateAndDelete(t *testing.T) {
-	var created, deleted bool
+// TestListByTag_NoSuchTag verifies that when the tag itself has never been
+// created (GET /v1/tags finds no exact-name match), ListByTag returns an
+// empty result instead of erroring — and never calls the assignments or
+// compute/instances endpoints, since there's nothing to look up.
+func TestListByTag_NoSuchTag(t *testing.T) {
+	var calledAssignments, calledInstances bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/v1/compute/instances":
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/tags":
+			w.Write([]byte(`{"data":[]}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/assignments"):
+			calledAssignments = true
+			w.Write([]byte(`{"data":[],"_pagination":{"totalElements":0}}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/compute/instances"):
+			calledInstances = true
+			w.Write([]byte(`{"data":[]}`))
+		default:
+			w.Write([]byte(tokenResponse))
+		}
+	}))
+	defer srv.Close()
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
+	got, err := c.ListByTag(context.Background(), "no-such-tag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no instances, got %+v", got)
+	}
+	if calledAssignments || calledInstances {
+		t.Fatalf("expected no assignments/instances lookups for a nonexistent tag, calledAssignments=%v calledInstances=%v", calledAssignments, calledInstances)
+	}
+}
+
+// TestCreateAndDelete exercises the full happy path: create an instance,
+// resolve+create its tag, assign the tag, then cancel (Delete) it.
+func TestCreateAndDelete(t *testing.T) {
+	var created, tagCreated, assigned, canceled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/compute/instances":
 			created = true
 			w.Write([]byte(`{"data":[{"instanceId":99,"displayName":"fuzeinfra-elastic-1","status":"provisioning"}]}`))
-		case r.Method == "POST" && strings.Contains(r.URL.Path, "/tag-assignments"):
-			// Tag assignment endpoint
-			w.WriteHeader(200)
-		case r.Method == "DELETE" && strings.Contains(r.URL.Path, "/instances/99"):
-			deleted = true
-			w.WriteHeader(204)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/tags":
+			// Tag doesn't exist yet.
+			w.Write([]byte(`{"data":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tags":
+			tagCreated = true
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["name"] != "fuzeinfra-elastic" {
+				t.Errorf("expected create-tag name=fuzeinfra-elastic, got %v", body["name"])
+			}
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"data":[{"tenantId":"t","customerId":"c","tagId":7}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tags/7/assignments/instance/99":
+			assigned = true
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"_links":{}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/compute/instances/99/cancel":
+			canceled = true
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"data":[{"instanceId":99,"cancelDate":"2026-08-01"}]}`))
 		default:
-			w.Write([]byte(`{"access_token":"tok","expires_in":300}`))
+			w.Write([]byte(tokenResponse))
 		}
 	}))
 	defer srv.Close()
@@ -61,8 +126,107 @@ func TestCreateAndDelete(t *testing.T) {
 	if err := c.Delete(context.Background(), 99); err != nil {
 		t.Fatal(err)
 	}
-	if !created || !deleted {
-		t.Fatal("endpoints not hit")
+	if !created || !tagCreated || !assigned || !canceled {
+		t.Fatalf("endpoints not all hit: created=%v tagCreated=%v assigned=%v canceled=%v", created, tagCreated, assigned, canceled)
+	}
+}
+
+// TestCreate_ReusesExistingTag verifies that when the tag already exists
+// (GET /v1/tags finds an exact-name match), Create does NOT call POST
+// /v1/tags again — it goes straight to assigning the existing tag id.
+func TestCreate_ReusesExistingTag(t *testing.T) {
+	var tagCreatePosted, assigned bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/compute/instances":
+			w.Write([]byte(`{"data":[{"instanceId":55,"displayName":"fuzeinfra-elastic-2","status":"provisioning"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/tags":
+			w.Write([]byte(`{"data":[{"tagId":9,"name":"fuzeinfra-elastic","color":"#0A78C3"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tags":
+			tagCreatePosted = true
+			w.Write([]byte(`{"data":[{"tenantId":"t","customerId":"c","tagId":9}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tags/9/assignments/instance/55":
+			assigned = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.Write([]byte(tokenResponse))
+		}
+	}))
+	defer srv.Close()
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
+	inst, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-2", ProductID: "V45", ImageID: "img", Region: "EU", UserData: "#cloud-config", Tags: []string{"fuzeinfra-elastic"}})
+	if err != nil || inst.ID != 55 {
+		t.Fatalf("create: %v %+v", err, inst)
+	}
+	if tagCreatePosted {
+		t.Fatal("expected POST /v1/tags to be skipped when the tag already exists")
+	}
+	if !assigned {
+		t.Fatal("expected the existing tag id to be assigned to the new instance")
+	}
+}
+
+// TestCreate_RollsBackOnTagAssignFailure verifies the leak-prevention
+// behavior: if the instance is created but the tag can never be assigned
+// (e.g. the assignment endpoint keeps failing), Create rolls the instance
+// back (cancels it) and returns an error, rather than handing back a
+// "successful" but untagged/untrackable instance — an untagged instance
+// would never be found by ListByTag again, so cluster-autoscaler could
+// never account for or retry it, and a later create with the same
+// displayName would then hit Contabo's "duplicate display name" 400.
+func TestCreate_RollsBackOnTagAssignFailure(t *testing.T) {
+	var canceled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/compute/instances":
+			w.Write([]byte(`{"data":[{"instanceId":123,"displayName":"fuzeinfra-elastic-3","status":"provisioning"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/tags":
+			w.Write([]byte(`{"data":[{"tagId":3,"name":"fuzeinfra-elastic","color":"#0A78C3"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tags/3/assignments/instance/123":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"message":"internal error"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/compute/instances/123/cancel":
+			canceled = true
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"data":[{"instanceId":123,"cancelDate":"2026-08-01"}]}`))
+		default:
+			w.Write([]byte(tokenResponse))
+		}
+	}))
+	defer srv.Close()
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
+	_, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-3", ProductID: "V45", ImageID: "img", Region: "EU", UserData: "#cloud-config", Tags: []string{"fuzeinfra-elastic"}})
+	if err == nil {
+		t.Fatal("expected Create to return an error when tag assignment fails")
+	}
+	if !canceled {
+		t.Fatal("expected Create to roll back (cancel) the instance when tag assignment fails")
+	}
+}
+
+// TestDelete_UsesCancelEndpoint verifies Delete calls POST
+// /v1/compute/instances/{id}/cancel — NOT DELETE /v1/compute/instances/{id}
+// (which a live spike test confirmed returns HTTP 404 against the real
+// Contabo API).
+func TestDelete_UsesCancelEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/compute/instances/") {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"data":[{"instanceId":99,"cancelDate":"2026-08-01"}]}`))
+			return
+		}
+		w.Write([]byte(tokenResponse))
+	}))
+	defer srv.Close()
+	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
+	if err := c.Delete(context.Background(), 99); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/compute/instances/99/cancel" {
+		t.Fatalf("expected POST /v1/compute/instances/99/cancel, got %s %s", gotMethod, gotPath)
 	}
 }
 
@@ -81,14 +245,14 @@ func TestCreate_SSHKeysOmittedWhenZero(t *testing.T) {
 			if err := json.Unmarshal(body, &gotBody); err != nil {
 				t.Fatalf("unmarshal create request body: %v", err)
 			}
-			w.Write([]byte(`{"data":[{"instanceId":100,"displayName":"fuzeinfra-elastic-2","status":"provisioning"}]}`))
+			w.Write([]byte(`{"data":[{"instanceId":100,"displayName":"fuzeinfra-elastic-4","status":"provisioning"}]}`))
 		default:
-			w.Write([]byte(`{"access_token":"tok","expires_in":300}`))
+			w.Write([]byte(tokenResponse))
 		}
 	}))
 	defer srv.Close()
 	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
-	if _, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-2", ProductID: "V45", ImageID: "img", Region: "EU", UserData: "#cloud-config"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-4", ProductID: "V45", ImageID: "img", Region: "EU", UserData: "#cloud-config"}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	if _, ok := gotBody["sshKeys"]; ok {
@@ -108,14 +272,14 @@ func TestCreate_SSHKeysPresentWhenPositive(t *testing.T) {
 			if err := json.Unmarshal(body, &gotBody); err != nil {
 				t.Fatalf("unmarshal create request body: %v", err)
 			}
-			w.Write([]byte(`{"data":[{"instanceId":101,"displayName":"fuzeinfra-elastic-3","status":"provisioning"}]}`))
+			w.Write([]byte(`{"data":[{"instanceId":101,"displayName":"fuzeinfra-elastic-5","status":"provisioning"}]}`))
 		default:
-			w.Write([]byte(`{"access_token":"tok","expires_in":300}`))
+			w.Write([]byte(tokenResponse))
 		}
 	}))
 	defer srv.Close()
 	c := NewClient(Config{BaseURL: srv.URL, AuthURL: srv.URL})
-	if _, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-3", ProductID: "V45", ImageID: "img", Region: "EU", SSHKeyID: 777, UserData: "#cloud-config"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateReq{Name: "fuzeinfra-elastic-5", ProductID: "V45", ImageID: "img", Region: "EU", SSHKeyID: 777, UserData: "#cloud-config"}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	sshKeys, ok := gotBody["sshKeys"]


### PR DESCRIPTION
## Summary
Live-prod spike test on the Contabo externalgrpc cluster-autoscaler provider confirmed two wrong endpoints in `cluster-autoscaler/contabo-externalgrpc/internal/contabo/client.go`:

- **Tagging (root cause reported):** `POST /v1/compute/instances/{id}/tag-assignments` → 404. The instance is created but never tagged `fuzeinfra-elastic`, so `ListByTag` never finds it, CA retries the create, and hits `400 "There is already an instance with the same display name"` → permanent scale-up backoff.
- **Deletion (found while fixing tagging, confirmed live against a real running instance):** `DELETE /v1/compute/instances/{id}` → 404 as well. Contabo's Instances API has no DELETE method at all.

## Endpoints settled on (cross-checked against api.contabo.com, the official OpenAPI-generated Python SDK [`p-fruck/python-contabo`](https://github.com/p-fruck/python-contabo), and [`contabo/terraform-provider-contabo`](https://github.com/contabo/terraform-provider-contabo)'s `resourceInstanceDelete`)

- `GET /v1/tags?name=<name>&size=100` — list/lookup a tag by (substring, so re-checked exact-match client-side) name.
- `POST /v1/tags` `{"name":"...","color":"#0A78C3"}` — create a tag, response `data[0].tagId`. 409 on the create is treated as "already exists" and falls back to the GET lookup (race-safety).
- `POST /v1/tags/{tagId}/assignments/instance/{instanceId}` — assign (no body).
- `GET /v1/tags/{tagId}/assignments?resourceType=instance&size=100` — list instance ids currently carrying a tag; response `data[].resourceId` (string) / `resourceType`.
- `POST /v1/compute/instances/{id}/cancel` (JSON body `{}`) — the actual instance-removal call. Response includes `data[0].cancelDate`, logged for visibility.

## Behavior changes
- **`Create`**: resolves (creating if needed, cached per tag name on the client) and assigns each `req.Tags` entry via the new API. If tag resolution/assignment fails, the instance is **rolled back** (`Delete`/cancel) and `Create` returns an error — an untagged instance would be invisible to `ListByTag` forever and would permanently block re-creating the same displayName, which is strictly worse than a create failure.
- **`ListByTag`**: no longer trusts a `.tags[]` field on the compute-instance object (Contabo's compute-instance resource doesn't carry its own tags — tags are a separate resource). Now resolves the tag id, reads its assignments, and filters `GET /v1/compute/instances` (unchanged, known-good) down to the assigned id set.
- **`Delete`**: now calls `POST /v1/compute/instances/{id}/cancel` instead of the nonexistent DELETE.

## ⚠️ Scale-down semantics caveat (flagging, not silently fixing)
Per Contabo's own docs, **cancellation is NOT immediate** — "your service will remain active until the displayed cancellation date," i.e. cancel schedules removal at the end of the current billing period. The instance keeps running (and keeps being billed, and keeps appearing in `GET /v1/compute/instances` and therefore in `ListByTag`, since its tag assignment is untouched) until `cancelDate`. `NodeGroupTargetSize`/`NodeGroupNodes` (`internal/provider/size.go`) derive purely from `ListByTag`, so immediately after a CA-initiated scale-down the "removed" node will still be counted/listed — there is no documented Contabo API for a hard, immediate terminate.

Fully closing this (e.g. also stripping the elastic tag on cancel so `ListByTag` reflects the scale-down instantly) needs `Delete` to know the tag name — the `Client` interface deliberately still only takes `(ctx, id)` per the task's explicit "don't change the Client interface" constraint — so it's left as a flagged follow-up rather than widened here. Documented at length in the `Delete` doc-comment in `client.go`.

## Uncertainty for the next live spike test
- `POST /v1/tags/{tagId}/assignments/instance/{instanceId}` — path/verb verified against 3 independent sources but not yet exercised against the real Contabo API (only httptest mocks here). Watch the new diagnostic logs (`contabo: POST /v1/tags/... -> <status>`) on the next spike.
- Exact success status codes (I accept 200/201/204 defensively) and whether Contabo's `name` filter on `GET /v1/tags` is case-sensitive.
- `GET /v1/tags/{tagId}/assignments` pagination: single page (`size=100`) for now; logs a loud warning if `_pagination.totalElements` exceeds what was returned. Not expected to matter at FuzeInfra's current elastic-fleet scale, but noted.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -race -count=1` — all packages pass, including new tests: tag resolve/create/reuse, assign-on-create, rollback-on-assign-failure, `ListByTag` via the assignments API (and correctly excluding an untagged instance present in `/v1/compute/instances`), `Delete` hitting `/cancel` not `DELETE`. Existing token/SSH-key tests still green.
- [ ] Live spike test against real Contabo API (not run here — this PR is httptest-mock-only, per the endpoint uncertainty noted above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)