### PR TITLE
fix(neo4j): pin to durable Longhorn-disk nodes

### DIFF
--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -315,6 +315,11 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "neo4j" "root" $) | nindent 8 }}
     spec:
+      {{- with .Values.neo4j.nodeSelector }}
+      # Pin Neo4j to durable (Longhorn-disk) nodes — same rationale as Postgres.
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: neo4j
           image: {{ .Values.neo4j.image }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -51,6 +51,11 @@ mongodb:
   resources:
     requests: {cpu: 100m, memory: 256Mi}
     limits: {cpu: "1", memory: 512Mi}
+neo4j:
+  # Pin to durable Longhorn-disk nodes (same as postgres) so Neo4j never runs
+  # on an ephemeral autoscaled node once products start seeding it.
+  nodeSelector:
+    node.longhorn.io/create-default-disk: "true"
 redis:
   storage: 2Gi
   resources:

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -243,6 +243,9 @@ neo4j:
   httpPort: 7474
   boltPort: 7687
   storage: 5Gi
+  # Optional durable-node pin (empty by default; set on overlays with a durable
+  # node pool). See postgres.nodeSelector.
+  nodeSelector: {}
   resources:
     requests: { cpu: 200m, memory: 512Mi }
     limits:   { cpu: "1",  memory: 2Gi }


### PR DESCRIPTION
Mirror of #397 for Neo4j (freshly rebuilt on Longhorn). Values-gated nodeSelector, Contabo sets create-default-disk=true. Keeps Neo4j off ephemeral nodes before products seed it.