### PR TITLE
feat(longhorn): gated, default-OFF Longhorn block storage scaffolding

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -12,7 +12,11 @@ on:
 jobs:
   validate:
     name: Lint & schema-validate chart
-    runs-on: staging
+    # ubuntu-latest, NOT the `staging` ARC scaleset: that scaleset registers but
+    # never fetches jobs (broker/MTU), so this gate queued forever ("pending")
+    # on every PR. This job is static (helm lint + kubeconform), no cluster
+    # needed — GitHub-hosted runs it fine.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 

--- a/argocd/applications/longhorn.yaml
+++ b/argocd/applications/longhorn.yaml
@@ -1,0 +1,100 @@
+# =============================================================================
+# ArgoCD Application — Longhorn replicated block storage (cluster infra add-on)
+#
+# GATED OFF BY DESIGN. This Application is NOT applied by any automation and its
+# syncPolicy has NO `automated` block (MANUAL sync). Consequences:
+#   * Merging this file into `main` deploys NOTHING — the Application object does
+#     not exist in the cluster until a human runs:
+#         kubectl apply -f argocd/applications/longhorn.yaml
+#   * Even after it is applied, Argo will NOT sync until a human clicks Sync (or
+#     runs `argocd app sync longhorn`). This is the strongest default-OFF gate.
+#
+# PREREQUISITES (human-gated, see docs/design/longhorn-storage.md §3) — do FIRST:
+#   1. Install open-iscsi + nfs-common and create /var/lib/longhorn on every node
+#      that will host a replica (cloud-init for NEW nodes via
+#      modules/contabo-k3s-node enable_longhorn_prereqs=true; Longhorn's
+#      iscsi/nfs installation DaemonSets for LIVE nodes).
+#   2. Run longhorn-environment-check.sh (read-only) — confirm all nodes pass.
+#   3. Confirm ≥3 DURABLE (non-elastic) schedulable nodes for 3-replica anti-affinity.
+#
+# Turn on `automated{prune,selfHeal}` only AFTER a proven-stable manual install
+# (a deliberate follow-up PR) — auto-syncing a privileged CSI DaemonSet before the
+# node prereqs exist just CrashLoops the engine pods.
+# =============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: longhorn
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    platform.izzywdev/gate: >
+      MANUAL SYNC ONLY. Do not add syncPolicy.automated until the node
+      prerequisites (open-iscsi/nfs-common//var/lib/longhorn) are installed and
+      longhorn-environment-check.sh passes on every node. See
+      docs/design/longhorn-storage.md.
+spec:
+  # project: default so it can install cluster-scoped CRDs + a privileged
+  # DaemonSet into its own namespace, like the sealed-secrets add-on. It must NOT
+  # live under the restrictive `fuzeinfra` AppProject.
+  project: default
+  source:
+    repoURL: https://charts.longhorn.io
+    chart: longhorn
+    # Pin the chart; bump deliberately. Confirm the Longhorn<->k8s compat matrix
+    # against the live k3s version before enabling (design O-1).
+    targetRevision: 1.7.2
+    helm:
+      releaseName: longhorn
+      values: |
+        # --- Node data dir (must match the prereq mkdir in cloud-init) ---
+        defaultSettings:
+          defaultDataPath: /var/lib/longhorn
+          # 3 replicas across DISTINCT nodes. Soft anti-affinity OFF = hard spread.
+          defaultReplicaCount: 3
+          replicaSoftAntiAffinity: false
+          # Small V92 disks: no thin over-provisioning; keep kubelet headroom.
+          storageOverProvisioningPercentage: 100
+          storageMinimalAvailablePercentage: 15
+          # Do not let a node self-select all disks blindly; operator tags durable
+          # nodes for replica placement (design §4.1 / O-6).
+          createDefaultDiskLabeledNodes: true
+          # Guard against replicas landing on autoscaled/reaped elastic nodes.
+          allowVolumeCreationWithDegradedAvailability: false
+        # Keep local-path the cluster default: do NOT create a default-marked
+        # Longhorn StorageClass. The opt-in `longhorn` SC ships from the umbrella
+        # chart (templates/storageclass-longhorn.yaml), non-default.
+        persistence:
+          defaultClass: false
+          defaultClassReplicaCount: 3
+          reclaimPolicy: Retain
+        # Trim footprint on the memory-constrained control-plane.
+        csi:
+          attacherReplicaCount: 1
+          provisionerReplicaCount: 1
+          resizerReplicaCount: 1
+          snapshotterReplicaCount: 1
+        longhornManager:
+          priorityClass: ""
+        # UI stays ClusterIP-only by default; expose via a CF Access app +
+        # Traefik Ingress deliberately later (design O-2), never wide open.
+        ingress:
+          enabled: false
+        # First install: skip the pre-upgrade checker job.
+        preUpgradeChecker:
+          jobEnabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: longhorn-system
+  syncPolicy:
+    # NO `automated:` block on purpose — MANUAL sync is the default-OFF gate.
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m

--- a/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata.template
+++ b/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata.template
@@ -58,6 +58,20 @@ write_files:
       INSTALL_K3S_CHANNEL=v1.36
 
 runcmd:
+  # --- Longhorn node prerequisites (OPT-IN, commented OFF by default) ---
+  # Longhorn attaches volumes over iSCSI and serves RWX over NFS, so any node that
+  # may host a Longhorn replica or mount a Longhorn-backed volume needs the iSCSI
+  # initiator + NFS client + /var/lib/longhorn. Left COMMENTED so a merge is a
+  # no-op: this file is a source artifact an operator must base64-encode into
+  # clusterAutoscaler.provider.userDataTemplateB64 (values-contabo.yaml) for it to
+  # take effect. Uncomment + re-encode ONLY when enabling Longhorn AND elastic
+  # nodes are allowed to run Longhorn-backed pods (see
+  # docs/design/longhorn-storage.md §3/§4.1 — replicas are normally pinned to
+  # DURABLE baseline nodes, off billing-reaped elastic nodes).
+  # - [ sh, -c, "DEBIAN_FRONTEND=noninteractive apt-get update -y || true" ]
+  # - [ sh, -c, "DEBIAN_FRONTEND=noninteractive apt-get install -y open-iscsi nfs-common || true" ]
+  # - [ sh, -c, "systemctl enable --now iscsid || true" ]
+  # - [ sh, -c, "mkdir -p /var/lib/longhorn" ]
   # Host firewall: agent needs to reach the API (6443) outbound and accept
   # kubelet (10250) from the server, plus whichever flannel backend the
   # cluster is actually running. The live prod cluster runs flannel

--- a/helm/fuzeinfra/templates/storageclass-longhorn.yaml
+++ b/helm/fuzeinfra/templates/storageclass-longhorn.yaml
@@ -1,0 +1,42 @@
+{{- /*
+============================ Longhorn StorageClass (opt-in) ============================
+An OPT-IN, NON-DEFAULT `longhorn` StorageClass for replicated networked block
+storage. `local-path` remains the cluster default — nothing uses Longhorn unless a
+PVC explicitly sets `storageClassName: longhorn`.
+
+Gated OFF by default (`longhorn.storageClass.enabled=false`). Rendering nothing is
+the safe no-op: merging never changes storage. Enable ONLY after the Longhorn
+controller (argocd/applications/longhorn.yaml) is installed and healthy — the
+provisioner `driver.longhorn.io` must exist for a PVC on this class to bind.
+
+Cluster-scoped object: no namespace. See docs/design/longhorn-storage.md §4.3.
+*/ -}}
+{{- if .Values.longhorn.storageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.longhorn.storageClass.name | default "longhorn" }}
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+  annotations:
+    # local-path stays the cluster default; this class is opt-in only.
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: driver.longhorn.io
+# Never auto-delete an underlying (replicated) DB volume when a PVC is removed.
+reclaimPolicy: {{ .Values.longhorn.storageClass.reclaimPolicy | default "Retain" }}
+allowVolumeExpansion: true
+volumeBindingMode: {{ .Values.longhorn.storageClass.volumeBindingMode | default "Immediate" }}
+parameters:
+  numberOfReplicas: {{ .Values.longhorn.storageClass.numberOfReplicas | default 3 | quote }}
+  staleReplicaTimeout: {{ .Values.longhorn.storageClass.staleReplicaTimeout | default 30 | quote }}
+  fsType: {{ .Values.longhorn.storageClass.fsType | default "ext4" | quote }}
+  {{- with .Values.longhorn.storageClass.diskSelector }}
+  # Pin replicas to durable (baseline) nodes tagged for Longhorn — keeps replicas
+  # off billing-reaped elastic nodes (see design doc §4.1 / O-6).
+  diskSelector: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.longhorn.storageClass.nodeSelector }}
+  nodeSelector: {{ . | quote }}
+  {{- end }}
+  fromBackup: ""
+{{- end }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -12,11 +12,23 @@
 # Replace with a real domain once you have DNS pointing at the server.
 # =============================================================================
 global:
+  # local-path stays the cluster DEFAULT StorageClass. Longhorn is added as an
+  # OPT-IN `longhorn` class (see `longhorn:` below), never as the default.
   storageClass: "local-path"
   # Cloudflare tunnel routes *.prod.fuzefront.com → Traefik → these Ingress rules.
   # Change back to <ip>.nip.io if the tunnel is disabled for debugging.
   domain: "prod.fuzefront.com"
   imagePullPolicy: IfNotPresent
+# Longhorn opt-in StorageClass. GATED OFF. The controller installs via the
+# independent Argo app argocd/applications/longhorn.yaml (manual sync); this only
+# renders the non-default `longhorn` StorageClass. P4 enable step (design doc §9):
+# flip storageClass.enabled to true AFTER the controller is installed + healthy.
+longhorn:
+  enabled: false
+  storageClass:
+    enabled: false
+    numberOfReplicas: 3
+    reclaimPolicy: Retain
 ingress:
   enabled: true
   className: traefik

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -688,3 +688,40 @@ handoffMcp:
   resources:
     requests: { cpu: "100m", memory: "256Mi" }
     limits:   { cpu: "500m", memory: "512Mi" }
+
+# -----------------------------------------------------------------------------
+# Longhorn replicated block storage (OPT-IN, default OFF).
+#
+# The Longhorn CONTROLLER (CSI driver, manager DaemonSet, CRDs, UI) deploys via
+# its OWN independent Argo Application `argocd/applications/longhorn.yaml`
+# (manual sync) — NOT this umbrella chart. This block only controls the OPT-IN,
+# NON-DEFAULT `longhorn` StorageClass that the chart renders when
+# `storageClass.enabled=true` (templates/storageclass-longhorn.yaml).
+#
+# `local-path` stays the cluster default (global.storageClass). Enabling this
+# StorageClass changes NOTHING on its own — no existing PVC/StatefulSet is
+# migrated here; each DB is moved onto `longhorn` in a separate, human-gated
+# maintenance window. Enable ONLY after the Longhorn controller is installed and
+# healthy (provisioner driver.longhorn.io must exist). See
+# docs/design/longhorn-storage.md.
+# -----------------------------------------------------------------------------
+longhorn:
+  # Umbrella-level marker (documentation/consistency). The actual controller is
+  # the separate Argo Application; this chart never installs Longhorn itself.
+  enabled: false
+  storageClass:
+    # Render the opt-in `longhorn` StorageClass. Default OFF → renders nothing.
+    enabled: false
+    name: longhorn
+    # 3 replicas across distinct DURABLE (baseline) nodes. Keep replicas off
+    # billing-reaped elastic nodes via diskSelector/nodeSelector (design §4.1).
+    numberOfReplicas: 3
+    # Never reap the underlying replicated DB volume when a PVC is deleted.
+    reclaimPolicy: Retain
+    volumeBindingMode: Immediate
+    staleReplicaTimeout: 30
+    fsType: ext4
+    # Longhorn disk/node tags scoping replicas to durable nodes. Empty = no
+    # scoping (set to e.g. "baseline" once baseline nodes are tagged in Longhorn).
+    diskSelector: ""
+    nodeSelector: ""

--- a/modules/contabo-k3s-node/cloud-init.tftpl
+++ b/modules/contabo-k3s-node/cloud-init.tftpl
@@ -37,6 +37,17 @@ write_files:
 %{ endif ~}
 
 runcmd:
+%{ if enable_longhorn_prereqs ~}
+  # Longhorn node prerequisites (gated by enable_longhorn_prereqs, default off).
+  # Longhorn attaches volumes over iSCSI and serves RWX over NFS, so the node
+  # needs the iSCSI initiator (+ iscsid running), the NFS client, and a data dir.
+  # Missing these → the Longhorn engine pod CrashLoops on attach. See
+  # docs/design/longhorn-storage.md §3.
+  - [ sh, -c, "DEBIAN_FRONTEND=noninteractive apt-get update -y || true" ]
+  - [ sh, -c, "DEBIAN_FRONTEND=noninteractive apt-get install -y open-iscsi nfs-common || true" ]
+  - [ sh, -c, "systemctl enable --now iscsid || true" ]
+  - [ sh, -c, "mkdir -p /var/lib/longhorn" ]
+%{ endif ~}
 %{ if private_network_enabled ~}
   # Apply the private-NIC netplan before joining so k3s can bind its overlay/
   # node-ip to the private interface (no-op / harmless when the NIC is absent).

--- a/modules/contabo-k3s-node/main.tf
+++ b/modules/contabo-k3s-node/main.tf
@@ -24,6 +24,8 @@ resource "contabo_instance" "node" {
     k3s_channel    = var.k3s_channel
     node_name      = each.value.name
     role           = each.value.role
+    # Gated Longhorn node prereqs (open-iscsi/nfs-common//var/lib/longhorn).
+    enable_longhorn_prereqs = var.enable_longhorn_prereqs
     # Private networking (Contabo VPC): bring up the private NIC + route k3s
     # over it only when the caller opted into a private network by name.
     private_network_enabled = var.private_network_name != ""

--- a/modules/contabo-k3s-node/variables.tf
+++ b/modules/contabo-k3s-node/variables.tf
@@ -103,6 +103,21 @@ variable "private_network_region" {
   default     = "EU"
 }
 
+# ---------------------------------------------------------------------------
+# Longhorn node prerequisites (optional, default OFF)
+#
+# Longhorn attaches volumes over iSCSI and serves RWX over NFS, so every node
+# that will host a Longhorn replica or a Longhorn-backed pod needs open-iscsi
+# (+ iscsid running), nfs-common, and a /var/lib/longhorn data dir. When true,
+# cloud-init installs these on first boot. Default false keeps a merge a no-op
+# for existing consumers. See docs/design/longhorn-storage.md §3.
+# ---------------------------------------------------------------------------
+variable "enable_longhorn_prereqs" {
+  description = "Install Longhorn node prerequisites (open-iscsi, nfs-common, /var/lib/longhorn) via cloud-init on first boot."
+  type        = bool
+  default     = false
+}
+
 variable "private_iface" {
   description = "Private NIC device name the Contabo VPC attaches as (eth1 on a 2-NIC Ubuntu 24.04 image). When private_network_name is set, the node brings this interface up via netplan and k3s routes its overlay (--flannel-iface) + node-ip over it. NOTE: the per-instance Contabo VPC add-on is a MANUAL panel purchase (HTTP 402 otherwise) that Terraform cannot order."
   type        = string


### PR DESCRIPTION
## Gated, default-OFF Longhorn scaffolding — merging is a prod no-op

Implements the deploy/CI scaffolding for **Longhorn** replicated block storage on
the prod Contabo k3s cluster, per the design in #380
(`docs/design/longhorn-storage.md`). Everything is **gated OFF**; merging deploys
**nothing** until a human runs the human-gated enable steps.

### What this adds
- **`argocd/applications/longhorn.yaml`** — independent Argo `Application` sourcing the upstream Longhorn chart (`charts.longhorn.io`, pinned `1.7.2`). **MANUAL sync — no `automated` block.** The Application isn't created until a human `kubectl apply`s it, and won't sync until a human clicks Sync. Inline values: `defaultDataPath: /var/lib/longhorn`, `defaultReplicaCount: 3`, `replicaSoftAntiAffinity: false`, `persistence.defaultClass: false` (keeps local-path default), trimmed CSI/manager footprint, UI ingress off.
- **`helm/fuzeinfra/templates/storageclass-longhorn.yaml`** — a gated, **non-default** `longhorn` StorageClass (`is-default-class: "false"`, `reclaimPolicy: Retain`, `numberOfReplicas: 3`), rendered only when `longhorn.storageClass.enabled=true`.
- **`helm/fuzeinfra/values.yaml`** + **`values-contabo.yaml`** — `longhorn:` block, all flags **false**.
- **`modules/contabo-k3s-node/`** — `enable_longhorn_prereqs` (default **false**); when true, cloud-init installs `open-iscsi` + `nfs-common`, enables `iscsid`, creates `/var/lib/longhorn`.
- **`cluster-autoscaler/.../elastic-userdata.template`** — same prereq block, **commented OFF** (base64-embedded source artifact; inert until re-encoded).

### Explicitly gated OFF (a merge changes nothing in prod)
| Artifact | Gate |
|---|---|
| Argo `longhorn` Application | manual sync, not auto-applied |
| `longhorn` StorageClass template | `longhorn.storageClass.enabled=false` |
| `longhorn:` values | `enabled: false` |
| node prereqs (module) | `enable_longhorn_prereqs=false` |
| elastic prereqs | commented out |

**No existing PVC / StatefulSet / `global.storageClass` is changed.** `local-path`
stays the cluster default. The per-DB migration is a separate, human-gated,
one-DB-per-window operation (design §6) and is **not** in this PR.

### Validation (all run locally)
- `helm lint` — default + local + aws + contabo overlays: **0 failed**.
- `helm template` contabo overlay: gate OFF → **0** StorageClasses; gate ON → exactly the one non-default `longhorn` SC.
- `kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.29.0`: contabo gate-ON **85 valid / 0 invalid / 0 errors** (2 CRD-skipped); local **67/0/0**; aws **64/0/0**.
- `terraform fmt -check` clean; `terraform validate` (module, `-backend=false`) **Success**; cloud-init template render verified for prereqs ON (installs packages) and OFF (0 longhorn lines).
- Argo Application: valid YAML, `syncPolicy.automated` absent (manual-sync gate confirmed), inline helm values parse; `defaultReplicaCount=3`, `persistence.defaultClass=false`.

### Must-do human steps before ANY migration (see design #380 §9)
1. Install node prereqs (`open-iscsi`/`nfs-common`//var/lib/longhorn) on every replica-hosting node — cloud-init for NEW nodes (`enable_longhorn_prereqs=true`), Longhorn's iscsi/nfs installation DaemonSets for LIVE nodes; run `longhorn-environment-check.sh` (read-only) first.
2. Confirm ≥3 durable (non-elastic) schedulable nodes for 3-replica anti-affinity.
3. `kubectl apply -f argocd/applications/longhorn.yaml`, then manually Sync; verify engine/manager pods healthy.
4. Flip `longhorn.storageClass.enabled=true` in `values-contabo.yaml`.
5. Per-DB backup→restore migration, one DB per maintenance window (Postgres/Mongo/Neo4j first, Redis last).

Does not touch `terraform/contabo`; **ELASTIC-EXCLUSION invariant preserved**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)