### PR TITLE
fix(arc): dind + maxRunners 3 on all sets — restore the verified config

### DIFF
--- a/argocd/applications/arc-runners.yaml
+++ b/argocd/applications/arc-runners.yaml
@@ -16,9 +16,11 @@
 # is a new block here, not a workflow run against prod.
 #
 # ⚠ BECAUSE Argo will now ACTUALLY apply that file, anything set in it reaches
-# all 8 sets at once. containerMode.dind is deliberately DISABLED there — it
-# was measured on 2026-07-27 to leave runners registered-but-never-online and
-# every job queued. Read the block in that file before re-enabling it.
+# all 8 sets at once — read it in full before merging, not just this diff.
+# In particular containerMode.dind is ON there, and it ONLY works alongside the
+# explicit `command: ["/home/runner/run.sh"]` on the runner container. Enabling
+# dind without that command leaves every runner registered-but-never-online with
+# all jobs queued (measured 2026-07-27; fix verified on fuzepicker).
 #
 # PREREQUISITE (this is the bug that made the previous single Application a
 # silent no-op since 2026-07-08):
@@ -76,7 +78,7 @@ spec:
           - name: runnerScaleSetName
             value: "staging"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git
@@ -143,7 +145,7 @@ spec:
           - name: runnerScaleSetName
             value: "mendysrobotics"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git
@@ -210,7 +212,7 @@ spec:
           - name: runnerScaleSetName
             value: "fuzehub"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git
@@ -277,7 +279,7 @@ spec:
           - name: runnerScaleSetName
             value: "fuzesales"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git
@@ -344,7 +346,7 @@ spec:
           - name: runnerScaleSetName
             value: "fuzesocial"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git
@@ -411,7 +413,7 @@ spec:
           - name: runnerScaleSetName
             value: "fuzecontact"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git
@@ -478,7 +480,7 @@ spec:
           - name: runnerScaleSetName
             value: "fuzeservice"
           - name: maxRunners
-            value: "5"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git

--- a/runners/arc/runner-scale-set-values.yaml
+++ b/runners/arc/runner-scale-set-values.yaml
@@ -38,14 +38,13 @@ runnerScaleSetName: staging
 # ---- Scaling ----------------------------------------------------------------
 # minRunners=0  → idle costs nothing; runners spin up on demand.
 # maxRunners    → hard cap; tune based on cluster capacity. All sets share ONE
-#                 4-vCPU/8GB CI node (fuzeinfra-ci-runner-1), so the sum across
-#                 sets is what matters, not the per-set number.
-#                 NOTE: drop this to 3 in the same change that re-enables
-#                 containerMode.dind — dind sidecars are unbounded and 5 per set
-#                 across 8 sets will OOM the node.
+#                 4-vCPU/8GB CI node (fuzeinfra-ci-runner-1), so the SUM across
+#                 sets is what matters, not the per-set number. Kept at 3
+#                 because containerMode.dind is on and dind sidecars are
+#                 unbounded — that node has already been OOMed once.
 # Overridden per set by argocd/applications/arc-runners.yaml.
 minRunners: 0
-maxRunners: 5
+maxRunners: 3
 
 # ---- Runner pod spec --------------------------------------------------------
 template:
@@ -56,17 +55,21 @@ template:
 
     containers:
       - name: runner
-        # Stock image, matching live state. The CI-capable image
-        # (ghcr.io/izzywdev/fuzeinfra-arc-runner, built from runners/arc/
-        # Dockerfile) adds compose-v2 + buildx + a warm toolcache, and IS
-        # published and publicly pullable — but it buys nothing while
-        # containerMode.dind is disabled below, because without a Docker daemon
-        # neither `docker build` nor `docker compose` can run at all. Switch to
-        # it in the SAME change that re-enables dind, not before.
+        # Stock image. Has the docker CLI + buildx (enough for `docker build`
+        # and `docker buildx build --push`) but NOT compose-v2, so
+        # `docker compose -f ...` fails with "unknown shorthand flag: 'f'".
+        # For compose, switch to the CI-capable image built from
+        # runners/arc/Dockerfile (ghcr.io/izzywdev/fuzeinfra-arc-runner:latest,
+        # published and publicly pullable — there is NO imagePullSecret in
+        # arc-runners, so it must stay public).
         image: ghcr.io/actions/actions-runner:latest
-        # NOTE: do NOT override command/args here. (A debug JITCONFIG wrapper
-        # used to live here — removed now that the runner is stable. It exec'd
-        # run.sh directly and added connectivity-curl noise.)
+        # REQUIRED WHENEVER containerMode.dind IS ON — see the dind block below.
+        # The ARC controller injects this itself on the non-dind path, but not
+        # when dind rewrites this container; without it the container runs the
+        # image default Cmd ["/bin/bash"], exits 0 instantly, and the runner
+        # never comes online. (The old "do NOT override command/args" note here
+        # referred to a removed debug JITCONFIG wrapper, not to run.sh.)
+        command: ["/home/runner/run.sh"]
         # securityContext omitted — seccompProfile.type:RuntimeDefault is not
         # guaranteed available on k3s nodes; add back once runner is stable.
         # Headroom for buildkit client work + Node actions (1Gi OOMs). Compose/
@@ -91,41 +94,35 @@ template:
         operator: Exists
         effect: NoSchedule
 
-# ---- Docker-in-Docker — DISABLED, DO NOT RE-ENABLE WITHOUT READING THIS -----
-# containerMode.type=dind is what you want for `docker build`, and it is
-# currently OFF because it BREAKS RUNNER CONNECTIVITY on this cluster.
+# ---- Docker-in-Docker ------------------------------------------------------
+# Injects a privileged `dind` sidecar + `init-dind-externals` initContainer and
+# wires DOCKER_HOST, so `docker build` / `docker buildx build --push` /
+# `docker run` work self-hosted.
 #
-# Measured 2026-07-27 on Contabo k3s (v1.36.2), all 8 scale sets:
-#   * enabling dind → runners REGISTER with GitHub (a runnerId is issued) but
-#     NEVER come online: `gh api repos/<o>/<r>/actions/runners` showed
-#     total=3, online=0, and every job stayed queued.
-#   * pods churned continuously — created, dind sidecar starts fine ("Docker
-#     daemon ... API listen on /var/run/docker.sock"), the runner container
-#     reaches ready=true but emits ZERO logs, then the pod is torn down after
-#     a few seconds. Controller reported pending=3 running=0 finished=0 failed=0.
-#   * NOT the runner image: `staging` ran the stock actions-runner image and
-#     churned identically. NOT the ARC controller: restarting it did not help.
-#     NOT PodSecurity: the arc-runners namespace has no PSA labels and the dind
-#     sidecar does get privileged=true.
-#   * `helm rollback` to the pre-dind revision brought runners online within
-#     ~48s (3 online, 5 pods Running) — reverting it is what fixes it.
+# ⚠ REQUIRES the explicit `command: ["/home/runner/run.sh"]` on the runner
+# container above. Do not remove one without the other. Enabling dind WITHOUT
+# it silently breaks every runner in this exact way (measured 2026-07-27):
+#   * runners REGISTER with GitHub but NEVER come online
+#     (`gh api repos/<o>/<r>/actions/runners` → total=1, online=0), every job
+#     queues forever, and pods churn every few seconds.
+#   * the runner container exits `exitCode=0, reason=Completed` with
+#     startedAt == finishedAt and ZERO log output.
+# Cause: the ARC controller injects `command: ["/home/runner/run.sh"]` into the
+# runner container in the NON-dind path (verified on a live working pod), but
+# not when dind rewrites that container. Without it the container runs the
+# image's default `Cmd: ["/bin/bash"]`, which with no TTY reads EOF and exits 0
+# immediately — the runner never starts, so it can never come online.
 #
-# Leading hypothesis (UNCONFIRMED): dockerd manipulates iptables/nftables inside
-# the SHARED pod network namespace — its own logs show it deleting nftables
-# rules and falling back ("Failed to find nft tool") — which appears to break
-# the runner's outbound long-poll to broker.actions.githubusercontent.com.
+# Verified working on fuzepicker with dind + the explicit command:
+#   registered=1 online=1, pod 2/2 Running and stable, and inside the pod
+#   `docker version` → client 29.6.1 / server 29.6.2, `docker build` produced an
+#   image and `docker run` executed it.
 #
-# Before re-enabling: reproduce on ONE non-critical scale set, and verify
-# `online>0` via the runners API — pods reaching Running is NOT sufficient
-# evidence, they reach Running and still never connect.
-#
-# CONSEQUENCE while this is off: there is no Docker daemon in runner pods, so
-# `docker build` / `docker compose` jobs fail with
-#   "failed to connect to the docker API at unix:///var/run/docker.sock".
-# Such jobs must use ubuntu-latest until dind is fixed.
-#
-# containerMode:
-#   type: dind
+# DIAGNOSTIC RULE: pods reaching Running is NOT evidence that runners work.
+# They reach Running and still never connect. Always check `online > 0` via the
+# runners API.
+containerMode:
+  type: dind
 
 # ---- ARC controller reference -----------------------------------------------
 controllerServiceAccount:


### PR DESCRIPTION
## PR #415 merged at the wrong commit

[#415](https://github.com/izzywdev/FuzeInfra/pull/415) merged at its **intermediate** commit `f00c8c9`, not the branch tip. So main carries the *safe-rollback* state — `containerMode.dind` commented out, `maxRunners: 5` — instead of the verified-working config in `a5ccae8`, which never reached main:

```console
$ git branch -r --contains a5ccae8
  origin/fix/arc-scale-sets-gitops     # ← only the feature branch
```

This restores both files to `a5ccae8`.

## What changes

| | before (main) | after |
|---|---|---|
| `containerMode` | commented out | **`dind`** |
| runner `command` | absent | **`["/home/runner/run.sh"]`** |
| `maxRunners` | 5 (×7 sets) | **3** |

**The two must move together.** Enabling dind *without* the command is what broke every runner earlier: the ARC controller injects `command: ["/home/runner/run.sh"]` on the non-dind path, but not when dind rewrites the runner container. The container then runs the image default `Cmd: ["/bin/bash"]`, reads EOF with no TTY, and **exits 0 instantly** — so runners register but never come online and every job queues. That failure mode is documented inline in the values file so the two don't get separated.

Verified on `fuzepicker`:

| config | result |
|---|---|
| dind, no command | `registered=1 online=0`, pods churning ~14s |
| dind + command | `registered=1 online=1`, pod `2/2 Running` stable |

and inside that pod: `docker version` → client 29.6.1 / server 29.6.2, `docker build` produced an image, `docker run` executed it.

`maxRunners` drops to 3 because dind sidecars are unbounded and all sets share **one** 4-vCPU/8GB CI node — the node that was OOMed earlier in this incident.

## Where per-set settings live

Each Application in `argocd/applications/arc-runners.yaml` carries a `helm.parameters` block (`githubConfigUrl`, `runnerScaleSetName`, `maxRunners`, `minRunners`). Everything shared — dind, image, resources, node pinning — comes from the single `runners/arc/runner-scale-set-values.yaml`. So **`maxRunners` is per-set; dind is global**.

`fuzepicker` stays at `0` (it was parked before any of this work). It inherits dind but spawns no runners — set it to `"3"` to enable.

## ⚠️ Note for whoever merges

`argocd/applications/*.yaml` is **not** applied automatically — nothing syncs that directory, it's `kubectl apply -f ...` by hand. Merging #415 changed Git without changing the cluster; there are still no ARC Applications in Argo. Merging this PR alone will likewise not move the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
