### PR TITLE
feat(backups): PVC (Longhorn) sink + enable nightly DB backups on prod

### DIFF
--- a/helm/fuzeinfra/templates/backup-cronjobs.yaml
+++ b/helm/fuzeinfra/templates/backup-cronjobs.yaml
@@ -40,6 +40,37 @@ Everything is gated OFF by default (`backups.enabled=false`).
 {{- end -}}
 
 {{- define "fuzeinfra.backup.uploadContainer" -}}
+{{- if eq .b.sink "pvc" -}}
+{{- /* PVC sink: copy the dump onto a Longhorn PVC (mounted at /remote) and
+       rotate in-pod. Needs no object storage — the interim tier used until the
+       S3 bucket + backups.s3.existingSecret are provisioned (docs/backups-and-blobs.md). */ -}}
+- name: upload
+  image: {{ .b.pvc.image | quote }}
+  imagePullPolicy: {{ include "fuzeinfra.pullPolicy" .root }}
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -eu
+      key="$(cat /backup/remote-key)"
+      dest="/remote/$key"
+      dir="$(dirname "$dest")"
+      mkdir -p "$dir"
+      cp /backup/dump.bin "$dest.partial"
+      mv "$dest.partial" "$dest"
+      echo "Backup written -> $dest ($(wc -c < "$dest") bytes)"
+      keep={{ .b.pvc.keep }}
+      # Rotate: keep the newest $keep dumps in THIS db's dir (each DB has its own).
+      ls -1t "$dir"/* 2>/dev/null | tail -n +$((keep+1)) | xargs -r rm -f || true
+      echo "Retention: kept newest $keep in $dir."
+  volumeMounts:
+    - name: backup
+      mountPath: /backup
+    - name: remote
+      mountPath: /remote
+  resources:
+    {{- toYaml .b.resources | nindent 4 }}
+{{- else -}}
 - name: upload
   image: {{ .b.awsCliImage | quote }}
   imagePullPolicy: {{ include "fuzeinfra.pullPolicy" .root }}
@@ -60,20 +91,44 @@ Everything is gated OFF by default (`backups.enabled=false`).
   resources:
     {{- toYaml .b.resources | nindent 4 }}
 {{- end -}}
+{{- end -}}
 
 {{- if .Values.backups.enabled }}
 {{- $b := .Values.backups }}
+{{- if eq $b.sink "s3" }}
 {{- if not $b.s3.existingSecret }}
-{{- fail "backups.s3.existingSecret is required when backups.enabled=true (offline-sealed SealedSecret with the S3 key pair)" }}
+{{- fail "backups.s3.existingSecret is required when backups.enabled=true and sink=s3 (offline-sealed SealedSecret with the S3 key pair)" }}
 {{- end }}
 {{- if not $b.s3.endpoint }}
-{{- fail "backups.s3.endpoint is required when backups.enabled=true (e.g. https://eu2.contabostorage.com)" }}
+{{- fail "backups.s3.endpoint is required when backups.enabled=true and sink=s3 (e.g. https://eu2.contabostorage.com)" }}
+{{- end }}
+{{- else if ne $b.sink "pvc" }}
+{{- fail "backups.sink must be either \"s3\" or \"pvc\"" }}
 {{- end }}
 {{- $secretName := include "fuzeinfra.secretName" . }}
 {{- $dbs := list
     (dict "name" "postgres" "cfg" $b.postgres)
     (dict "name" "mongodb"  "cfg" $b.mongodb)
     (dict "name" "neo4j"    "cfg" $b.neo4j) -}}
+{{- if eq $b.sink "pvc" }}
+---
+{{- /* Shared destination volume for the PVC sink (one RWO PVC; per-DB CronJob
+       schedules are staggered so they never mount it at the same time). */}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fuzeinfra-db-backups
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ $b.pvc.storageClass | quote }}
+  resources:
+    requests:
+      storage: {{ $b.pvc.size | quote }}
+{{- end }}
 
 {{- range $dbs }}
 {{- if .cfg.enabled }}
@@ -106,6 +161,11 @@ spec:
           volumes:
             - name: backup
               emptyDir: {}
+            {{- if eq $b.sink "pvc" }}
+            - name: remote
+              persistentVolumeClaim:
+                claimName: fuzeinfra-db-backups
+            {{- end }}
           initContainers:
             - name: dump
               image: {{ .cfg.image | quote }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -121,7 +121,23 @@ loki:
 # prod; kept OFF until the `fuzeinfra-backups-s3` SealedSecret is committed.
 # See docs/backups-and-blobs.md for the enable + retention-policy steps.
 backups:
-  enabled: false             # human-gated flip (needs the fuzeinfra-backups-s3 SealedSecret)
+  # ENABLED via the PVC sink (Longhorn) — the interim tier instituted after the
+  # 2026-07-24 data-loss incident. Works today with no object storage. When the
+  # fuzeinfra-backups bucket + fuzeinfra-backups-s3 SealedSecret are provisioned,
+  # flip `sink: s3` for durable off-cluster backups (the S3 block below is ready).
+  enabled: true
+  sink: pvc
+  pvc:
+    storageClass: longhorn
+    size: 20Gi
+    keep: 7
+  # Stagger per-DB schedules: they share one RWO PVC, so they must not overlap.
+  postgres:
+    schedule: "0 2 * * *"    # 02:00 UTC
+  mongodb:
+    schedule: "20 2 * * *"   # 02:20 UTC
+  neo4j:
+    schedule: "40 2 * * *"   # 02:40 UTC
   s3:
     endpoint: "https://eu2.contabostorage.com"
     region: "default"

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -448,6 +448,17 @@ loki:
 # bucket lifecycle policy, NOT by these Jobs — see docs/backups-and-blobs.md.
 backups:
   enabled: false
+  # Where dumps land: "s3" (Contabo Object Storage — the durable off-cluster
+  # target, needs the bucket + backups.s3.existingSecret) or "pvc" (a Longhorn
+  # PVC in-cluster — needs no object storage; the interim tier that works today,
+  # replicated across the durable nodes). See docs/backups-and-blobs.md.
+  sink: s3
+  # PVC-sink settings (used only when sink=pvc).
+  pvc:
+    storageClass: longhorn
+    size: 20Gi
+    image: busybox:1.36     # sh + cp/ls/xargs for copy + in-pod rotation
+    keep: 7                 # keep newest N dumps per DB on the PVC
   # aws-cli image used by the upload sidecar step of every CronJob.
   awsCliImage: amazon/aws-cli:2.17.0
   # Default cron schedule (UTC). Per-DB `schedule` overrides this when set.


### PR DESCRIPTION
## Why
After the **2026-07-24 data-loss incident** there are **no backups running**. The existing `backup-cronjobs.yaml` (S3 → Contabo Object Storage) is complete but **blocked** on object-storage provisioning (bucket + offline-sealed `fuzeinfra-backups-s3` secret + Contabo-panel S3 keys). This adds an immediately-usable path.

## What
- New `backups.sink` option: **`s3`** (default, unchanged) or **`pvc`**.
  - `pvc` reuses the **exact same per-DB dump logic** — `pg_dumpall`, `mongodump`, and neo4j **APOC online export** — and writes the compressed dump to a **replicated Longhorn PVC** (`fuzeinfra-db-backups`) with **in-pod rotation** (`keep` newest N per DB). No object storage required.
  - `s3` path and its `fail` guard are unchanged (guard now only fires for `sink=s3`).
- **Enabled on Contabo** (`values-contabo.yaml`): `sink: pvc`, staggered schedules **02:00 / 02:20 / 02:40 UTC** (they share one RWO PVC, so they must not overlap).

## Tiers
`pvc` is the **interim** tier — replicated across the durable nodes, survives the single-node-loss scenario that caused the incident. **S3** remains the durable off-cluster target: flipping to it later is just `sink: s3` + the sealed secret. Documented in `docs/backups-and-blobs.md` (follow-up doc update).

## Validation
`helm template -f values-contabo.yaml` renders 1 Longhorn PVC + 3 CronJobs (busybox upload → `/remote`); default `sink=s3` still `fail`s without the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)