### PR TITLE
fix(db): spread anti-affinity + kafka fsGroup

### DIFF
--- a/helm/fuzeinfra/templates/_helpers.tpl
+++ b/helm/fuzeinfra/templates/_helpers.tpl
@@ -61,3 +61,22 @@ Usage: {{ include "fuzeinfra.host" (dict "root" $ "sub" "grafana") }}
 {{- define "fuzeinfra.host" -}}
 {{ .sub }}.{{ .root.Values.global.domain }}
 {{- end -}}
+
+{{/*
+Soft anti-affinity: spread heavy stateful DBs across nodes (avoid piling all onto
+one node — root cause of the 2026-07-24 OOM). Preferred (never blocks scheduling).
+Usage in a pod spec: {{- include "fuzeinfra.dbSpread" $ | nindent 6 }}
+*/}}
+{{- define "fuzeinfra.dbSpread" -}}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values: ["{{ .Release.Name }}"]
+{{- end -}}

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -42,6 +42,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "fuzeinfra.dbSpread" $ | nindent 6 }}
       containers:
         - name: postgres
           image: {{ .Values.postgres.image }}
@@ -126,6 +127,7 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "mongodb" "root" $) | nindent 8 }}
     spec:
+      {{- include "fuzeinfra.dbSpread" $ | nindent 6 }}
       containers:
         - name: mongodb
           image: {{ .Values.mongodb.image }}
@@ -320,6 +322,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "fuzeinfra.dbSpread" $ | nindent 6 }}
       containers:
         - name: neo4j
           image: {{ .Values.neo4j.image }}

--- a/helm/fuzeinfra/templates/messaging.yaml
+++ b/helm/fuzeinfra/templates/messaging.yaml
@@ -39,6 +39,12 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "kafka" "root" $) | nindent 8 }}
     spec:
+      # Confluent Kafka runs as uid 1000; fsGroup makes k8s chown the fresh
+      # Longhorn data volume to gid 1000 on mount (else the ext4 PV is root-owned
+      # and Kafka fails its writable preflight and CrashLoops).
+      securityContext:
+        fsGroup: 1000
+      {{- include "fuzeinfra.dbSpread" $ | nindent 6 }}
       containers:
         - name: kafka
           image: {{ .Values.kafka.image }}


### PR DESCRIPTION
(a) soft podAntiAffinity on postgres/mongodb/neo4j/kafka to prevent single-node concentration (2026-07-24 OOM root cause) and enable safe node drains for the VLAN cutover. (b) kafka fsGroup=1000 so its fresh Longhorn volume is writable (was CrashLooping). Renders clean on all overlays.