### PR TITLE
chore(tf): stale plan refresh — reconcile the unapplied terraform backlog

### DIFF
--- a/terraform/contabo/backend.tf
+++ b/terraform/contabo/backend.tf
@@ -25,4 +25,25 @@ terraform {
   }
 }
 
-# CD plan verification trigger — no infra change (see PR). Safe to remove.
+# ---------------------------------------------------------------------------
+# STALE-PLAN RECOVERY (why a comment-only commit sometimes lands here)
+#
+# terraform-plan-apply is merge-to-apply: the plan is computed on the PR, saved
+# as an artifact keyed by the PR head SHA, and the merge applies THAT EXACT plan.
+# Terraform refuses a saved plan whose state serial moved since it was created.
+#
+# That refusal is correct and deliberate — it is what stops an unreviewed change
+# from applying. But it means any terraform PR whose plan predates ANOTHER
+# terraform apply becomes permanently un-appliable: merging two terraform PRs
+# close together guarantees the second fails, re-running the job re-downloads the
+# same stale artifact, and there is no workflow_dispatch. The config sits merged
+# on main and never applies, which is easy to miss because the PR reads as done.
+#
+# Recovery: land a trivial change under terraform/** (this comment). That runs a
+# FRESH plan against current state — which necessarily includes every accumulated
+# unapplied change — so one review reconciles the whole backlog. Prior art:
+# "chore(tf): replan CI runner node (stale plan refresh)", 2026-07-08.
+#
+# Review that plan as the apply approval, exactly as normal: it is not a no-op,
+# it is the entire pending delta. Safe to rewrite this block on the next refresh.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
**Comment-only change.** It contains no resource of its own. Its purpose is to trigger a **fresh `terraform plan` against current state**, because four applies have failed as `Saved plan is stale` and their config is sitting on `main` unapplied.

## Why this is needed

`terraform-plan-apply` is merge-to-apply: the plan is computed on the PR, saved as an artifact keyed by the PR head SHA, and the merge applies *that exact plan*. Terraform refuses a saved plan whose state serial moved since it was created.

That refusal is correct and deliberate — it is what stops an unreviewed change from applying. But there is no recovery path: any terraform PR whose plan predates another terraform apply becomes permanently un-appliable, re-running the job re-downloads the same stale artifact, and there is no `workflow_dispatch`.

```
2026-07-27 19:48  failure   #407  Unleash + Authentik launcher tiles
2026-07-27 18:45  failure   #412  custom-hostname DNS + sealed secret
2026-07-27 18:45  success   #416  drop public Access bypasses
2026-07-27 08:37  failure   #410  multi-tenant portal wildcard
```

#416 applied at 18:45:13 and moved the state serial. #412 merged 5 seconds later carrying a plan built before #416 existed, so it was refused.

**That refusal prevented a real regression.** #412's stale plan still contained the two Access-bypass recreations that #416 had just removed. Applying it would have silently restored public unauthenticated access to `neo4j.prod.fuzefront.com/browser` and `grafana.prod.fuzefront.com/public/build`.

## Expected plan — review it as the apply approval

This is **not** a no-op plan. It is the entire pending delta:

| Resource | From |
|---|---|
| `cloudflare_record.tenant_wildcard` | #412 |
| `cloudflare_record.saas_connect` | #412 |
| `cloudflare_record.saas_origin` | #412 |
| `cloudflare_custom_hostname_fallback_origin.saas` | #412 |
| `cloudflare_zero_trust_access_application.launcher["unleash"]` | #407 |
| `cloudflare_zero_trust_access_application.launcher["authentik"]` | #407 |
| 3 outputs | #410 |

**Adds only — any `destroy` in the plan is a stop signal, not this change.** The two `launcher` entries are App Launcher *bookmark* tiles from #407; they sit under the `*.prod` wildcard and add no new access path. They are expected here precisely because #407's apply never ran.

Verified unapplied against live DNS before opening this:

```
connect.fuzefront.com          NXDOMAIN
saas-origin.fuzefront.com      NXDOMAIN
*.fuzefront.com                NXDOMAIN
app.fuzefront.com              resolves    (control)
argocd.prod.fuzefront.com      resolves    (control)
```

## Follow-up, not in this PR

The comment left in `backend.tf` documents the recovery procedure so the next person doesn't re-derive it. The actual fix — `workflow_dispatch` to re-plan on `main`, and/or a concurrency group so terraform merges serialize instead of racing — belongs in its own PR. It would have prevented all four failures above.

Refs FFRNT-137, #407, #410, #412, #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)