### PR TITLE
fix(argocd): allow the fuzefront namespace in the fuzeinfra AppProject

### DIFF
--- a/argocd/projects/fuzeinfra.yaml
+++ b/argocd/projects/fuzeinfra.yaml
@@ -29,6 +29,15 @@ spec:
     # rejects that Application with InvalidSpecError and never syncs it.
     - namespace: arc-systems
       server: https://kubernetes.default.svc
+    # The custom-hostname API manages a CONSUMER's Ingress, so the chart renders a
+    # scoped Role + RoleBinding into that consumer's namespace (see
+    # global.routeProfiles in values.yaml). Without this entry the whole
+    # fuzeinfra-prod sync fails with
+    #   Role/custom-hostname-api-ingress: namespace fuzefront is not permitted
+    #   in project 'fuzeinfra'
+    # which blocks EVERY other resource in the app, not just these two.
+    - namespace: fuzefront
+      server: https://kubernetes.default.svc
   # The chart creates cluster-scoped objects (monitoring ClusterRole/Binding),
   # so cluster resources must be allowed for this project.
   clusterResourceWhitelist:


### PR DESCRIPTION
`fuzeinfra-prod` has been **OutOfSync/Degraded** with its sync failing on two resources:

```
Role/custom-hostname-api-ingress:        namespace fuzefront is not permitted in project 'fuzeinfra'
RoleBinding/custom-hostname-api-ingress: namespace fuzefront is not permitted in project 'fuzeinfra'
```

#417 enabled the custom-hostname API and its `fuzefront` route profile. That API manages a **consumer's** Ingress, so the chart renders a scoped Role + RoleBinding into that consumer's namespace (`global.routeProfiles` in `values.yaml`) — a destination the AppProject didn't permit.

**Two rejected resources block the entire application sync**, not just themselves. That's why unrelated resources — prometheus, kube-state-metrics, the rule ConfigMaps — were all stuck OutOfSync behind them.

This is the same class of bug as the ARC one: an AppProject destination missing for a namespace the chart legitimately targets. That one left `arc-runners-staging` at InvalidSpec, never synced, since 2026-07-08 — and was the root cause of the ARC drift chased all through this incident. Worth noting the pattern: **a missing AppProject destination fails silently and takes the whole app down with it.**

Verified: `kubectl apply --dry-run=server` accepts the AppProject.