### PR TITLE
fix(deploy): register every argocd/applications manifest, not a stale hand-list

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,11 +10,9 @@ on:
     paths:
       - 'helm/**'
       - 'deploy/sealed-secrets/**'
-      - 'argocd/applications/fuzeinfra-prod.yaml'
-      - 'argocd/applications/fuzeinfra-sealed-secrets.yaml'
-      - 'argocd/applications/sealed-secrets.yaml'
-      - 'argocd/applications/fuzequality.yaml'
-      - 'argocd/applications/arc-selfheal.yaml'
+      # Any Application manifest — the registration step below globs the whole
+      # directory, so listing files individually here only risks going stale.
+      - 'argocd/applications/**'
       - 'argocd/projects/fuzefront.yaml'
       - 'argocd/projects/fuzeinfra.yaml'
       - 'runners/arc/gitops/**'
@@ -91,8 +89,24 @@ jobs:
           # deploy. Terraform only applies them on first-provision, so on a VPS
           # rebuild (or if one was never registered — e.g. sealed-secrets, #88) they
           # would silently go missing. apply -f makes the repo the source of truth.
-          for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets fuzequality arc-selfheal; do
-            kubectl apply -f "argocd/applications/$app.yaml"
+          # Register EVERY Application manifest in argocd/applications/, except the
+          # ones scoped to another environment. This was a hand-maintained list and
+          # it went stale: argocd/applications/arc-runners.yaml (8 ARC scale-set
+          # Applications) was never added, so those Applications existed in Git but
+          # NOT in the cluster — the GitOps wiring was declared and inert, and the
+          # live scale sets drifted from runner-scale-set-values.yaml indefinitely.
+          # A glob cannot go stale the same way.
+          #
+          # NOTE: file basename != Application name for some manifests
+          # (fuzeagent.yaml -> fuzeagent-apps, arc-runners.yaml -> 8 apps), which is
+          # why this iterates FILES while the sync loop below iterates NAMES.
+          SKIP_APPS="fuzeinfra-local fuzeinfra-aws"   # kind / EKS overlays — never prod
+          for f in argocd/applications/*.yaml; do
+            app=$(basename "$f" .yaml)
+            case " $SKIP_APPS " in
+              *" $app "*) echo "skipped $app (other environment)"; continue;;
+            esac
+            kubectl apply -f "$f"
             echo "registered $app"
           done
 
@@ -119,6 +133,10 @@ jobs:
             fi
           fi
           # Kick an immediate sync so the rollout starts seconds after merge.
+          # Deliberately an explicit list, NOT every registered app: forcing a hard
+          # refresh + sync on the ARC scale sets would restart listeners and can
+          # disrupt in-flight CI jobs. Those Applications carry selfHeal, so Argo
+          # converges them on its own without being kicked.
           for app in fuzeinfra-prod sealed-secrets fuzeinfra-sealed-secrets fuzequality arc-selfheal; do
             # Ensure the sync renders this Git revision instead of reusing a
             # cached Helm result whose reported revision has already advanced.


### PR DESCRIPTION
## The gap

Nothing applied `argocd/applications/`. The prod deploy registered a **hardcoded list** of five manifests; anything not on that list existed in Git and **not** in the cluster — declared GitOps that never ran.

That's exactly what happened to `argocd/applications/arc-runners.yaml`. The 8 ARC scale-set Applications were written, reviewed, merged... and never registered. Confirmed live: `kubectl -n argocd get applications -l app.kubernetes.io/part-of=arc-runners` returns nothing. That's why the live scale sets kept drifting from `runner-scale-set-values.yaml` and every fix had to be hand-applied with Helm.

## The fix

Glob the directory instead of listing files:

```bash
SKIP_APPS="fuzeinfra-local fuzeinfra-aws"   # kind / EKS overlays — never prod
for f in argocd/applications/*.yaml; do
  app=$(basename "$f" .yaml)
  case " $SKIP_APPS " in *" $app "*) echo "skipped $app"; continue;; esac
  kubectl apply -f "$f"
done
```

Only the two environment overlays are excluded — applying the kind or EKS Application to Contabo prod would be wrong. The push trigger is widened from five listed files to `argocd/applications/**` for the same anti-staleness reason.

**The sync loop is deliberately left as an explicit list.** Forcing a hard refresh + sync on the ARC scale sets would restart their listeners and can disrupt in-flight CI jobs; those Applications carry `selfHeal`, so Argo converges them without being kicked. Note also that basename ≠ Application name for several manifests (`fuzeagent.yaml` → `fuzeagent-apps`, `arc-runners.yaml` → 8 apps) — which is why registration iterates **files** and sync iterates **names**.

## Verified by server-side dry-run against prod

| manifest | effect |
|---|---|
| `arc-runners` | `arc-runners-staging` **configured** + **7 created** |
| `arc-selfheal` | configured |
| `longhorn` | configured ⚠️ *(see below)* |
| `fuzeagent`, `fuzepicker`, `fuzeinfra-prod`, `sealed-secrets`, `fuzeinfra-sealed-secrets`, `fuzequality` | **unchanged** (no-ops) |

Plus: workflow YAML parses, the modified step passes `bash -n`, and the glob+skip logic was simulated against the real directory (9 registered, 2 skipped).

## ⚠️ Two consequences worth knowing before merge

**1. It takes over the old `arc-runners-staging` Application.** That Application is live *right now* with `prune: true`, `selfHeal: true`, no helm parameters and no labels — it went active the moment #415 fixed the AppProject. This replaces it with the reviewed spec (`prune: false` + per-set parameters) and creates the other 7. That is the intended and safer end state — it turns `prune` **off** — but it is a real change to a live Application managing prod runners.

**2. Longhorn picks up pending drift.** `longhorn.yaml` in Git carries `replicaReplenishmentWaitInterval: 30` which is **not** applied live. Registering it applies that, and Argo will sync it to Longhorn. The value looks deliberate (it ships with a comment about node reinstalls during a rolling cutover making volumes look stuck-degraded for 10 minutes), so this is drift GitOps *should* correct — but it changes replica-rebuild behaviour on storage, so it should be a conscious call rather than a surprise. Say the word and I'll add `longhorn` to `SKIP_APPS` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
