### PR TITLE
fix(ca): unique elastic instance names + cloud-init aligned to working module

### DIFF
--- a/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata.template
+++ b/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata.template
@@ -38,25 +38,35 @@ users:
     ssh_authorized_keys:
       - __SSH_PUBLIC_KEY__
 
+package_update: true
+
 write_files:
   # k3s join secrets land in a root-only env file rather than the process
   # table, so the token never shows up in `ps`/cloud-init logs as a CLI arg.
+  # INSTALL_K3S_CHANNEL is pinned to "stable" to match
+  # modules/contabo-k3s-node's k3s_channel default (see its variables.tf /
+  # README "k3s version skew" note) — an agent more than one minor
+  # ahead/behind the server is unsupported, so this must track whatever
+  # channel the running k3s server was installed from.
   - path: /etc/k3s-agent.env
     permissions: "0600"
     owner: root:root
     content: |
       K3S_URL={{.K3SServerURL}}
       K3S_TOKEN={{.K3SNodeToken}}
+      INSTALL_K3S_CHANNEL=stable
 
 runcmd:
-  # Host firewall: agent needs to reach the k3s API (6443) outbound and accept
-  # kubelet (10250) + the flannel overlay from the server. 51820/udp is the
-  # WireGuard backend (wireguard-native) the server is being reprovisioned
-  # onto; 8472/udp (VXLAN) is kept alongside it during the transition.
+  # Host firewall: agent needs to reach the API (6443) outbound and accept
+  # kubelet (10250) + the flannel VXLAN overlay (8472/udp) from the server.
+  # WireGuard overlay is a separate, cluster-wide hardening initiative —
+  # intentionally NOT coupled to autoscaling; elastic nodes join over the
+  # same public-IP + VXLAN path as the baseline nodes provisioned by
+  # modules/contabo-k3s-node (mirror that module's firewall rules exactly;
+  # do not add a WireGuard port here unless it does too).
   - [ sh, -c, "ufw allow 22/tcp || true" ]
   - [ sh, -c, "ufw allow 10250/tcp || true" ]
   - [ sh, -c, "ufw allow 8472/udp || true" ]
-  - [ sh, -c, "ufw allow 51820/udp || true" ]
   - [ sh, -c, "ufw --force enable || true" ]
   # Join as a k3s agent using the join secrets written above. --node-name and
   # --kubelet-arg=provider-id are what let NodeGroupNodes/NodeGroupDeleteNodes

--- a/cluster-autoscaler/contabo-externalgrpc/go.mod
+++ b/cluster-autoscaler/contabo-externalgrpc/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.30.5
 	k8s.io/apimachinery v0.30.5
 )
@@ -21,7 +22,6 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/cluster-autoscaler/contabo-externalgrpc/internal/provider/elastic_userdata_template_test.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/provider/elastic_userdata_template_test.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestElasticUserDataTemplate_RendersValidCloudConfig proves that
+// deploy/elastic-userdata.template — the canonical source ca-cutover.yml
+// base64-encodes into clusterAutoscaler.provider.userDataTemplateB64 — still
+// renders to syntactically valid #cloud-config YAML once its Go-template
+// vars ({{.NodeName}}/{{.K3SServerURL}}/{{.K3SNodeToken}}) and the
+// __SSH_PUBLIC_KEY__ placeholder are substituted exactly as renderUserData
+// and ca-cutover.yml do it.
+//
+// This guards against the failure mode a real elastic scale-up hit: a VPS
+// created from a userdata blob that cloud-init can't parse as valid YAML
+// aborts before runcmd ever executes, so k3s is never installed and the node
+// never joins — silently, with no error surfaced to the autoscaler.
+func TestElasticUserDataTemplate_RendersValidCloudConfig(t *testing.T) {
+	tmplPath := elasticUserDataTemplatePath(t)
+	raw, err := os.ReadFile(tmplPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", tmplPath, err)
+	}
+
+	rendered, err := renderUserData(
+		string(raw),
+		"fuzeinfra-elastic-a1b2c3d4",
+		"https://161.97.118.134:6443",
+		"K10stubtoken::server:stub",
+	)
+	if err != nil {
+		t.Fatalf("renderUserData: %v", err)
+	}
+
+	// Stub the SSH-key placeholder the same way ca-cutover.yml's Python step
+	// does (content.replace("__SSH_PUBLIC_KEY__", key)), so this fixture
+	// matches what actually gets base64-encoded into userDataTemplateB64.
+	const stubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstubstubstubstubstubstubstubstubstub ci-stub"
+	rendered = strings.ReplaceAll(rendered, "__SSH_PUBLIC_KEY__", stubKey)
+
+	if strings.Contains(rendered, "__SSH_PUBLIC_KEY__") {
+		t.Fatalf("stub substitution left __SSH_PUBLIC_KEY__ unresolved:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "{{") || strings.Contains(rendered, "}}") {
+		t.Fatalf("rendered userdata still contains unrendered template actions:\n%s", rendered)
+	}
+	if !strings.HasPrefix(rendered, "#cloud-config") {
+		t.Fatalf("rendered userdata must start with #cloud-config (required by cloud-init to select the cloud-config handler), got:\n%.80s", rendered)
+	}
+
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal([]byte(rendered), &doc); err != nil {
+		t.Fatalf("rendered userdata is not valid YAML: %v\n--- rendered ---\n%s", err, rendered)
+	}
+
+	for _, key := range []string{"users", "write_files", "runcmd"} {
+		if _, ok := doc[key]; !ok {
+			t.Errorf("rendered cloud-config missing expected top-level key %q", key)
+		}
+	}
+
+	// The join command is the single point of failure for cluster membership:
+	// assert the substituted values and the required join flags all made it
+	// into the rendered runcmd, so a future edit can't silently drop one.
+	runcmd, ok := doc["runcmd"].([]interface{})
+	if !ok || len(runcmd) == 0 {
+		t.Fatalf("want a non-empty runcmd list, got %#v", doc["runcmd"])
+	}
+	joinLine := renderedRuncmdShellString(t, runcmd[len(runcmd)-1])
+	for _, want := range []string{
+		"K3S_URL=https://161.97.118.134:6443",
+		"K3S_TOKEN=K10stubtoken::server:stub",
+		"--node-name 'fuzeinfra-elastic-a1b2c3d4'",
+		"--kubelet-arg 'provider-id=contabo://fuzeinfra-elastic-a1b2c3d4'",
+		"--node-label 'fuzeinfra.io/pool=elastic'",
+		"--node-taint 'fuzeinfra.io/elastic=true:PreferNoSchedule'",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered userdata missing %q\n--- rendered ---\n%s", want, rendered)
+		}
+	}
+	if !strings.Contains(joinLine, "get.k3s.io") {
+		t.Errorf("want the last runcmd entry to be the k3s join command, got: %v", joinLine)
+	}
+}
+
+// renderedRuncmdShellString extracts the shell command string from a
+// `[ sh, -c, "..." ]` runcmd entry as decoded by yaml.v2 (a []interface{} of
+// strings).
+func renderedRuncmdShellString(t *testing.T, entry interface{}) string {
+	t.Helper()
+	parts, ok := entry.([]interface{})
+	if !ok || len(parts) != 3 {
+		t.Fatalf("want a 3-element [sh, -c, \"...\"] runcmd entry, got %#v", entry)
+	}
+	cmd, ok := parts[2].(string)
+	if !ok {
+		t.Fatalf("want the third runcmd element to be a string, got %#v", parts[2])
+	}
+	return cmd
+}
+
+func elasticUserDataTemplatePath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed to resolve this test file's location")
+	}
+	// This file lives in internal/provider/; the template lives in deploy/,
+	// two directories up from there (internal/provider -> internal ->
+	// contabo-externalgrpc -> deploy).
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "deploy", "elastic-userdata.template")
+}

--- a/cluster-autoscaler/contabo-externalgrpc/internal/provider/scale.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/provider/scale.go
@@ -2,8 +2,8 @@ package provider
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -42,15 +42,22 @@ func (s *Server) NodeGroupIncreaseSize(ctx context.Context, req *protos.NodeGrou
 			current, req.Delta, s.cfg.MaxSize)
 	}
 
-	// Compute next available index for naming.
-	// Find the max numeric suffix among existing elastic instance names,
-	// then increment to get the start index for new instances.
-	nextIndex := computeNextIndex(instances, s.cfg.NamePrefix)
+	// Track names already known (from the tagged fleet) or freshly minted in
+	// this loop, so a random-suffix collision is retried locally rather than
+	// sent to Contabo (which 400s on a duplicate display name).
+	usedNames := make(map[string]struct{}, len(instances)+int(req.Delta))
+	for _, inst := range instances {
+		usedNames[inst.Name] = struct{}{}
+	}
 
 	// Create Delta instances.
 	for i := 0; i < int(req.Delta); i++ {
-		// Build instance name
-		instanceName := fmt.Sprintf("%s-%d", s.cfg.NamePrefix, nextIndex+i)
+		// Build a unique instance name.
+		instanceName, err := uniqueInstanceName(s.cfg.NamePrefix, usedNames)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "NodeGroupIncreaseSize: generating instance name: %v", err)
+		}
+		usedNames[instanceName] = struct{}{}
 
 		// Render UserData from template
 		userData, err := renderUserData(s.cfg.UserDataTmpl, instanceName, s.cfg.K3SServerURL, s.cfg.K3SNodeToken)
@@ -76,38 +83,49 @@ func (s *Server) NodeGroupIncreaseSize(ctx context.Context, req *protos.NodeGrou
 	return &protos.NodeGroupIncreaseSizeResponse{}, nil
 }
 
-// computeNextIndex finds the max numeric suffix in existing instance names
-// matching the NamePrefix pattern and returns the next index to use.
-// If no matching instances, returns 0.
-func computeNextIndex(instances []contabo.Instance, namePrefix string) int {
-	prefix := namePrefix + "-"
-	maxIdx := -1
+// maxNameSuffixAttempts bounds the retry loop in uniqueInstanceName against a
+// pathological run of random collisions. At 4 random bytes (32 bits) of
+// suffix space, exhausting this many attempts in practice indicates a bug
+// (e.g. a broken RNG) rather than bad luck.
+const maxNameSuffixAttempts = 20
 
-	for _, inst := range instances {
-		// Check if the name starts with the expected prefix
-		if !strings.HasPrefix(inst.Name, prefix) {
-			continue
-		}
-
-		// Extract the suffix after the prefix
-		suffix := inst.Name[len(prefix):]
-
-		// Try to parse the suffix as an integer
-		idx, err := strconv.Atoi(suffix)
+// uniqueInstanceName generates an instance name of the form
+// "<namePrefix>-<8-hex-suffix>" that is not already present in used.
+//
+// The suffix is a short random value (crypto/rand, mirroring the UUID
+// request-id helper in internal/contabo/client.go) rather than a sequential
+// index. A sequential index collides whenever a prior create left an
+// untracked or still-cancelling instance holding a name: Contabo's cancel is
+// end-of-billing, so a cancelled instance keeps its display name (and thus
+// blocks reuse of that name) for the remainder of the billing period, and
+// Contabo's create API 400s ("There is already an instance with the same
+// display name") on any collision. The prefix invariant is preserved and the
+// resulting name still flows unmodified through create -> tag -> cloud-init
+// --node-name -> providerID, which is all NodeGroupForNode/
+// NodeGroupDeleteNodes require for correlation — nothing depends on the
+// suffix being sequential or predictable, only unique.
+func uniqueInstanceName(namePrefix string, used map[string]struct{}) (string, error) {
+	for attempt := 0; attempt < maxNameSuffixAttempts; attempt++ {
+		suffix, err := randomHexSuffix()
 		if err != nil {
-			// Suffix is not a valid integer; skip this instance
-			continue
+			return "", err
 		}
-
-		if idx > maxIdx {
-			maxIdx = idx
+		name := fmt.Sprintf("%s-%s", namePrefix, suffix)
+		if _, collision := used[name]; !collision {
+			return name, nil
 		}
 	}
+	return "", fmt.Errorf("could not generate a unique instance name after %d attempts", maxNameSuffixAttempts)
+}
 
-	if maxIdx < 0 {
-		return 0
+// randomHexSuffix returns 4 crypto/rand bytes rendered as 8 lowercase hex
+// characters, e.g. "a1b2c3d4".
+func randomHexSuffix() (string, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random name suffix: %w", err)
 	}
-	return maxIdx + 1
+	return fmt.Sprintf("%x", b), nil
 }
 
 // renderUserData renders cfg.UserDataTmpl with the provided nodeName and the

--- a/cluster-autoscaler/contabo-externalgrpc/internal/provider/scale_test.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/provider/scale_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/izzywdev/fuzeinfra/contabo-externalgrpc/internal/contabo"
@@ -78,17 +79,18 @@ func TestIncreaseSize_HappyPath(t *testing.T) {
 		t.Fatalf("want 2 create calls, got %d", fc.createCalls)
 	}
 
-	// Verify instance names are correct
+	// Verify instance names are correct: prefixed, and unique from each other
+	// (naming is now a random suffix, not a sequential index — see
+	// uniqueInstanceName in scale.go).
 	if len(fc.instances) != 2 {
 		t.Fatalf("want 2 instances, got %d", len(fc.instances))
 	}
 
-	if fc.instances[0].Name != "fuzeinfra-elastic-0" {
-		t.Fatalf("want instance[0].Name=fuzeinfra-elastic-0, got %q", fc.instances[0].Name)
-	}
+	assertElasticName(t, fc.instances[0].Name, "fuzeinfra-elastic")
+	assertElasticName(t, fc.instances[1].Name, "fuzeinfra-elastic")
 
-	if fc.instances[1].Name != "fuzeinfra-elastic-1" {
-		t.Fatalf("want instance[1].Name=fuzeinfra-elastic-1, got %q", fc.instances[1].Name)
+	if fc.instances[0].Name == fc.instances[1].Name {
+		t.Fatalf("want unique instance names, got duplicate %q", fc.instances[0].Name)
 	}
 }
 
@@ -144,8 +146,13 @@ func TestIncreaseSize_ListErrorPropagates(t *testing.T) {
 	}
 }
 
-func TestIncreaseSize_NamingContinuesFromExisting(t *testing.T) {
-	// Pre-load with instances named 0,1,2 and verify next index is 3
+func TestIncreaseSize_NamingAvoidsCollisionWithExisting(t *testing.T) {
+	// Pre-load with an untracked/still-cancelling instance holding the
+	// lowest-numbered legacy sequential name. A sequential-index scheme
+	// would try to reuse "fuzeinfra-elastic-0" (already taken -> Contabo
+	// 400s on duplicate display name); the random-suffix scheme must instead
+	// produce names that are prefixed, unique from each other, and distinct
+	// from every pre-existing name.
 	fc := &fakeCloudCapTest{
 		instances: []contabo.Instance{
 			{ID: 10, Name: "fuzeinfra-elastic-0", Tags: []string{"fuzeinfra-elastic"}},
@@ -178,17 +185,51 @@ func TestIncreaseSize_NamingContinuesFromExisting(t *testing.T) {
 		t.Fatalf("want non-nil response")
 	}
 
-	// Verify 2 new instances created with indices 3 and 4
 	if len(fc.instances) != 5 {
 		t.Fatalf("want 5 instances total, got %d", len(fc.instances))
 	}
 
-	if fc.instances[3].Name != "fuzeinfra-elastic-3" {
-		t.Fatalf("want instance[3].Name=fuzeinfra-elastic-3, got %q", fc.instances[3].Name)
+	newNames := map[string]struct{}{
+		fc.instances[3].Name: {},
+		fc.instances[4].Name: {},
+	}
+	if len(newNames) != 2 {
+		t.Fatalf("want 2 distinct new instance names, got %v", newNames)
 	}
 
-	if fc.instances[4].Name != "fuzeinfra-elastic-4" {
-		t.Fatalf("want instance[4].Name=fuzeinfra-elastic-4, got %q", fc.instances[4].Name)
+	preExisting := map[string]struct{}{
+		"fuzeinfra-elastic-0": {},
+		"fuzeinfra-elastic-1": {},
+		"fuzeinfra-elastic-2": {},
+	}
+	for name := range newNames {
+		assertElasticName(t, name, "fuzeinfra-elastic")
+		if _, collides := preExisting[name]; collides {
+			t.Fatalf("new instance name %q collides with a pre-existing name", name)
+		}
+	}
+}
+
+// assertElasticName asserts name has the given prefix followed by
+// "-<8-hex-chars>" (the random suffix format from uniqueInstanceName), and
+// nothing else.
+func assertElasticName(t *testing.T, name, prefix string) {
+	t.Helper()
+
+	wantPrefix := prefix + "-"
+	if !strings.HasPrefix(name, wantPrefix) {
+		t.Fatalf("want name with prefix %q, got %q", wantPrefix, name)
+	}
+
+	suffix := strings.TrimPrefix(name, wantPrefix)
+	if len(suffix) != 8 {
+		t.Fatalf("want an 8-char hex suffix, got %q (len %d) in name %q", suffix, len(suffix), name)
+	}
+	for _, r := range suffix {
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')
+		if !isHex {
+			t.Fatalf("want a lowercase-hex suffix, got %q in name %q", suffix, name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
A real elastic scale-up in prod created a Contabo VPS but hit two problems. Builds on top of #363 (tag+cancel endpoint fix), does not revert it.

- **Naming collision**: `NodeGroupIncreaseSize` named new instances `fuzeinfra-elastic-<sequentialIndex>`. A prior create had left an untracked/still-cancelling instance holding `fuzeinfra-elastic-0` (Contabo `cancel` is end-of-billing, so a cancelled instance keeps its display name for weeks), so the next create collided and Contabo 400'd with `"There is already an instance with the same display name"`. Replaced the sequential index with `uniqueInstanceName`, a short `crypto/rand` hex suffix (mirrors the UUID request-id helper in `internal/contabo/client.go`), retried against the known fleet + names already minted in the same batch. The `fuzeinfra-elastic-` prefix is preserved, and the name still flows unmodified through create → tag → cloud-init `--node-name` → providerID — `NodeGroupForNode`/`NodeGroupDeleteNodes` only require that name be *consistent*, not sequential.
- **Nodes never joined k3s**: `deploy/elastic-userdata.template` had drifted from the proven `modules/contabo-k3s-node/cloud-init.tftpl` it was modeled on. A stale `ufw allow 51820/udp` (WireGuard) rule survived a refactor (`074702c`) that deliberately dropped WireGuard from the module's critical path, and `package_update`/`INSTALL_K3S_CHANNEL` were missing entirely from the elastic template. Realigned the firewall rule set, added `package_update: true`, and pinned `INSTALL_K3S_CHANNEL=stable` to match the module's default — so elastic nodes now provision over the identical VXLAN-only path the working baseline/CI nodes already use. (The `users:`/SSH-key block and the extra `--kubelet-arg 'provider-id=...'` flag were already structurally identical to the module and are intentionally kept — the drift was isolated to the firewall/channel/package directives.)

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -race -count=1` — all packages pass, including:
  - `TestIncreaseSize_HappyPath` / `TestIncreaseSize_NamingAvoidsCollisionWithExisting` — new naming asserts prefix + uniqueness, not a fixed index, and that new names never collide with a pre-existing (possibly cancelling) name.
  - `TestElasticUserDataTemplate_RendersValidCloudConfig` (new) — renders the real `deploy/elastic-userdata.template` through `renderUserData` plus the same `__SSH_PUBLIC_KEY__` substitution `ca-cutover.yml` performs, parses the result as YAML, and asserts the join command's required flags (`--node-name`, `--kubelet-arg provider-id`, node-label, node-taint, K3S_URL/K3S_TOKEN) survive rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)