### PR TITLE
fix(argocd): RespectIgnoreDifferences so StatefulSet syncs stop failing

### DIFF
--- a/argocd/applications/fuzeinfra-prod.yaml
+++ b/argocd/applications/fuzeinfra-prod.yaml
@@ -50,6 +50,18 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      # Makes ignoreDifferences apply to the SYNC, not just the diff. Without it
+      # Argo hides .spec.volumeClaimTemplates from the diff (so the app reports
+      # Synced) but STILL sends it in the server-side apply, and the API server
+      # rejects every StatefulSet with:
+      #   updates to statefulset spec for fields other than 'replicas',
+      #   'ordinals', 'template', ... are forbidden
+      # That failed the sync for all 10 stateful services (postgres, mongodb,
+      # neo4j, kafka, elasticsearch, redis, rabbitmq, loki, alertmanager,
+      # chromadb) and left the app permanently Degraded while claiming Synced.
+      # volumeClaimTemplates is immutable, so changing a StatefulSet's
+      # storageClass still requires recreating it deliberately.
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
`fuzeinfra-prod` reported **Synced** while its sync operation failed on every retry. All 10 stateful services were rejected:

```
StatefulSet.apps "fuzeinfra-postgres" is invalid: spec: Forbidden: updates to
statefulset spec for fields other than 'replicas', 'ordinals', 'template',
'updateStrategy', ... are forbidden
```

postgres · mongodb · neo4j · kafka · elasticsearch · redis · rabbitmq · loki · alertmanager · chromadb

## Why

The app already has `ignoreDifferences` on `.spec.volumeClaimTemplates` — added because that field is immutable and live still differs from Git (`local-path` vs the intended `longhorn`).

**But `ignoreDifferences` only affects the diff.** With `ServerSideApply`, Argo still *sends* the field, so the API server rejects the apply. The result is the worst kind of failure: the app **claims Synced** while nothing can actually converge, and health sits Degraded indefinitely.

`RespectIgnoreDifferences=true` makes the ignore apply to the **sync** as well, so the field is omitted and the remaining changes land.

## What this does not do

It does **not** migrate storage. `volumeClaimTemplates` remains immutable — moving a StatefulSet from `local-path` to `longhorn` still requires deliberately recreating it (as was just done for prometheus, which was only safe because its volume was empty). This change simply stops the sync failing over a field nobody intends to patch in place.

⚠️ Worth flagging separately: **all 11 StatefulSets are currently on `local-path`** while Git intends `longhorn` for every one. That's node-local storage with no replication, on a cluster that has already lost a volume this way. It needs a planned per-volume migration.

Verified: `kubectl apply --dry-run=server` accepts the Application; it parses with all three syncOptions and ignoreDifferences intact.