### PR TITLE
fix(argocd): use jsonPointers for the volumeClaimTemplates ignore

### DIFF
--- a/argocd/applications/fuzeinfra-prod.yaml
+++ b/argocd/applications/fuzeinfra-prod.yaml
@@ -35,8 +35,14 @@ spec:
   ignoreDifferences:
     - group: apps
       kind: StatefulSet
-      jqPathExpressions:
-        - .spec.volumeClaimTemplates
+      # jsonPointers, NOT jqPathExpressions: RespectIgnoreDifferences reliably
+      # honours jsonPointers, but does not consistently apply jq expressions —
+      # with the jq form the field was still sent in the apply and every
+      # StatefulSet was rejected as immutable, even with
+      # RespectIgnoreDifferences=true enabled. The arc-runners Applications
+      # already use the jsonPointers form for the same reason.
+      jsonPointers:
+        - /spec/volumeClaimTemplates
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
#427 added `RespectIgnoreDifferences=true`, but the sync **still failed** on every StatefulSet:

```
StatefulSet.apps "fuzeinfra-alertmanager" is invalid: spec: Forbidden: updates to
statefulset spec for fields other than 'replicas', ... are forbidden
```

I verified live that `volumeClaimTemplates` is the **only** immutable field that differs — `serviceName` and `selector` match exactly:

| field | desired | live |
|---|---|---|
| serviceName | `fuzeinfra-alertmanager` | same |
| selector | matchLabels ×2 | same |
| **volumeClaimTemplates** | **data/longhorn** | **data/local-path** |

So the ignore simply wasn't being applied.

**Cause:** the ignore used `jqPathExpressions`. `RespectIgnoreDifferences` reliably honours `jsonPointers` but does **not** consistently apply jq expressions — so the field was still sent in the apply and rejected. Switching to `jsonPointers` (the form the `arc-runners` Applications already use) makes the ignore effective during **sync**, not just during diff.

This still does **not** migrate storage — `volumeClaimTemplates` stays immutable, and moving a StatefulSet to longhorn requires deliberate recreation. It stops the sync erroring over a field nobody intends to patch in place, so the rest of the app can converge.

Verified: `kubectl apply --dry-run=server` accepts it; parses with jsonPointers and all three syncOptions intact.