### PR TITLE
fix(ci): open Claude/automation PRs as a real user so their checks actually run

### DIFF
--- a/.github/workflows/claude-auto-pr.yml
+++ b/.github/workflows/claude-auto-pr.yml
@@ -2,8 +2,34 @@ name: Auto-PR from claude branches
 
 # Closes the issue->PR autonomy gap: anthropics/claude-code-action (in claude.yml)
 # pushes a `claude/**` branch and only posts a "Create PR" link — it does not open
-# the PR itself. This workflow opens a DRAFT PR from any pushed `claude/**` branch
-# when one doesn't already exist (draft = a human still reviews before merge).
+# the PR itself. This workflow opens a PR from any pushed `claude/**` branch when
+# one doesn't already exist. The PR is opened ready-for-review (not draft) and a
+# human still merges it.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS USES A PAT AND NOT secrets.GITHUB_TOKEN
+#
+# A PR opened with GITHUB_TOKEN is authored by `github-actions[bot]`, and GitHub
+# gates workflow runs whose actor is a bot: every `pull_request` run on the PR is
+# created with conclusion `action_required`, waiting on a human to click Approve.
+# Observed on PR #410 — all 11 checks (Harden Gate, Infrastructure Tests, Helm
+# Chart Validation, kind-validate, terraform-plan-apply, ...) sat gated:
+#
+#     event: pull_request · actor: github-actions[bot] · conclusion: action_required
+#
+# In practice nobody clicks Approve, so Claude-authored PRs get merged with the
+# entire harden gate un-run — which is how a doc error reached main and took
+# plan.fuzefront.com down (see docs/consuming-repos/CUSTOM_DOMAINS.md §3). The
+# gate existed; the bot authorship silently disarmed it.
+#
+# Opening the PR with a real-user PAT makes the actor a real user, so checks run
+# immediately and normally. GH_TOKEN is the repo's real-user PAT (see claude.yml,
+# provision-*.yml); the `||` fallback keeps PR creation working if it is ever
+# unset, degrading to today's gated-but-created behaviour rather than failing.
+#
+# No recursion risk from dropping the GITHUB_TOKEN guard: this workflow only
+# opens/edits a PR, it never pushes a commit, so it cannot re-trigger itself.
+# ---------------------------------------------------------------------------
 on:
   push:
     branches:
@@ -22,12 +48,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Open draft PR if none exists
+      - name: Open PR if none exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Real-user PAT — see the header. With GITHUB_TOKEN the PR is authored
+          # by github-actions[bot] and every check on it lands in action_required.
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          HAVE_PAT: ${{ secrets.GH_TOKEN != '' }}
           BRANCH: ${{ github.ref_name }}
           BASE: ${{ github.event.repository.default_branch }}
         run: |
+          if [ "$HAVE_PAT" != "true" ]; then
+            echo "::warning::secrets.GH_TOKEN is unset — opening this PR as github-actions[bot]." \
+                 "Every check on it will be created as 'action_required' and will NOT run until a" \
+                 "human clicks Approve in the Actions tab. Set GH_TOKEN to a real-user PAT" \
+                 "(contents: read, pull-requests: write) to restore automatic checks."
+          fi
           existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)
           if [ -n "$existing" ]; then
             echo "PR #$existing already open for $BRANCH — nothing to do."

--- a/.github/workflows/infra-request-handler.yml
+++ b/.github/workflows/infra-request-handler.yml
@@ -222,7 +222,14 @@ jobs:
       - name: Open gated PR for manual approval
         if: steps.validate.outputs.decision == 'gate'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Real-user PAT, same reason as claude-auto-pr.yml: a PR opened with
+          # GITHUB_TOKEN is authored by github-actions[bot], and GitHub creates
+          # every check on a bot-authored PR as `action_required` — un-run until
+          # someone clicks Approve. That matters most HERE, because merging this
+          # PR *is* the approval to provision real infrastructure, and the human
+          # doing it should be looking at real check results rather than a column
+          # of grey "waiting for approval" marks.
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           cd fuzeinfra
           REPO="${{ github.event.client_payload.repo }}"


### PR DESCRIPTION
Every check on a Claude-authored PR has been landing in `action_required` —
created, then frozen until a human clicks Approve in the Actions tab. Nobody
clicks it, so these PRs have been getting merged with the entire harden gate
un-run while the checks list still looked populated.

Root cause, from the run metadata rather than inference. On PR #410 all eleven
checks recorded:

    event: pull_request · actor: github-actions[bot] · conclusion: action_required

The `pull_request` event fires and the runs ARE created; GitHub gates them
because the ACTOR is a bot. claude-auto-pr.yml opens the PR with
`secrets.GITHUB_TOKEN`, which makes github-actions[bot] the author, which makes
every downstream check bot-triggered.

The cost is not hypothetical. #410 merged with Harden Gate, Infrastructure Tests,
Helm Chart Validation, kind-validate and terraform-plan-apply all un-run, and the
doc error it carried took plan.fuzefront.com down a day later (FuzeFront#431).
The gate existed and was disarmed by authorship, which is the worst version of
this failure: it reads as coverage.

Fix: open the PR with the repo's real-user PAT (`secrets.GH_TOKEN`, already used
by claude.yml, codex.yml and the provision-* workflows), falling back to
GITHUB_TOKEN so PR creation still works if the secret is ever unset — degrading
to today's behaviour rather than failing. When it does fall back it now emits a
::warning:: saying checks will not run and why, so the failure mode is legible
instead of silent.

No recursion risk from losing the GITHUB_TOKEN guard: this workflow only opens
and edits a PR, it never pushes a commit, so it cannot re-trigger itself.

infra-request-handler.yml had the identical bug on its gated infra-provisioning
PR and gets the same fix. It matters more there, if anything — merging that PR IS
the approval to provision real infrastructure, so the human doing it should be
reading real check results, not a column of grey "waiting for approval" marks.

Audited every other workflow that opens a PR: argo-outofsync-autofix, ca-cutover,
ca-spike-test, claude, codex, grafana-crit-fix, provision-fuzequality,
provision-mendys, rotate-fuzequality-chroma and rotate-sealed-secret already use
a PAT (or PAT-with-fallback). These two were the only ones left on a bare
GITHUB_TOKEN.

Also corrected the header comment, which claimed the workflow opens a DRAFT PR;
it passes no --draft and never has.

This change tests itself: if it works, the PR opened for THIS branch has running
checks instead of `action_required` ones.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EkVURsLwKFf5KKS1Z76C4f
