### PR TITLE
fix(ca): elastic cloud-init allows WireGuard + pins k3s to v1.36 channel

### DIFF
--- a/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata.template
+++ b/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata.template
@@ -43,30 +43,33 @@ package_update: true
 write_files:
   # k3s join secrets land in a root-only env file rather than the process
   # table, so the token never shows up in `ps`/cloud-init logs as a CLI arg.
-  # INSTALL_K3S_CHANNEL is pinned to "stable" to match
-  # modules/contabo-k3s-node's k3s_channel default (see its variables.tf /
-  # README "k3s version skew" note) — an agent more than one minor
-  # ahead/behind the server is unsupported, so this must track whatever
-  # channel the running k3s server was installed from.
+  # INSTALL_K3S_CHANNEL is pinned to "v1.36" to mirror
+  # modules/contabo-k3s-node's k3s_channel default (see its variables.tf,
+  # updated by FuzeInfra#318/#366) — same minor as the fleet, which is live
+  # on v1.36.2+k3s1 across all 4 nodes including the control-plane. An agent
+  # more than one minor ahead/behind the server is unsupported, so this must
+  # track whatever channel the baseline module pins.
   - path: /etc/k3s-agent.env
     permissions: "0600"
     owner: root:root
     content: |
       K3S_URL={{.K3SServerURL}}
       K3S_TOKEN={{.K3SNodeToken}}
-      INSTALL_K3S_CHANNEL=stable
+      INSTALL_K3S_CHANNEL=v1.36
 
 runcmd:
   # Host firewall: agent needs to reach the API (6443) outbound and accept
-  # kubelet (10250) + the flannel VXLAN overlay (8472/udp) from the server.
-  # WireGuard overlay is a separate, cluster-wide hardening initiative —
-  # intentionally NOT coupled to autoscaling; elastic nodes join over the
-  # same public-IP + VXLAN path as the baseline nodes provisioned by
-  # modules/contabo-k3s-node (mirror that module's firewall rules exactly;
-  # do not add a WireGuard port here unless it does too).
+  # kubelet (10250) from the server, plus whichever flannel backend the
+  # cluster is actually running. The live prod cluster runs flannel
+  # wireguard-native on ALL nodes (FuzeInfra#366), so an elastic agent MUST
+  # allow 51820/udp or it can register with the API server but never pass
+  # WireGuard pod-overlay traffic — the likely reason a prior elastic
+  # instance never truly joined. 8472/udp (VXLAN) is kept too since it's
+  # harmless and mirrors the baseline module's firewall rules.
   - [ sh, -c, "ufw allow 22/tcp || true" ]
   - [ sh, -c, "ufw allow 10250/tcp || true" ]
   - [ sh, -c, "ufw allow 8472/udp || true" ]
+  - [ sh, -c, "ufw allow 51820/udp || true" ]
   - [ sh, -c, "ufw --force enable || true" ]
   # Join as a k3s agent using the join secrets written above. --node-name and
   # --kubelet-arg=provider-id are what let NodeGroupNodes/NodeGroupDeleteNodes

--- a/cluster-autoscaler/contabo-externalgrpc/internal/provider/elastic_userdata_template_test.go
+++ b/cluster-autoscaler/contabo-externalgrpc/internal/provider/elastic_userdata_template_test.go
@@ -81,6 +81,14 @@ func TestElasticUserDataTemplate_RendersValidCloudConfig(t *testing.T) {
 		"--kubelet-arg 'provider-id=contabo://fuzeinfra-elastic-a1b2c3d4'",
 		"--node-label 'fuzeinfra.io/pool=elastic'",
 		"--node-taint 'fuzeinfra.io/elastic=true:PreferNoSchedule'",
+		// Pinned to the same channel as the baseline module (v1.36, per
+		// #318/#366) rather than a floating "stable" channel, so an elastic
+		// agent joins in lockstep with the rest of the fleet.
+		"INSTALL_K3S_CHANNEL=v1.36",
+		// The live prod cluster runs flannel wireguard-native on all nodes
+		// (#366), so an elastic agent must allow WireGuard traffic or it can
+		// never pass pod-overlay traffic even after joining the API server.
+		"ufw allow 51820/udp",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Errorf("rendered userdata missing %q\n--- rendered ---\n%s", want, rendered)


### PR DESCRIPTION
## Summary
- Re-does the elastic cloud-init corrections from the force-merged #364 (its branch was deleted), retargeted onto latest `main` after #366 converged the fleet onto flannel `wireguard-native` + k3s `v1.36`.
- `deploy/elastic-userdata.template`: adds `ufw allow 51820/udp` (WireGuard) alongside the existing `8472/udp` (VXLAN) rule — the live cluster runs flannel wireguard-native on all nodes, so an elastic agent that can't pass WireGuard traffic registers with the API server but never joins the pod overlay. Rewrites the stale "WireGuard is a separate initiative" comment accordingly.
- Replaces the floating `INSTALL_K3S_CHANNEL=stable` with `INSTALL_K3S_CHANNEL=v1.36`, mirroring the baseline module's `k3s_channel` default (#318/#366) — the fleet (incl. control-plane) is converged on `v1.36.2+k3s1`.
- Updates `internal/provider/elastic_userdata_template_test.go` to assert both the pinned channel and the new firewall rule render into the cloud-init.

## Root cause of the gate-lint / gate-test "failures"
Not a Go source defect. `gate-lint`/`gate-test` in `.github/workflows/harden-gate.yml` are generic, report-only jobs (`set +e; ... exit 0`) that don't even invoke Go tooling — they only look for `package.json`/`*.py`/`*.js`. Both jobs' step timelines showed them stuck `in_progress` forever on `actions/setup-python@v7` (steps 5+ stayed `pending`) until a ~12min timeout marked the job `failure` — a self-hosted "staging" runner hang, not a code issue. Confirmed by re-running the exact same failed jobs on #364 with zero code changes: both went green (`gate-test` 5m52s, `gate-lint` 1m11s). `go build ./... && go vet ./... && gofmt -l . && go test ./...` are all clean/green in the `golang:1.25` Docker toolchain for this branch.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean (checked against an LF-normalized copy to avoid Windows-checkout CRLF false positives)
- [x] `go test ./...` green, including the updated `TestElasticUserDataTemplate_RendersValidCloudConfig`
- [ ] CI gates on this PR (monitor; re-run if the same self-hosted-runner flake recurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)