### PR TITLE
feat(s3): wire Loki→S3, add gated DB backup CronJobs, doc app blobs

### DIFF
--- a/docs/backups-and-blobs.md
+++ b/docs/backups-and-blobs.md
@@ -1,0 +1,134 @@
+# Stateful data on S3 (Contabo Object Storage)
+
+FuzeInfra runs its stateful stores on **block / local-path** storage. Object
+storage (S3-compatible, Contabo Object Storage) is **not** a live data volume for
+any database — S3 has no POSIX/block semantics, so Postgres, MongoDB, Redis,
+Neo4j, Elasticsearch, ChromaDB, Kafka and RabbitMQ all keep their data on the
+node's block storage. S3 has exactly three roles on this platform:
+
+| Use | Bucket | Mechanism | Default |
+|-----|--------|-----------|---------|
+| Loki log chunks + index | `fuzeinfra-loki` | Loki native S3 backend | off |
+| Scheduled DB backup dumps | `fuzeinfra-backups` | backup CronJobs (this chart) | off |
+| Application blob storage | `fuzeinfra-blobs` | app SDK (S3 client) | n/a |
+
+Everything is **default-disabled** and every enable step is human-gated and
+GitOps-driven. Prometheus long-term storage is a separate, deferred concern
+(documented at the bottom).
+
+Buckets and S3 key pairs are provisioned by Terraform (`object-storage.tf`, on
+the existing Contabo OAuth2 provider). Credentials are **never** created with
+`kubectl create secret` — they are sealed OFFLINE into SealedSecrets in the
+`fuzeinfra` namespace, committed, and synced by Argo CD.
+
+---
+
+## 1. Loki → S3 (`fuzeinfra-loki`)
+
+Loki's S3 backend is already wired in the chart (`loki.s3.*` in `values.yaml`,
+consumed by `templates/configmaps-monitoring.yaml` and `templates/monitoring.yaml`).
+On the prod overlay (`values-contabo.yaml`) the endpoint/bucket are filled in and
+the switch is `loki.s3.enabled`, kept **false** until the credential SealedSecret
+exists (flipping it on without the secret would crash-loop Loki).
+
+**Enable (human-gated):**
+
+1. Fetch the S3 key pair for `fuzeinfra-loki` from the Contabo panel.
+2. Seal it offline into a SealedSecret named `loki-s3` in the `fuzeinfra`
+   namespace with keys `LOKI_S3_ACCESS_KEY_ID` / `LOKI_S3_SECRET_ACCESS_KEY`.
+   Commit it; let Argo sync.
+3. Set `loki.s3.enabled: true` in `values-contabo.yaml`; commit; let Argo sync.
+
+There is **no** log migration — existing on-disk chunks age out under the Loki
+retention policy; new chunks land in S3.
+
+---
+
+## 2. Scheduled DB backups → S3 (`fuzeinfra-backups`)
+
+`templates/backup-cronjobs.yaml` creates one CronJob per database, gated by
+`backups.enabled` (default false) and per-DB `backups.<db>.enabled`. Each pod:
+
+- **initContainer `dump`** runs in the database's own image (so it ships the
+  native dump tool), connects to the in-namespace Service, and writes one
+  compressed file to a shared `emptyDir`:
+  - **Postgres** — `pg_dumpall | gzip` (all databases + globals).
+  - **MongoDB** — `mongodump --archive --gzip` (single-file archive).
+  - **Neo4j** — **online** logical export via `apoc.export.cypher.all(..stream..)`
+    streamed over Bolt and gzipped. Community Neo4j has no online
+    `neo4j-admin backup`; APOC is present in the cluster image
+    (`NEO4J_PLUGINS=["apoc"]`), so this needs no downtime.
+- **container `upload`** runs the aws-cli image and `aws s3 cp`s the file to
+  `s3://fuzeinfra-backups/<prefix>/<db>/fuzeinfra-<db>-<ts>.<ext>`.
+
+DB credentials come from `fuzeinfra-secrets` (in-namespace, by key). The S3 key
+pair comes from the SealedSecret named by `backups.s3.existingSecret`
+(e.g. `fuzeinfra-backups-s3`, keys `BACKUP_S3_ACCESS_KEY_ID` /
+`BACKUP_S3_SECRET_ACCESS_KEY`).
+
+**Enable (human-gated):**
+
+1. `terraform apply` the `object-storage.tf` bucket (out of scope for this PR).
+2. Seal the S3 key pair offline into `fuzeinfra-backups-s3`; commit; Argo sync.
+3. Set `backups.enabled: true` (and `backups.s3.endpoint`) in
+   `values-contabo.yaml`; commit; Argo sync.
+
+**Retention** (age-out of old dumps) is an **S3 bucket lifecycle policy** on
+`fuzeinfra-backups`, defined in Terraform — *not* in these CronJobs. The Jobs
+only ever write; the lifecycle rule expires objects older than N days.
+
+**Restore** (manual, break-glass): download the object, then
+`gunzip | psql` (Postgres, into a fresh cluster), `mongorestore --archive --gzip`
+(Mongo), or `cypher-shell < dump.cypher` (Neo4j). Restore is intentionally not
+automated.
+
+### Tuning
+
+```yaml
+backups:
+  enabled: true
+  schedule: "0 2 * * *"        # default; per-DB `schedule:` overrides
+  s3: { endpoint, region, bucket, prefix, existingSecret }
+  postgres: { enabled: true, image: postgres:15, host, port }
+  mongodb:  { enabled: true, image: mongo:7,     host, port }
+  neo4j:    { enabled: true, image: neo4j:5,      host, boltPort }
+```
+
+---
+
+## 3. Application blobs → S3 (`fuzeinfra-blobs`)
+
+User-generated blobs (uploads, attachments, exports, generated media) belong in
+object storage, **not** in a database column or a pod PVC. Apps talk to the
+`fuzeinfra-blobs` bucket directly with any S3 SDK — FuzeInfra provisions the
+bucket and hands the app a scoped key pair; it does not proxy blob traffic.
+
+Onboarding an app for blob storage:
+
+1. Provision a bucket/prefix + a scoped S3 key pair (Terraform `object-storage.tf`).
+2. Seal the key pair for the app's namespace as a SealedSecret (the app repo
+   does this via the `@claude` delegation flow — FuzeInfra is not edited directly).
+3. The app reads endpoint/bucket/creds from env and uses its S3 SDK:
+
+```
+S3_ENDPOINT=https://eu2.contabostorage.com
+S3_REGION=default
+S3_BUCKET=fuzeinfra-blobs
+S3_FORCE_PATH_STYLE=true          # required for Contabo/MinIO-style endpoints
+S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY   # from the SealedSecret
+```
+
+Contabo (like MinIO) requires **path-style** addressing and a non-AWS
+`endpoint`. Most SDKs need both `forcePathStyle: true` and an explicit
+`endpoint` set. Presigned URLs work for direct browser upload/download without
+routing bytes through the app.
+
+---
+
+## Deferred: Prometheus long-term storage (Thanos)
+
+Prometheus keeps only local TSDB today. Long-term/HA metrics on S3 is a separate
+effort via the **Thanos** sidecar + object-store path (`thanos-store`,
+`thanos-compact`) writing to a `fuzeinfra-metrics` bucket. It is **not** part of
+this work and is tracked separately; the DB-backup and Loki paths above do not
+depend on it.

--- a/helm/fuzeinfra/templates/backup-cronjobs.yaml
+++ b/helm/fuzeinfra/templates/backup-cronjobs.yaml
@@ -1,0 +1,188 @@
+{{- /*
+============================ Scheduled DB backups → S3 ============================
+One CronJob per stateful database. Each dumps a *running* instance (no downtime)
+and uploads the compressed snapshot to the Contabo Object Storage backup bucket.
+
+Structure of every CronJob's pod:
+  * initContainer `dump`  — runs in the DB's own image (so it ships the native
+    dump tool), connects to the in-namespace DB Service, writes a single file to
+    the shared emptyDir at /backup/dump.bin, and records the desired S3 object
+    key in /backup/remote-key.
+  * container    `upload` — runs in the aws-cli image and `aws s3 cp`s that file
+    to s3://<bucket>/<key> against the Contabo S3 endpoint.
+
+Credentials never touch git: DB creds come from `fuzeinfra-secrets` (in-namespace,
+by key only); the S3 key pair comes from an OFFLINE-sealed SealedSecret referenced
+by `backups.s3.existingSecret`. Retention/age-out is an S3 bucket lifecycle policy
+(see docs/backups-and-blobs.md), not this template.
+
+Everything is gated OFF by default (`backups.enabled=false`).
+*/ -}}
+
+{{- /* Reusable pieces shared by every CronJob below (defined at top level). */ -}}
+{{- define "fuzeinfra.backup.s3env" -}}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .b.s3.existingSecret | quote }}
+      key: {{ .b.s3.accessKeyIdKey | quote }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .b.s3.existingSecret | quote }}
+      key: {{ .b.s3.secretAccessKeyKey | quote }}
+- name: AWS_DEFAULT_REGION
+  value: {{ .b.s3.region | quote }}
+- name: S3_ENDPOINT
+  value: {{ .b.s3.endpoint | quote }}
+- name: S3_BUCKET
+  value: {{ .b.s3.bucket | quote }}
+{{- end -}}
+
+{{- define "fuzeinfra.backup.uploadContainer" -}}
+- name: upload
+  image: {{ .b.awsCliImage | quote }}
+  imagePullPolicy: {{ include "fuzeinfra.pullPolicy" .root }}
+  env:
+    {{- include "fuzeinfra.backup.s3env" . | nindent 4 }}
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -eu
+      key="$(cat /backup/remote-key)"
+      echo "Uploading /backup/dump.bin -> s3://$S3_BUCKET/$key"
+      aws --endpoint-url "$S3_ENDPOINT" s3 cp /backup/dump.bin "s3://$S3_BUCKET/$key"
+      echo "Backup upload complete."
+  volumeMounts:
+    - name: backup
+      mountPath: /backup
+  resources:
+    {{- toYaml .b.resources | nindent 4 }}
+{{- end -}}
+
+{{- if .Values.backups.enabled }}
+{{- $b := .Values.backups }}
+{{- if not $b.s3.existingSecret }}
+{{- fail "backups.s3.existingSecret is required when backups.enabled=true (offline-sealed SealedSecret with the S3 key pair)" }}
+{{- end }}
+{{- if not $b.s3.endpoint }}
+{{- fail "backups.s3.endpoint is required when backups.enabled=true (e.g. https://eu2.contabostorage.com)" }}
+{{- end }}
+{{- $secretName := include "fuzeinfra.secretName" . }}
+{{- $dbs := list
+    (dict "name" "postgres" "cfg" $b.postgres)
+    (dict "name" "mongodb"  "cfg" $b.mongodb)
+    (dict "name" "neo4j"    "cfg" $b.neo4j) -}}
+
+{{- range $dbs }}
+{{- if .cfg.enabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fuzeinfra-backup-{{ .name }}
+  labels:
+    {{- include "fuzeinfra.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .cfg.schedule | default $b.schedule | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: {{ $b.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $b.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ $b.backoffLimit }}
+      activeDeadlineSeconds: {{ $b.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "fuzeinfra.labels" $ | nindent 12 }}
+            {{- include "fuzeinfra.selectorLabels" (dict "component" (printf "backup-%s" .name) "root" $) | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          volumes:
+            - name: backup
+              emptyDir: {}
+          initContainers:
+            - name: dump
+              image: {{ .cfg.image | quote }}
+              imagePullPolicy: {{ include "fuzeinfra.pullPolicy" $ }}
+              env:
+                - name: PREFIX
+                  value: {{ $b.s3.prefix | quote }}
+                {{- if eq .name "postgres" }}
+                - name: PGHOST
+                  value: {{ .cfg.host | quote }}
+                - name: PGPORT
+                  value: {{ .cfg.port | quote }}
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef: { name: {{ $secretName }}, key: POSTGRES_USER }
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef: { name: {{ $secretName }}, key: POSTGRES_PASSWORD }
+                {{- else if eq .name "mongodb" }}
+                - name: MONGO_HOST
+                  value: {{ .cfg.host | quote }}
+                - name: MONGO_PORT
+                  value: {{ .cfg.port | quote }}
+                - name: MONGODB_USER
+                  valueFrom:
+                    secretKeyRef: { name: {{ $secretName }}, key: MONGODB_USER }
+                - name: MONGODB_PASSWORD
+                  valueFrom:
+                    secretKeyRef: { name: {{ $secretName }}, key: MONGODB_PASSWORD }
+                {{- else if eq .name "neo4j" }}
+                - name: NEO4J_HOST
+                  value: {{ .cfg.host | quote }}
+                - name: NEO4J_BOLT_PORT
+                  value: {{ .cfg.boltPort | quote }}
+                - name: NEO4J_AUTH
+                  valueFrom:
+                    secretKeyRef: { name: {{ $secretName }}, key: NEO4J_AUTH }
+                {{- end }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+                  {{- if eq .name "postgres" }}
+                  # Full logical dump of every database + globals (roles/grants).
+                  export PGPASSWORD="$POSTGRES_PASSWORD"
+                  pg_dumpall -h "$PGHOST" -p "$PGPORT" -U "$POSTGRES_USER" \
+                    | gzip -c > /backup/dump.bin
+                  echo "$PREFIX/postgres/fuzeinfra-postgres-$ts.sql.gz" > /backup/remote-key
+                  {{- else if eq .name "mongodb" }}
+                  # Single-file compressed archive of the whole mongod.
+                  mongodump --host "$MONGO_HOST" --port "$MONGO_PORT" \
+                    -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+                    --authenticationDatabase admin --archive --gzip \
+                    > /backup/dump.bin
+                  echo "$PREFIX/mongodb/fuzeinfra-mongodb-$ts.archive.gz" > /backup/remote-key
+                  {{- else if eq .name "neo4j" }}
+                  # ONLINE logical export via APOC streamed over Bolt (community
+                  # edition has no online `neo4j-admin backup`; APOC ships in the
+                  # cluster image via NEO4J_PLUGINS=["apoc"]). Requires apoc.
+                  NEO4J_USER="${NEO4J_AUTH%%/*}"
+                  NEO4J_PASS="${NEO4J_AUTH#*/}"
+                  cypher-shell -a "bolt://$NEO4J_HOST:$NEO4J_BOLT_PORT" \
+                    -u "$NEO4J_USER" -p "$NEO4J_PASS" --non-interactive --format plain \
+                    "CALL apoc.export.cypher.all(null,{stream:true,format:'cypher-shell'}) YIELD cypherStatements RETURN cypherStatements" \
+                    | gzip -c > /backup/dump.bin
+                  echo "$PREFIX/neo4j/fuzeinfra-neo4j-$ts.cypher.gz" > /backup/remote-key
+                  {{- end }}
+                  echo "Dump written: $(cat /backup/remote-key) ($(wc -c < /backup/dump.bin) bytes)"
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+              resources:
+                {{- toYaml $b.resources | nindent 16 }}
+          containers:
+            {{- include "fuzeinfra.backup.uploadContainer" (dict "b" $b "root" $) | nindent 12 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -82,20 +82,40 @@ grafana:
 #       repeat_interval: 1h
 
 # Loki S3 backend (Contabo Object Storage) — keeps logs off the node disk.
-# 1. Create the bucket in Contabo Object Storage.
-# 2. Create a Secret with the credentials, e.g.:
-#      kubectl -n fuzeinfra create secret generic loki-s3 \
-#        --from-literal=LOKI_S3_ACCESS_KEY_ID=<key> \
-#        --from-literal=LOKI_S3_SECRET_ACCESS_KEY=<secret>
-# 3. Uncomment and fill in:
-# loki:
-#   s3:
-#     enabled: true
-#     endpoint: "eu2.contabostorage.com"
-#     region: "default"
-#     bucket: "fuzeinfra-loki"
-#     s3ForcePathStyle: true
-#     existingSecret: "loki-s3"
+#
+# The endpoint/bucket are wired here for prod; the switch is `enabled`, kept
+# FALSE until the credential SealedSecret is present (flipping it on without the
+# secret would crash-loop Loki). This is a human-gated phase — see
+# docs/backups-and-blobs.md.
+#
+# To turn on (GitOps — never `kubectl create secret` in prod):
+#   1. Fetch the S3 key pair from the Contabo panel for the `fuzeinfra-loki`
+#      bucket (provisioned by terraform object-storage).
+#   2. Seal it OFFLINE into a SealedSecret named `loki-s3` in the fuzeinfra
+#      namespace with keys LOKI_S3_ACCESS_KEY_ID / LOKI_S3_SECRET_ACCESS_KEY,
+#      commit it, let Argo sync.
+#   3. Flip loki.s3.enabled -> true here, commit, let Argo sync.
+loki:
+  s3:
+    enabled: false            # human-gated flip (needs the loki-s3 SealedSecret)
+    endpoint: "eu2.contabostorage.com"
+    region: "default"
+    bucket: "fuzeinfra-loki"
+    s3ForcePathStyle: true
+    insecure: false
+    existingSecret: "loki-s3"
+
+# Scheduled DB backups → S3 (Contabo Object Storage). Bucket/endpoint wired for
+# prod; kept OFF until the `fuzeinfra-backups-s3` SealedSecret is committed.
+# See docs/backups-and-blobs.md for the enable + retention-policy steps.
+backups:
+  enabled: false             # human-gated flip (needs the fuzeinfra-backups-s3 SealedSecret)
+  s3:
+    endpoint: "https://eu2.contabostorage.com"
+    region: "default"
+    bucket: "fuzeinfra-backups"
+    prefix: "db"
+    existingSecret: "fuzeinfra-backups-s3"
 airflow:
   replicas: 0 # TEMP headroom (#93): webserver/scheduler/flower -> 0 pods
   workerReplicas: 0 # TEMP headroom (#93): celery worker -> 0 pods

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -429,6 +429,73 @@ loki:
     accessKeyIdKey: LOKI_S3_ACCESS_KEY_ID
     secretAccessKeyKey: LOKI_S3_SECRET_ACCESS_KEY
 
+# ---------------------------------------------------------------------------
+# Scheduled database backups → S3 (Contabo Object Storage)
+# ---------------------------------------------------------------------------
+# The stateful databases keep running on block/local-path storage — S3 has no
+# POSIX/block semantics, so it is NOT a live data volume for any DB. Its only
+# role here is a *backup offload*: each CronJob below dumps a logical snapshot
+# of a running DB and uploads it to the `fuzeinfra-backups` bucket.
+#
+# Everything is OFF by default. To enable in an overlay:
+#   1. Provision the bucket (terraform object-storage) + an S3 key pair.
+#   2. Seal the key pair OFFLINE into a SealedSecret in the fuzeinfra namespace,
+#      e.g. `fuzeinfra-backups-s3` with keys BACKUP_S3_ACCESS_KEY_ID /
+#      BACKUP_S3_SECRET_ACCESS_KEY. (Never `kubectl create secret` — GitOps.)
+#   3. Set backups.enabled=true, backups.s3.existingSecret, backups.s3.endpoint.
+#
+# Object lifecycle / retention (age-out of old dumps) is enforced by an S3
+# bucket lifecycle policy, NOT by these Jobs — see docs/backups-and-blobs.md.
+backups:
+  enabled: false
+  # aws-cli image used by the upload sidecar step of every CronJob.
+  awsCliImage: amazon/aws-cli:2.17.0
+  # Default cron schedule (UTC). Per-DB `schedule` overrides this when set.
+  schedule: "0 2 * * *"
+  # Keep this many most-recent Jobs' pods around for log inspection.
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # Fail (and alert via kube-state-metrics job_failed) rather than hang forever.
+  activeDeadlineSeconds: 3600
+  backoffLimit: 2
+  resources:
+    requests: { cpu: 100m, memory: 128Mi }
+    limits:   { cpu: 500m, memory: 512Mi }
+  # S3 destination for all dumps.
+  s3:
+    # Full URL incl. scheme, e.g. https://eu2.contabostorage.com
+    endpoint: ""
+    region: "default"
+    bucket: "fuzeinfra-backups"
+    # Key prefix inside the bucket; each DB adds its own subfolder + timestamp.
+    prefix: "db"
+    # SealedSecret (in the fuzeinfra namespace) holding the S3 credentials.
+    # REQUIRED when backups.enabled=true. Never inlined.
+    existingSecret: ""
+    accessKeyIdKey: BACKUP_S3_ACCESS_KEY_ID
+    secretAccessKeyKey: BACKUP_S3_SECRET_ACCESS_KEY
+  # Per-database toggles. Each dumps a *running* instance (no downtime) and is
+  # independently gated so an overlay can enable only the DBs it runs.
+  postgres:
+    enabled: true
+    # "" -> inherits backups.schedule
+    schedule: ""
+    image: postgres:15          # ships pg_dumpall
+    host: fuzeinfra-postgres
+    port: 5432
+  mongodb:
+    enabled: true
+    schedule: ""
+    image: mongo:7              # ships mongodump
+    host: fuzeinfra-mongodb
+    port: 27017
+  neo4j:
+    enabled: true
+    schedule: ""
+    image: neo4j:5             # ships cypher-shell; APOC stream export (online)
+    host: fuzeinfra-neo4j
+    boltPort: 7687
+
 promtail:
   enabled: true
   image: grafana/promtail:3.2.0


### PR DESCRIPTION
## What

Feasible, non-breaking parts of the S3 stateful-data plan (`docs/design/s3-and-private-networking.md`). **Everything is default-disabled. No `terraform apply`, no prod mutation, no data migration** — enable steps are human-gated (SealedSecret → flip `enabled` → Argo sync).

1. **Loki → S3** (`fuzeinfra-loki`): filled in the Contabo endpoint/bucket in `values-contabo.yaml` under the chart's existing `loki.s3.*` block. Kept `enabled: false` until the `loki-s3` SealedSecret exists (flipping on without it crash-loops Loki). Config-only flip — the templates already support it.
2. **DB backup CronJobs** (`templates/backup-cronjobs.yaml`, gated by `backups.enabled`, default off): one CronJob per DB — Postgres `pg_dumpall`, MongoDB `mongodump --archive --gzip`, Neo4j **online** APOC cypher stream over Bolt — each dumps a *running* instance into a shared `emptyDir`, then an aws-cli sidecar uploads to `fuzeinfra-backups`. DB creds by key from `fuzeinfra-secrets`; S3 creds from a SealedSecret (`backups.s3.existingSecret`). Fail-guard requires the secret + endpoint when enabled.
3. **Docs** (`docs/backups-and-blobs.md`): Loki S3, backup CronJobs + retention (S3 lifecycle policy, not the Jobs), app-blob usage (`fuzeinfra-blobs`, path-style + presigned URLs), and the deferred Thanos path for Prometheus.

**The databases keep running on block/local-path storage** — S3 has no POSIX/block semantics, so its only role for DBs is backup offload.

## Out of scope (not in this PR)
`object-storage.tf` provisioning, the private-networking import, the SealedSecrets themselves, and any `terraform apply` / prod flip — all human-gated per the design's phased rollout.

## Validation
```
helm template helm/fuzeinfra -f values-contabo.yaml | kubeconform -strict -ignore-missing-schemas
```
- Default (backups off): **Valid: 84, Invalid: 0, Errors: 0, Skipped: 2** (CRDs)
- With `backups.enabled=true` + `loki.s3.enabled=true`: **Valid: 87, Invalid: 0, Errors: 0, Skipped: 2** — 3 backup CronJobs render only when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)