### PR TITLE
feat(cloudflare): add fuzehub.fuzefront.com public vanity host

### DIFF
--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -31,7 +31,7 @@ locals {
   # *.prod Access wildcard); FuzePlan declares its own Traefik Ingress for this
   # host in izzywdev/FuzePlan. Routing to Traefik is via the catch-all ingress
   # rule below — no per-host tunnel rule is needed.
-  public_vanity_hosts = ["app", "auth", "plan"]
+  public_vanity_hosts = ["app", "auth", "plan", "fuzehub"]
 }
 
 # 32-byte cryptographically random tunnel secret


### PR DESCRIPTION
## Summary

- Adds `"fuzehub"` to `public_vanity_hosts` in `terraform/contabo/cloudflare.tf`
- `terraform apply` will create a proxied DNS CNAME `fuzehub.fuzefront.com → tunnel`
- Keeps the hostname **outside** the `*.prod.fuzefront.com` Cloudflare Access OTP gate (public-facing, auth handled by Authentik inside the cluster)

## Routing chain

```
Client → fuzehub.fuzefront.com (CF edge, TLS terminates here)
       → cloudflared catch-all rule → Traefik (kube-system:80)
       → fuzehub ns Traefik Ingress (fuzehub.fuzefront.com)
       → frontend:3000 (/) or backend:3001 (/api)
```

The FuzeHub Traefik Ingress for `fuzehub.fuzefront.com` was added in [izzywdev/FuzeHub #45](https://github.com/izzywdev/FuzeHub/pull/45) and is already live.

## Test plan

- [ ] `terraform plan` in `terraform/contabo/` shows one DNS record added for `fuzehub.fuzefront.com`
- [ ] After `terraform apply`, `dig fuzehub.fuzefront.com` returns a CF-proxied CNAME
- [ ] `https://fuzehub.fuzefront.com` loads the FuzeHub Next.js frontend
- [ ] `https://fuzehub.fuzefront.com/api/health` returns `200` from the Express backend

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz5rsgiCNXDEJ7dY1kBfkp)_