### PR TITLE
feat(setup): codify VLAN + Longhorn state so from-zero == today's cluster

### DIFF
--- a/argocd/applications/longhorn.yaml
+++ b/argocd/applications/longhorn.yaml
@@ -60,6 +60,11 @@ spec:
           # Do not let a node self-select all disks blindly; operator tags durable
           # nodes for replica placement (design §4.1 / O-6).
           createDefaultDiskLabeledNodes: true
+          # How long Longhorn waits before rebuilding a replica whose node went
+          # away. The 600s default makes a node reinstall/reboot look like a
+          # 10-minute "stuck degraded" volume during a rolling cutover; 30s
+          # rebuilds promptly while still absorbing a quick restart.
+          replicaReplenishmentWaitInterval: 30
           # Guard against replicas landing on autoscaled/reaped elastic nodes.
           allowVolumeCreationWithDegradedAvailability: false
         # Keep local-path the cluster default: do NOT create a default-marked

--- a/cluster-autoscaler/contabo-externalgrpc/deploy/cp-userdata-eth1.template
+++ b/cluster-autoscaler/contabo-externalgrpc/deploy/cp-userdata-eth1.template
@@ -23,6 +23,26 @@
 # Template variables (rendered by ca-salvage-enroll):
 #   {{.NodeName}}     - k8s node name (pass node_name to keep it stable)
 #   {{.K3SServerURL}} / {{.K3SNodeToken}} - intentionally UNUSED here.
+#
+# OPERATOR STEP AFTER THIS RUNS — write config.yaml then install the server:
+#
+#   cat > /etc/rancher/k3s/config.yaml <<CFG
+#   server: https://<A PEER SERVER>:6443     # never this node's own URL
+#   token: <contents of /var/lib/rancher/k3s/server/token on a peer>
+#   flannel-backend: wireguard-native        # must match the fleet
+#   flannel-iface: eth1                      # pod overlay rides the private VLAN
+#   node-name: <this node>
+#   tls-san: [ <public ip>, <vlan ip> ]
+#   node-taint: [ "node-role.kubernetes.io/control-plane=:PreferNoSchedule" ]
+#   CFG
+#   curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=<fleet version> sh -s - server
+#
+# DO NOT set `node-ip` on a SERVER: it changes the node's expected etcd peer URL
+# and k3s then refuses to start ("this server is not a member of the etcd
+# cluster ... expect: <name>=https://<ip>:2380"). If a server's peer address
+# must move to the VLAN, update it in etcd FIRST from a peer:
+#   etcdctl member update <id> --peer-urls=https://<vlan-ip>:2380
+# (agents may set node-ip/node-external-ip freely — they have no etcd identity).
 
 users:
   - name: root

--- a/cluster-autoscaler/contabo-externalgrpc/deploy/durable-userdata-eth1.template
+++ b/cluster-autoscaler/contabo-externalgrpc/deploy/durable-userdata-eth1.template
@@ -62,6 +62,17 @@ write_files:
   # on v1.36.2+k3s1 across all 4 nodes including the control-plane. An agent
   # more than one minor ahead/behind the server is unsupported, so this must
   # track whatever channel the baseline module pins.
+  # k3s config: put the pod overlay on the private VLAN (eth1). Written BEFORE
+  # the join so the node comes up on the VLAN directly — no Stage-2 flip needed.
+  # NOTE: node-ip is set for AGENTS only. Never set node-ip on an etcd SERVER:
+  # it changes the expected etcd peer URL and the server refuses to start
+  # ("this server is not a member of the etcd cluster ... expect: <ip>:2380").
+  - path: /etc/rancher/k3s/config.yaml
+    permissions: "0600"
+    owner: root:root
+    content: |
+      flannel-iface: eth1
+
   - path: /etc/k3s-agent.env
     permissions: "0600"
     owner: root:root

--- a/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata-eth1.template
+++ b/cluster-autoscaler/contabo-externalgrpc/deploy/elastic-userdata-eth1.template
@@ -62,6 +62,17 @@ write_files:
   # on v1.36.2+k3s1 across all 4 nodes including the control-plane. An agent
   # more than one minor ahead/behind the server is unsupported, so this must
   # track whatever channel the baseline module pins.
+  # k3s config: put the pod overlay on the private VLAN (eth1). Written BEFORE
+  # the join so the node comes up on the VLAN directly — no Stage-2 flip needed.
+  # NOTE: node-ip is set for AGENTS only. Never set node-ip on an etcd SERVER:
+  # it changes the expected etcd peer URL and the server refuses to start
+  # ("this server is not a member of the etcd cluster ... expect: <ip>:2380").
+  - path: /etc/rancher/k3s/config.yaml
+    permissions: "0600"
+    owner: root:root
+    content: |
+      flannel-iface: eth1
+
   - path: /etc/k3s-agent.env
     permissions: "0600"
     owner: root:root

--- a/docs/runbooks/cluster-from-zero.md
+++ b/docs/runbooks/cluster-from-zero.md
@@ -1,0 +1,106 @@
+# Runbook — prod cluster from zero (HA + private VLAN + Longhorn)
+
+The end-state this reproduces, and where each piece is codified. Everything below
+is either **automatic** (Git/Helm/Argo/cloud-init) or a **single scripted step** —
+no ad-hoc `kubectl` archaeology. Written 2026-07-26 after the HA + private-VLAN
+cutover, so the manual steps discovered that day never have to be rediscovered.
+
+**Target state:** 3-node embedded-etcd control plane (no SPOF) · every node's pod
+overlay on the Contabo private VLAN (net 60932, `10.0.0.0/22`) · Longhorn 3-replica
+storage pinned to durable nodes · all DB StatefulSets on `longhorn` · nightly
+logical backups · Argo CD `automated{prune,selfHeal}`.
+
+---
+
+## 1. Nodes (Terraform / cloud-init) — automatic
+
+| Node class | Template | Joins as | Private VLAN |
+|---|---|---|---|
+| elastic (autoscaled) | `deploy/elastic-userdata-eth1.template` | agent | yes — `flannel-iface: eth1` written pre-join |
+| durable worker | `deploy/durable-userdata-eth1.template` | agent | yes — same, plus open-iscsi/nfs + `/var/lib/longhorn` |
+| control plane | `deploy/cp-userdata-eth1.template` | **prepared only** | yes — operator then writes `config.yaml` (§2) |
+
+All three write `/etc/rancher/k3s/config.yaml` with **`flannel-iface: eth1`** *before*
+the k3s join, so a node comes up on the VLAN directly — there is no "Stage 2 flip"
+for new nodes. They also `ufw allow from 10.0.0.0/22` and open `51820/udp`
+(flannel wireguard-native).
+
+> **The Contabo private NIC (`eth1`) only appears after a REINSTALL.** A reboot is
+> not enough — confirmed twice. Any node that must move onto the VLAN gets
+> reinstalled via the `ca-salvage-enroll` workflow with the matching `-eth1` template.
+
+## 2. Control plane / HA — scripted
+
+First server: `cluster-init: true` in `/etc/rancher/k3s/config.yaml` (migrates an
+existing SQLite datastore to embedded etcd in place). Servers 2 and 3 join with a
+`config.yaml` carrying `server: https://<peer>:6443` + the server token. Full
+procedure, gates and rollback: **`docs/runbooks/k3s-ha-etcd-migration.md`**.
+
+Two rules that cost real downtime when violated:
+
+- **Never pass `--server`/`--token` as cloud-init CLI args** — they can arg-mangle
+  and the node bootstraps *its own* etcd cluster (split-brain). Always `config.yaml`.
+- **Never set `node-ip` on a server.** It changes the node's expected etcd peer URL
+  and k3s refuses to start (`this server is not a member of the etcd cluster …
+  expect: <name>=https://<ip>:2380`). To move a server's peer onto the VLAN, update
+  it in etcd **first**, from a peer:
+  `etcdctl member update <id> --peer-urls=https://<vlan-ip>:2380`.
+  Agents may set `node-ip`/`node-external-ip` freely.
+
+Firewall between servers (in the CP template; add by hand for pre-existing nodes):
+`2379:2380/tcp` (etcd), `6443/tcp`, `10250/tcp`, and `from 10.0.0.0/22`.
+
+## 3. Longhorn — Git + one script
+
+Chart + settings: `argocd/applications/longhorn.yaml` (`defaultSettings`) — 3
+replicas, hard anti-affinity, `createDefaultDiskLabeledNodes: true`,
+`storageOverProvisioningPercentage: 100`, `replicaReplenishmentWaitInterval: 30`.
+
+**The one piece that is NOT in Git** is the per-node durable label — it is node-local
+and does **not survive a reinstall**:
+
+```bash
+./scripts/label-durable-nodes.sh          # run after bring-up, ANY node reinstall, or adding a durable node
+./scripts/label-durable-nodes.sh --verify-only
+```
+
+Without the label the node contributes no replica disk, and volumes stall with
+`ReplicaSchedulingFailure … insufficient storage` / `disks are unavailable`.
+
+**Never promote an elastic node to durable.** A promoted elastic's Longhorn engine
+hung a live Postgres volume in prod and only a hard reboot released it.
+
+## 4. Workloads — Git (Argo)
+
+Already declarative in `helm/fuzeinfra`; listed so a from-zero operator knows they
+are covered: `global.storageClass: longhorn` (prod) so any StatefulSet recreation
+lands on durable storage · `postgres.nodeSelector` / `neo4j.nodeSelector` pinning
+DBs to durable nodes · `fuzeinfra.dbSpread` soft anti-affinity so DBs don't pile
+onto one node · kafka `fsGroup: 1000` + init-chown (fresh ext4 Longhorn volumes are
+root-owned) · `backups.sink: pvc` nightly `pg_dumpall`/`mongodump`/neo4j-APOC to a
+Longhorn PVC · Argo `ignoreDifferences` on StatefulSet `.spec.volumeClaimTemplates`
+(the immutable field that once caused DBs to be recreated onto empty local-path PVCs).
+
+## 5. Verify
+
+```bash
+kubectl get nodes                                            # all Ready
+kubectl get nodes -l node-role.kubernetes.io/etcd=true       # 3 servers
+kubectl get nodes -o json | python3 -c 'import json,sys;n=json.load(sys.stdin)["items"];print(sum(1 for x in n if x["metadata"].get("annotations",{}).get("flannel.alpha.coreos.com/public-ip","").startswith("10.0.")),"/",len(n),"on VLAN")'
+./scripts/label-durable-nodes.sh --verify-only               # >=3 durable, 0 cordoned
+kubectl -n longhorn-system get volumes.longhorn.io           # attached + healthy
+```
+
+## 6. Troubleshooting notes worth keeping
+
+- **A volume won't attach** → check the *volume's* `Scheduled` condition first
+  (`kubectl -n longhorn-system get volumes.longhorn.io <vol> -o json`). The
+  csi-attacher message `volume … is not ready for workloads` means it cannot place
+  replicas — **not** that CSI is broken. Usual causes: too few labelled durable
+  nodes, leftover **cordons** (Longhorn skips cordoned nodes), or disks full of
+  **orphaned volumes** from earlier PVC recreations (delete Longhorn volumes not
+  bound by any PVC — they keep consuming scheduled space).
+- **`mke2fs … is apparently in use by the system`** on mount = stale device mapping
+  on that node; move the pod to another node (or clear the device).
+- After clearing a backlog, `kubectl -n longhorn-system rollout restart
+  deployment/csi-attacher` clears the exponential retry backoff.

--- a/scripts/label-durable-nodes.sh
+++ b/scripts/label-durable-nodes.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Label the DURABLE nodes so Longhorn places replicas only on them, and verify
+# the cluster is in the state the platform expects.
+#
+# WHY THIS EXISTS
+# Longhorn runs with `createDefaultDiskLabeledNodes: true`
+# (argocd/applications/longhorn.yaml), which means a node contributes a replica
+# disk ONLY if it carries `node.longhorn.io/create-default-disk=true`. That
+# label is node-local state — it is NOT in Git and it does NOT survive a node
+# reinstall. Every time a durable node was reinstalled during the private-VLAN
+# cutover the label was silently lost, and Longhorn then had too few schedulable
+# disks to place 3 replicas ("ReplicaSchedulingFailure ... insufficient
+# storage" / "disks are unavailable"), which stalls every affected volume.
+#
+# Run this after: initial cluster bring-up, ANY node reinstall, or adding a
+# durable node. It is idempotent and safe to re-run.
+#
+#   ./scripts/label-durable-nodes.sh                 # label + verify (default nodes)
+#   DURABLE_NODES="a b c" ./scripts/label-durable-nodes.sh
+#   ./scripts/label-durable-nodes.sh --verify-only
+#
+# NEVER label an ephemeral/autoscaled elastic node durable: its Longhorn engine
+# is short-lived, and a promoted elastic hung a live Postgres volume in prod
+# (2026-07-24) — see docs/runbooks/k3s-ha-etcd-migration.md.
+set -euo pipefail
+
+LABEL="node.longhorn.io/create-default-disk=true"
+# The three durable (replica-hosting) nodes. Override via DURABLE_NODES.
+DURABLE_NODES="${DURABLE_NODES:-vmi3383846 vmi3396106 mendys-worker-1}"
+VERIFY_ONLY="${1:-}"
+
+kubectl version --request-timeout=10s >/dev/null 2>&1 || {
+  echo "ERROR: kubectl cannot reach a cluster" >&2; exit 1; }
+
+if [ "$VERIFY_ONLY" != "--verify-only" ]; then
+  echo "== labelling durable nodes =="
+  for n in $DURABLE_NODES; do
+    if kubectl get node "$n" >/dev/null 2>&1; then
+      kubectl label node "$n" "$LABEL" --overwrite >/dev/null
+      echo "  ok   $n"
+    else
+      echo "  SKIP $n (not in cluster)"
+    fi
+  done
+fi
+
+echo "== verification =="
+labelled=$(kubectl get nodes -l node.longhorn.io/create-default-disk=true \
+             --no-headers 2>/dev/null | wc -l | tr -d ' ')
+echo "  nodes labelled durable: $labelled"
+[ "$labelled" -ge 3 ] || {
+  echo "  WARN: Longhorn needs >=3 durable nodes for 3-replica volumes." >&2; }
+
+# Cordoned nodes are excluded from Longhorn replica scheduling. Leftover
+# troubleshooting cordons silently starve placement — surface them.
+cordoned=$(kubectl get nodes --no-headers 2>/dev/null | grep -c SchedulingDisabled || true)
+[ "$cordoned" -eq 0 ] && echo "  cordoned nodes: 0" \
+  || echo "  WARN: $cordoned cordoned node(s) — Longhorn will not schedule replicas there:
+$(kubectl get nodes --no-headers | awk '/SchedulingDisabled/{print "    "$1}')"
+
+if kubectl get nodes.longhorn.io -n longhorn-system >/dev/null 2>&1; then
+  echo "  Longhorn nodes with a schedulable disk:"
+  kubectl -n longhorn-system get nodes.longhorn.io -o json 2>/dev/null | python3 -c '
+import json,sys
+for n in json.load(sys.stdin)["items"]:
+    ds=n.get("status",{}).get("diskStatus",{})
+    ok=sum(1 for d in ds.values()
+           if any(c["type"]=="Schedulable" and c["status"]=="True" for c in d.get("conditions",[])))
+    if ok: print(f"    {n[\"metadata\"][\"name\"]}: {ok} disk(s)")
+' || true
+fi
+echo "done."


### PR DESCRIPTION
Makes a from-zero build land in the same state as the cluster after today's HA + private-VLAN cutover — no manual archaeology.

## The critical fix
The `-eth1` cloud-init templates brought the NIC up but **never set `flannel-iface`**, so every newly autoscaled elastic node would rejoin on the **public** network and break VLAN uniformity. They now write `/etc/rancher/k3s/config.yaml` with `flannel-iface: eth1` **before** the k3s join.

## Also codified
- **`cp-userdata-eth1`** documents the exact server-join `config.yaml` plus the two rules that cost downtime today: never pass `--server/--token` as cloud-init CLI args (arg-mangling → split-brain etcd bootstrap), and **never set `node-ip` on a server** (breaks its etcd peer URL — update it from a peer with `etcdctl member update` instead).
- **Longhorn** `replicaReplenishmentWaitInterval: 600 → 30` so a node reinstall doesn't present as a 10-minute stuck-degraded volume.
- **`scripts/label-durable-nodes.sh`** — the one piece that can't live in Git: `node.longhorn.io/create-default-disk` is node-local and is **lost on every reinstall**. Idempotent, and warns about leftover cordons (which silently starve Longhorn replica scheduling — a real cause of stalled volumes today).
- **`docs/runbooks/cluster-from-zero.md`** — end-state, where each piece is codified, verification commands, and volume-attach troubleshooting (incl. "check the volume's `Scheduled` condition first — `not ready for workloads` means replicas can't place, not that CSI is broken").

## Validation
Templates parse as valid cloud-config YAML with `flannel-iface` present; script passes `bash -n`.