### PR TITLE
feat(tf): Contabo Object Storage (S3) — gated tenant + buckets + sealed-secret wiring

### DIFF
--- a/deploy/sealed-secrets/loki-s3-credentials.yaml.template
+++ b/deploy/sealed-secrets/loki-s3-credentials.yaml.template
@@ -1,0 +1,51 @@
+# =============================================================================
+# PLACEHOLDER / TEMPLATE — Loki S3 (Contabo Object Storage) credentials.
+#
+# This is a *.template file on purpose: it is NOT a real SealedSecret and is NOT
+# synced by Argo (the fuzeinfra-sealed-secrets Application globs *.yaml/*.yml/
+# *.json under deploy/sealed-secrets/ with recurse; a `.template` suffix is
+# excluded). It exists so the credential-wiring path is committed and reviewable
+# WITHOUT ever committing real keys.
+#
+# ── How to produce the real file (human, one-time, offline) ──────────────────
+# The S3 access key + secret are ACCOUNT-LEVEL credentials — no Terraform
+# resource emits them. Fetch the pair ONCE from the Contabo panel:
+#   Account -> Security & Access -> S3 Object Storage Credentials
+# Write each value to a throwaway file (avoids plaintext in shell history / argv),
+# then seal OFFLINE against FuzeInfra's published public cert (zero cluster
+# access needed) and write the real manifest NEXT TO this template:
+#
+#   printf %s '<ACCESS_KEY_ID>'     > /tmp/loki_s3_key
+#   printf %s '<SECRET_ACCESS_KEY>' > /tmp/loki_s3_secret
+#   scripts/seal-secret.sh fuzeinfra/loki-s3 \
+#     LOKI_S3_ACCESS_KEY_ID=@/tmp/loki_s3_key \
+#     LOKI_S3_SECRET_ACCESS_KEY=@/tmp/loki_s3_secret \
+#     --out deploy/sealed-secrets/loki-s3-credentials.yaml
+#   shred -u /tmp/loki_s3_key /tmp/loki_s3_secret
+#
+# Commit ONLY the resulting deploy/sealed-secrets/loki-s3-credentials.yaml
+# (encrypted). Argo's fuzeinfra-sealed-secrets app self-heals it onto the
+# cluster; the sealed-secrets controller decrypts it into the `loki-s3` Secret,
+# which the Loki config (values-contabo.yaml -> loki.s3.existingSecret) reads.
+#
+# The SAME account credential pair covers the fuzeinfra-backups and
+# fuzeinfra-blobs buckets — seal a second SealedSecret `fuzeinfra/objstore-s3`
+# with generic keys (S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY) the same way for
+# the backup CronJobs / blob consumers.
+#
+# ── Shape of the REAL sealed output (for reference only) ─────────────────────
+# apiVersion: bitnami.com/v1alpha1
+# kind: SealedSecret
+# metadata:
+#   name: loki-s3
+#   namespace: fuzeinfra
+# spec:
+#   encryptedData:
+#     LOKI_S3_ACCESS_KEY_ID: <AgB...encrypted...>       # produced by kubeseal
+#     LOKI_S3_SECRET_ACCESS_KEY: <AgB...encrypted...>   # produced by kubeseal
+#   template:
+#     metadata:
+#       name: loki-s3
+#       namespace: fuzeinfra
+#     type: Opaque
+# =============================================================================

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -82,16 +82,26 @@ grafana:
 #       repeat_interval: 1h
 
 # Loki S3 backend (Contabo Object Storage) — keeps logs off the node disk.
-# 1. Create the bucket in Contabo Object Storage.
-# 2. Create a Secret with the credentials, e.g.:
-#      kubectl -n fuzeinfra create secret generic loki-s3 \
-#        --from-literal=LOKI_S3_ACCESS_KEY_ID=<key> \
-#        --from-literal=LOKI_S3_SECRET_ACCESS_KEY=<secret>
-# 3. Uncomment and fill in:
+# 1. Provision the tenant + bucket via Terraform (human-gated, PAID):
+#      cd terraform/contabo && terraform apply \
+#        -var enable_object_storage=true        # buys storage; see object-storage.tf
+#    Read the endpoint from state (never hardcode):
+#      terraform output object_storage_s3_url   # e.g. https://eu2.contabostorage.com
+# 2. Deliver the S3 credentials as a SealedSecret (GitOps — NOT `kubectl create
+#    secret`, which orphans a hand-made Secret and contradicts the no-hand-mutate
+#    rule). Fetch the account S3 key/secret from the Contabo panel
+#    (Account -> Security & Access -> S3 Object Storage Credentials) and seal them
+#    OFFLINE with the repo's canonical tool — see the template + instructions in
+#    deploy/sealed-secrets/loki-s3-credentials.yaml.template:
+#      scripts/seal-secret.sh fuzeinfra/loki-s3 \
+#        LOKI_S3_ACCESS_KEY_ID=@key.txt LOKI_S3_SECRET_ACCESS_KEY=@secret.txt \
+#        --out deploy/sealed-secrets/loki-s3-credentials.yaml
+#    Argo (fuzeinfra-sealed-secrets app) decrypts it into the `loki-s3` Secret.
+# 3. Then flip the chart on (this stays disabled until a human does the above):
 # loki:
 #   s3:
 #     enabled: true
-#     endpoint: "eu2.contabostorage.com"
+#     endpoint: "eu2.contabostorage.com"   # bare host from object_storage_s3_url (strip scheme)
 #     region: "default"
 #     bucket: "fuzeinfra-loki"
 #     s3ForcePathStyle: true

--- a/terraform/contabo/object-storage.tf
+++ b/terraform/contabo/object-storage.tf
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------
+# Contabo Object Storage (S3) — logs + backups + blobs
+#
+# Design: docs/design/s3-and-private-networking.md (§2).
+#
+# WHAT THIS IS FOR (the honest scope): S3 is an HTTP object store — no POSIX
+# filesystem, no block writes, no fsync/mmap/locking. Postgres, MongoDB, Redis,
+# Neo4j, Elasticsearch, ChromaDB, Kafka and RabbitMQ MUST keep running on
+# local-path block PVCs; their only S3 story is backup/snapshot OFFLOAD. The
+# genuine S3 consumers are: Loki (native object-store backend, already coded in
+# the chart), scheduled DB-backup CronJobs, and app/blob artifacts.
+#
+# COST GATE: applying contabo_object_storage PURCHASES paid storage
+# (~EUR 6.99/mo per 1 TB). Everything here is gated behind
+# var.enable_object_storage (default false) so a routine apply of this directory
+# never buys storage. Enable it only in an explicit, human-reviewed apply.
+#
+# ELASTIC-EXCLUSION INVARIANT (see main.tf): this file adds a self-contained
+# resource pair. It introduces NO `data "contabo_instance"` and NO for_each over
+# the account instance inventory, so it does not weaken that invariant.
+#
+# S3 endpoint is READ FROM STATE (contabo_object_storage.this[0].s3_url), never
+# hardcoded — the region determines the host (EU -> eu2.contabostorage.com).
+# ---------------------------------------------------------------------------
+
+resource "contabo_object_storage" "this" {
+  count                    = var.enable_object_storage ? 1 : 0
+  region                   = var.object_storage_region
+  total_purchased_space_tb = var.object_storage_purchased_tb
+  display_name             = var.object_storage_display_name
+
+  # Optional growth guardrail: auto-grow purchased quota up to a hard ceiling so
+  # a log/backup spike never fails writes, while capping the bill. Off unless
+  # var.object_storage_autoscaling_limit_tb > 0.
+  dynamic "auto_scaling" {
+    for_each = var.object_storage_autoscaling_limit_tb > 0 ? [1] : []
+    content {
+      state         = "enabled"
+      size_limit_tb = var.object_storage_autoscaling_limit_tb
+    }
+  }
+
+  lifecycle {
+    # Purchased quota is a paid, one-way-ish change; never let an unrelated plan
+    # silently resize it. Quota changes go through a deliberate, reviewed apply.
+    prevent_destroy = true
+  }
+}
+
+# Three purpose-scoped buckets in the one tenant. Buckets are created via the
+# Contabo OAuth2 API (not the S3 API), so no S3 access keys are needed at plan
+# time — the same OAuth2 provider block in main.tf covers them.
+resource "contabo_object_storage_bucket" "loki" {
+  count             = var.enable_object_storage ? 1 : 0
+  name              = var.object_storage_bucket_loki
+  object_storage_id = contabo_object_storage.this[0].id
+  public_sharing    = false
+}
+
+resource "contabo_object_storage_bucket" "backups" {
+  count             = var.enable_object_storage ? 1 : 0
+  name              = var.object_storage_bucket_backups
+  object_storage_id = contabo_object_storage.this[0].id
+  public_sharing    = false
+}
+
+resource "contabo_object_storage_bucket" "blobs" {
+  count             = var.enable_object_storage ? 1 : 0
+  name              = var.object_storage_bucket_blobs
+  object_storage_id = contabo_object_storage.this[0].id
+  public_sharing    = false
+}

--- a/terraform/contabo/outputs.tf
+++ b/terraform/contabo/outputs.tf
@@ -39,3 +39,37 @@ output "argocd_url_public" {
   description = "ArgoCD public URL (public once Cloudflare tunnel is wired)"
   value       = "https://argocd.${var.prod_subdomain}.${var.zone_name}"
 }
+
+# ---------------------------------------------------------------------------
+# Contabo Object Storage (S3) — see object-storage.tf.
+# Endpoint/region are read from state, never hardcoded. Empty strings/[] when
+# var.enable_object_storage is false.
+# ---------------------------------------------------------------------------
+output "object_storage_id" {
+  description = "Contabo Object Storage tenant ID (empty when object storage is disabled)."
+  value       = var.enable_object_storage ? contabo_object_storage.this[0].id : ""
+}
+
+output "object_storage_region" {
+  description = "Object Storage region (empty when disabled)."
+  value       = var.enable_object_storage ? var.object_storage_region : ""
+}
+
+output "object_storage_s3_url" {
+  description = "Full S3 endpoint incl. scheme (e.g. https://eu2.contabostorage.com). Strip the scheme to get the bare host the Loki chart's loki.s3.endpoint wants. Empty when disabled."
+  value       = var.enable_object_storage ? contabo_object_storage.this[0].s3_url : ""
+}
+
+output "object_storage_s3_tenant_id" {
+  description = "S3 tenant ID (path-style bucket prefix / canonical tenant). Empty when disabled."
+  value       = var.enable_object_storage ? contabo_object_storage.this[0].s3_tenant_id : ""
+}
+
+output "object_storage_buckets" {
+  description = "Names of the provisioned buckets (empty list when disabled)."
+  value = var.enable_object_storage ? [
+    contabo_object_storage_bucket.loki[0].name,
+    contabo_object_storage_bucket.backups[0].name,
+    contabo_object_storage_bucket.blobs[0].name,
+  ] : []
+}

--- a/terraform/contabo/variables.tf
+++ b/terraform/contabo/variables.tf
@@ -229,3 +229,77 @@ variable "enable_argocd_provisioner" {
   default     = false
 }
 
+# ---------------------------------------------------------------------------
+# Contabo Object Storage (S3) — see object-storage.tf and
+# docs/design/s3-and-private-networking.md.
+#
+# PAID: enabling this PURCHASES storage (~EUR 6.99/mo per 1 TB). Default OFF so
+# a routine apply never buys storage. The S3 access key / secret are NOT
+# produced by any resource here — they are account-level credentials fetched
+# once from the Contabo panel and delivered as an offline-sealed SealedSecret
+# (deploy/sealed-secrets/loki-s3-credentials.yaml.template). Never commit real
+# keys or put them in tfvars.
+# ---------------------------------------------------------------------------
+variable "enable_object_storage" {
+  description = "Provision Contabo Object Storage + buckets (PAID). Default off so a routine apply never buys storage. Flip to true only in an explicit human-reviewed apply."
+  type        = bool
+  default     = false
+}
+
+variable "object_storage_region" {
+  description = "Contabo Object Storage region. 'EU' -> eu2.contabostorage.com (co-located with the EU2 prod node). Other values: 'US-central', 'SIN'."
+  type        = string
+  default     = "EU"
+
+  validation {
+    condition     = contains(["EU", "US-central", "SIN"], var.object_storage_region)
+    error_message = "object_storage_region must be one of: EU, US-central, SIN."
+  }
+}
+
+variable "object_storage_purchased_tb" {
+  description = "Purchased quota in TB. Smallest tier is ~0.25 TB (250 GB); confirm the provider/account accepts sub-1TB in your region."
+  type        = number
+  default     = 0.25
+
+  validation {
+    condition     = var.object_storage_purchased_tb > 0
+    error_message = "object_storage_purchased_tb must be greater than 0."
+  }
+}
+
+variable "object_storage_autoscaling_limit_tb" {
+  description = "If > 0, enable auto-scaling of purchased quota up to this hard ceiling (TB) so a log/backup spike never fails writes while capping the bill. 0 disables auto-scaling."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.object_storage_autoscaling_limit_tb >= 0
+    error_message = "object_storage_autoscaling_limit_tb must be >= 0 (0 disables auto-scaling)."
+  }
+}
+
+variable "object_storage_display_name" {
+  description = "Display name for the Object Storage tenant in the Contabo panel."
+  type        = string
+  default     = "fuzeinfra-storage"
+}
+
+variable "object_storage_bucket_loki" {
+  description = "Bucket name for Loki log chunks (native S3 object-store backend)."
+  type        = string
+  default     = "fuzeinfra-loki"
+}
+
+variable "object_storage_bucket_backups" {
+  description = "Bucket name for scheduled DB dump/snapshot backups (CronJob offload)."
+  type        = string
+  default     = "fuzeinfra-backups"
+}
+
+variable "object_storage_bucket_blobs" {
+  description = "Bucket name for application blob/artifact storage."
+  type        = string
+  default     = "fuzeinfra-blobs"
+}
+


### PR DESCRIPTION
## What

Codifies **Contabo Object Storage in Terraform** (`terraform/contabo/`), implementing §2 of the design in `docs/design/s3-and-private-networking.md` (design PR #376).

S3 here is scoped to the workloads that can *genuinely* use an HTTP object store — **logs (Loki native backend), DB backup offload, and app blobs** — not live stateful storage. Postgres/Mongo/Redis/Neo4j/ES/Chroma/Kafka/RabbitMQ keep running on local-path block PVCs (S3 has no POSIX/block semantics); their only S3 story is backup offload.

## Changes

- **`terraform/contabo/object-storage.tf`** (new) — `contabo_object_storage` tenant + 3 purpose-scoped buckets (`fuzeinfra-loki` / `fuzeinfra-backups` / `fuzeinfra-blobs`) on the existing OAuth2 provider block. Everything is gated behind `var.enable_object_storage` (**default `false`** — a routine apply never buys paid storage). `prevent_destroy` on the tenant; optional `auto_scaling` guardrail.
- **`variables.tf`** — `enable_object_storage`, `object_storage_region` (validated `EU`/`US-central`/`SIN`), `object_storage_purchased_tb`, `object_storage_autoscaling_limit_tb`, `object_storage_display_name`, and the three bucket-name vars.
- **`outputs.tf`** — `object_storage_id`, `object_storage_region`, `object_storage_s3_url` (**endpoint read from state, never hardcoded**), `object_storage_s3_tenant_id`, `object_storage_buckets`. All empty when disabled.
- **`deploy/sealed-secrets/loki-s3-credentials.yaml.template`** (new) — credential-wiring placeholder. S3 keys are account-level, fetched from the Contabo panel and sealed **offline** via `scripts/seal-secret.sh`, replacing the GitOps-violating `kubectl create secret` recipe. **No real keys committed.** Named `.template` so Argo's `deploy/sealed-secrets` recurse glob never tries to sync a non-real secret.
- **`helm/fuzeinfra/values-contabo.yaml`** — rewrote the Loki S3 comment to the Terraform + SealedSecret path (Loki stays `enabled: false`; the flip is a separate human-gated step).

## Invariants preserved

- **ELASTIC-EXCLUSION** (`main.tf`): adds a self-contained resource pair with **no `data "contabo_instance"`** and **no `for_each`** over the account instance inventory.
- Buckets are created via the Contabo **OAuth2 API** (`contabo_object_storage_bucket`), not the S3 API — no S3 keys needed at plan time, and **no `null_resource`/`local-exec`**.

## Verification (read-only — no apply)

Against `contabo/contabo v0.1.42`:

```
terraform init -backend=false   -> init-exit=0
terraform validate              -> Success! The configuration is valid.  (only pre-existing cloudflare_worker_script deprecation warnings)
terraform fmt -check            -> exit 0
```

**No `terraform apply`, no prod mutation, no data migration.** Enabling object storage (and the private-networking / backup-CronJob / Thanos phases) is deliberately gated on human review per the design doc's phased rollout.

## Scope note

This PR is the Object Storage slice only. Private networking (import of net `60932`, `eth1`/flannel), backup CronJobs, and Prometheus/Thanos are separate phases in the design doc and are **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)