### PR TITLE
fix(arc): enable fuzepicker at maxRunners 3 like every other set

### DIFF
--- a/argocd/applications/arc-runners.yaml
+++ b/argocd/applications/arc-runners.yaml
@@ -549,7 +549,7 @@ spec:
           - name: runnerScaleSetName
             value: "fuzepicker"
           - name: maxRunners
-            value: "0"
+            value: "3"
           - name: minRunners
             value: "0"
     - repoURL: https://github.com/izzywdev/FuzeInfra.git


### PR DESCRIPTION
`fuzepicker` was the only scale set left at `maxRunners: 0`. That was **preserved state, not a decision** — it was already 0 when this incident began, so it was carried forward rather than enabling a disabled set unprompted. Enabling it is now explicit.

This change existed on the #418 branch but **never reached main**: #418 auto-merged on green at an earlier commit, before the fuzepicker push landed. The same race dropped the final commit from #415 (which is why dind had to be restored in #418 at all). Re-applied here on its own so it cannot be lost again.

All 8 sets are now uniform — dind + `command: ["/home/runner/run.sh"]` + `maxRunners: 3`. Already applied live and verified.

⚠️ **CI-node budget**: 8 sets x 3 = 24 potential runner pods, each with an unbounded dind sidecar, on **one** 4-vCPU/8GB node. At 500m/1Gi requests the scheduler admits ~7 concurrently and the rest queue, so they cannot all run at once — but `fuzeinfra-ci-runner-1` has been OOMed before and is worth watching under load.