### PR TITLE
fix(arc): run the CI-capable runner image, not stock actions-runner

### DIFF
--- a/runners/arc/runner-scale-set-values.yaml
+++ b/runners/arc/runner-scale-set-values.yaml
@@ -55,14 +55,19 @@ template:
 
     containers:
       - name: runner
-        # Stock image. Has the docker CLI + buildx (enough for `docker build`
-        # and `docker buildx build --push`) but NOT compose-v2, so
-        # `docker compose -f ...` fails with "unknown shorthand flag: 'f'".
-        # For compose, switch to the CI-capable image built from
-        # runners/arc/Dockerfile (ghcr.io/izzywdev/fuzeinfra-arc-runner:latest,
-        # published and publicly pullable — there is NO imagePullSecret in
-        # arc-runners, so it must stay public).
-        image: ghcr.io/actions/actions-runner:latest
+        # CI-capable image (built from runners/arc/Dockerfile), NOT the stock
+        # actions-runner. A self-hosted runner is not ubuntu-latest: the stock
+        # image ships almost no toolchain, so workflows written for hosted
+        # runners fail with exit 127. Observed on FuzeMarket the moment its jobs
+        # first ran: `gh: command not found`, and `pip install semgrep` -> 127.
+        # This image bakes in gh, jq, curl, docker compose-v2 + buildx, node,
+        # and pre-warms /opt/hostedtoolcache so actions/setup-python|node
+        # resolve locally instead of fetching.
+        # It is also register-repo.sh's RUNNER_IMAGE default, so this makes the
+        # Argo-managed sets match how new sets are registered.
+        # PREREQUISITE: must stay published + PUBLIC — there is NO
+        # imagePullSecret in arc-runners, so a private image ImagePullBackOffs.
+        image: ghcr.io/izzywdev/fuzeinfra-arc-runner:latest
         # REQUIRED WHENEVER containerMode.dind IS ON — see the dind block below.
         # The ARC controller injects this itself on the non-dind path, but not
         # when dind rewrites this container; without it the container runs the


### PR DESCRIPTION
**A self-hosted ARC runner is not `ubuntu-latest`.** The stock `ghcr.io/actions/actions-runner` image ships almost no toolchain, so workflows written against hosted runners fail with exit 127.

This surfaced the moment FuzeMarket's jobs first ran on a real runner. Its workflows had said `runs-on: self-hosted` for a long time, but nothing ever claimed them — so these assumptions had never been exercised:

```
Auto Merge PR : gh: command not found
gate-sast     : pip install -q semgrep -> 127   (no python on PATH)
gate-authz    : same
```

Switches the shared values to `ghcr.io/izzywdev/fuzeinfra-arc-runner`, which bakes in **gh, jq, curl, docker compose-v2 + buildx, node**, and pre-warms `/opt/hostedtoolcache` so `actions/setup-python|setup-node` resolve locally instead of fetching.

It is also `register-repo.sh`'s `RUNNER_IMAGE` default — so the Argo-managed sets now match how new sets are registered. That divergence is why the image differed at all.

**Applies to all 9 sets, deliberately**: every repo's auto-merge/governance workflows call `gh`, so each would hit this. The stock image only ever provided docker CLI + buildx.

### Why this had to go through Git

An imperative `helm --set` override of the image was **reverted by Argo within minutes**, now that the scale sets are Argo-managed with `selfHeal`. That's the GitOps model working as intended — and a good sign, given the whole point of #415/#424 was to stop imperative drift.

### Verified

- image is published and **anonymously pullable** (ghcr manifest → HTTP 200) — required, since there is no `imagePullSecret` in `arc-runners`
- values still parse with `dind` + `command: ["/home/runner/run.sh"]` + `maxRunners: 3` intact