### PR TITLE
fix(postgres): pin to durable Longhorn-disk nodes

### DIFF
--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -36,6 +36,12 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "postgres" "root" $) | nindent 8 }}
     spec:
+      {{- with .Values.postgres.nodeSelector }}
+      # Pin Postgres to durable (Longhorn-disk) nodes so it never runs on an
+      # ephemeral autoscaled node — the elastic taint is only PreferNoSchedule.
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: {{ .Values.postgres.image }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -41,6 +41,11 @@ postgres:
   resources:
     requests: {cpu: 250m, memory: 512Mi}
     limits: {cpu: "1", memory: 1Gi}
+  # Pin to durable Longhorn-disk nodes (the 3 durable nodes carry this label;
+  # ephemeral elastics do not) so Postgres availability never depends on an
+  # autoscaled node. See the 2026-07-24 storage/OOM incident.
+  nodeSelector:
+    node.longhorn.io/create-default-disk: "true"
 mongodb:
   storage: 10Gi
   resources:

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -196,6 +196,10 @@ postgres:
   image: postgres:15
   port: 5432
   storage: 5Gi
+  # Optional node pin. Empty by default (kind/AWS unaffected). On overlays with
+  # a durable node pool, set to a label only durable nodes carry so Postgres
+  # never schedules onto an ephemeral autoscaled node.
+  nodeSelector: {}
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: "1",  memory: 1Gi }


### PR DESCRIPTION
## Why
After the 2026-07-24 storage/OOM incident, Postgres kept scheduling onto **ephemeral elastic nodes** — the elastic taint is only `PreferNoSchedule`, so a tolerationless pod lands there anyway. Its data is durable on Longhorn, but the *compute* riding an autoscaled node means a node reap = an availability blip. Products depend on Postgres, so its availability must not depend on an elastic node.

## What
- Values-gated `postgres.nodeSelector` (default `{}` — kind/AWS unaffected).
- Contabo overlay sets it to `node.longhorn.io/create-default-disk: "true"` — a label only the **3 durable nodes** carry (elastics don't), so Postgres is pinned to durable nodes.

## Validation
`helm template -f values-contabo.yaml` renders the nodeSelector on the Postgres StatefulSet; default render has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)