### PR TITLE
feat(arc): onboard FuzeMarket — add its runner scale set

### DIFF
--- a/argocd/applications/arc-runners.yaml
+++ b/argocd/applications/arc-runners.yaml
@@ -585,3 +585,70 @@ spec:
         duration: 10s
         factor: 2
         maxDuration: 3m
+---
+# -----------------------------------------------------------------------------
+# fuzemarket  ->  workflows target it with `runs-on: fuzemarket`
+# -----------------------------------------------------------------------------
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-runners-fuzemarket
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: arc-runners
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: fuzeinfra
+  # Multi-source: OCI chart + git values file (ArgoCD >= 2.6). The $values ref
+  # lets valueFiles reference the git source by alias.
+  sources:
+    - repoURL: ghcr.io/actions/actions-runner-controller-charts
+      chart: gha-runner-scale-set
+      targetRevision: "0.14.2"
+      helm:
+        releaseName: fuzemarket
+        valueFiles:
+          - $values/runners/arc/runner-scale-set-values.yaml
+        parameters:
+          - name: githubConfigUrl
+            value: "https://github.com/izzywdev/FuzeMarket"
+          - name: runnerScaleSetName
+            value: "fuzemarket"
+          - name: maxRunners
+            value: "3"
+          - name: minRunners
+            value: "0"
+    - repoURL: https://github.com/izzywdev/FuzeInfra.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arc-runners
+  # Argo must not revert EphemeralRunnerSet replicas/patchID — the ARC listener
+  # owns those and patches them at runtime. selfHeal reverting them makes the
+  # listener loop forever without runners ever completing a job.
+  ignoreDifferences:
+    - group: actions.github.com
+      kind: EphemeralRunnerSet
+      jsonPointers:
+        - /spec/replicas
+        - /spec/patchID
+  syncPolicy:
+    automated:
+      selfHeal: true
+      # prune INTENTIONALLY false for the initial adoption: these sets already
+      # exist as imperative `helm install` releases, and Argo adopts the live
+      # objects via ServerSideApply. Pruning during that first reconcile could
+      # delete every runner set at once and take all repos' CI down. Flip to
+      # true once a clean sync has been observed for all 8.
+      prune: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m


### PR DESCRIPTION
FuzeMarket had **no runner scale set and no registered runners** — `gh api repos/izzywdev/FuzeMarket/actions/runners` returned `total_count: 0`. Every job it dispatched queued forever with `runner_id: 0`.

That was being read as a label mismatch or CI load. It was neither: there was physically nothing that could claim those jobs. The repo was never onboarded.

Adds `arc-runners-fuzemarket` alongside the other 8, sharing the same values file so it inherits dind + `command: ["/home/runner/run.sh"]` + CI-node pinning. `maxRunners: 3`, matching every other set.

### ⚠️ This alone does not fix FuzeMarket

Its workflows use `runs-on: self-hosted`, which **never** matches a `gha-runner-scale-set` runner — those register with **no labels** and are matched by *scale-set name*. A companion PR on FuzeMarket switches them to `runs-on: fuzemarket`. **Both halves are required**; either alone leaves the jobs queued.

The set is already registered live (helm revision 1, listener Running) so the runner exists *before* workflows start targeting it. This PR puts it under Argo so it isn't a one-off imperative install like the other 8 were.

Verified: `kubectl apply --dry-run=server` accepts all 9 Applications.