### PR TITLE
fix(backup): pin DB backup jobs to durable nodes so the volume can attach

### DIFF
--- a/helm/fuzeinfra/templates/backup-cronjobs.yaml
+++ b/helm/fuzeinfra/templates/backup-cronjobs.yaml
@@ -158,6 +158,29 @@ spec:
             app.kubernetes.io/component: backup
         spec:
           restartPolicy: Never
+          # Pin backup jobs to the DURABLE nodes. The fuzeinfra-db-backups PVC is
+          # a Longhorn volume whose replicas live only on durable nodes (Longhorn
+          # disks are deliberately scoped to them), so a job scheduled onto an
+          # elastic node cannot attach it:
+          #   FailedAttachVolume ... failed to attach to node fuzeinfra-elastic-*
+          # The pod then sits in Init until activeDeadlineSeconds expires and the
+          # Job dies with DeadlineExceeded. That silently broke the postgres,
+          # mongodb and neo4j backups for ~2 days — they were Complete in ~45s
+          # before, then started failing once they happened to land on elastic.
+          # Durable nodes are identified by the ABSENCE of fuzeinfra.io/pool
+          # (elastic nodes have pool=elastic, the CI node pool=ci); the second
+          # term keeps this working if durable nodes are ever labelled explicitly.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: fuzeinfra.io/pool
+                        operator: DoesNotExist
+                  - matchExpressions:
+                      - key: fuzeinfra.io/pool
+                        operator: NotIn
+                        values: ["elastic", "ci"]
           volumes:
             - name: backup
               emptyDir: {}


### PR DESCRIPTION
**The postgres, mongodb and neo4j backups have been silently dead for ~2 days.**

They fail with `DeadlineExceeded` — but they were not erroring, they were **hanging**:

```
FailedAttachVolume ... volume pvc-6d962336-... failed to attach to node
fuzeinfra-elastic-57543f68
```

Reproduced by running the job manually: the pod sat in `Init:0/1` for 5+ minutes with repeated `FailedAttachVolume`, and would have kept doing so until `activeDeadlineSeconds` (3600) killed it.

### Cause

The jobs had **no `nodeSelector` or `affinity`**, so they scheduled anywhere. `fuzeinfra-db-backups` is a Longhorn PVC whose 3 replicas live only on the **durable** nodes (Longhorn disks are deliberately scoped to them), so a job landing on an elastic node cannot attach it.

Backups completed in ~45s while they happened to land on a durable node, and started failing once they didn't. It was luck, not design.

**This matters:** these are the backups that saved Postgres during the 2026-07-24 storage incident — and the Longhorn backup-target is still unconfigured, so they are currently the only DB safety net.

### Fix

A required `nodeAffinity` selecting durable nodes. They're identified by the **absence** of `fuzeinfra.io/pool` (elastic → `pool=elastic`, CI → `pool=ci`); the second `nodeSelectorTerm` keeps this correct if durable nodes are ever labelled explicitly.

### Verified against the live cluster

| | |
|---|---|
| selector matches | `mendys-worker-1`, `vmi3383846`, `vmi3396106` |
| backup volume replicas on | `mendys-worker-1`, `vmi3383846`, `vmi3396106` — exact match |
| excluded | all 5 elastic nodes, the CI node, `mendys-prod` |
| rendering | all 3 CronJobs render with both terms |