### PR TITLE
fix(argocd): drop creationTimestamp:null from the CA-provider SealedSecret

### DIFF
--- a/helm/fuzeinfra/templates/autoscaler/sealed-secret-ca-provider.yaml
+++ b/helm/fuzeinfra/templates/autoscaler/sealed-secret-ca-provider.yaml
@@ -2,7 +2,6 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  creationTimestamp: null
   name: fuzeinfra-ca-provider
   namespace: fuzeinfra
 spec:
@@ -15,7 +14,6 @@ spec:
     NOTIFY_TELEGRAM_BOT_TOKEN: AgAWiUBr6wLoFqQDyQ9X9YxlRaJtmtP6ZY76C55khXBnA3ZjClT2XqPbcsK3hDlsbqJZz+21AAUqc5RxKR5d+Ze01UmsGGj9lN3asUJYkRlAVL8cRgUr5zRMZ6UyJLQlgnOTvxtlwqJmblmpTTJ7rJDYBpsqkn3gAzU/8Ya8r1zdVHt3MTicsxjX9rsU9AlUIt2FWoJU5Up0PdGXLmMWqlXj1Nj0cymyn3RK+LSboqir2KhxAB0iS8gCLV5UDUKYDveN/NYu8Yd24ApOFPA3umqUslliuopMVowKdyh0u2woSQGgy0tfTuuNYpEv7ddEx+XBekK8nzfgYJ2hUDs7l1aiHq0VhH9XO2cT6Ajy4XypFBbeJtp8TtJNSzjard6LqBToojYtD0RXayUNOucdaTy4gWoKbfOZU9dd9h2J1thpnfT3/8EUsJE3gV1UaUkO7Ao7+5k2Zs3k3RXNIbsqXpwd2a5NesFVYl7J3GbhoxmqH8HlgRhPb4ztyABgK0n1i0ZxkCyJucmOmKXoxyxW277/875jrDCAkGoXF4p+nsTWLiip9j9PsEF03oHvCiGMZPC0VrREoancC9ftpDxMpFLLQ5hBbMq78AVnENuES9GD62KAWcHaRwAykqgRA1GECrftNJn0Vol2MC6AMGev0FOOYw7lzclh0/fXo5pu7dyoDXlJ8gfrUjjyAnCQAg0USSyPcMLhZX4Fyyh7BG5sOFETCOqSAUQpxxUiaIduUAJjICAhKJ3PMW2VNy4WwG2M
   template:
     metadata:
-      creationTimestamp: null
       name: fuzeinfra-ca-provider
       namespace: fuzeinfra
     type: Opaque


### PR DESCRIPTION
`fuzeinfra-prod` stayed **OutOfSync/Degraded** on a single resource — `SealedSecret/fuzeinfra-ca-provider` — after every other cause was fixed.

**It was not real drift.** The encrypted payload is byte-identical between Git and the cluster (same 6 keys, same ciphertext). The manifest carried two `creationTimestamp: null` lines — a `kubeseal` output artifact — at `metadata.creationTimestamp` and `spec.template.metadata.creationTimestamp`.

The API server **strips** those on write, so the desired manifest permanently differed from live and Argo could never converge, however many times it synced.

Removes both. `creationTimestamp` is server-managed; an explicit `null` is meaningless and only exists because kubeseal serialises the full ObjectMeta.

### Verified

- chart still renders a valid SealedSecret with all **6** `encryptedData` keys
- `spec.template.metadata` reduced to `name` + `namespace`
- `kubectl diff` against prod now reports **only** Argo's own `argocd.argoproj.io/tracking-id` annotation — injected at apply time, not a diff Argo acts on

This is the last known blocker on fuzeinfra-prod reaching Synced/Healthy. The StatefulSet immutability problem behind it was resolved separately by re-creating all 11 StatefulSets with the `longhorn` template (orphan-delete + re-apply, no data moved, no pod restarted).