### PR TITLE
chore(tf): reconcile multi-tenant DNS state and record what actually resolves

### DIFF
--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -141,14 +141,34 @@ resource "cloudflare_record" "vanity" {
 # `traefik.ingress.kubernetes.io/router.priority: "1"`.
 # See docs/consuming-repos/CUSTOM_DOMAINS.md §3.
 #
-# PRE-EXISTING RECORD: a proxied wildcard CNAME for *.<zone> already exists in
-# the zone, created outside this state. This resource therefore does NOT gate
-# whether tenant hosts resolve — they already do; the consumer's Ingress rule is
-# the only gate on serving. Applying with tenant_wildcard_enabled = true on a
-# zone that already has the record fails on a duplicate rather than adopting it:
-# `terraform import 'cloudflare_record.tenant_wildcard[0]' '<zone_id>/<record_id>'`
-# first, and read the plan for a destroy/create pair before merging — that would
-# replace a record already serving production traffic.
+# PRE-EXISTING RECORDS — verified by resolution on 2026-07-29:
+#
+#     connect.fuzefront.com        -> 104.21.14.243   (Cloudflare)
+#     saas-origin.fuzefront.com    -> 104.21.14.243   (Cloudflare)
+#     tenant-probe.fuzefront.com   -> 172.67.160.205  (served by the wildcard)
+#
+# All three multi-tenant records already resolve, so NONE of these resources
+# gates whether the hostnames work. They already do; the consumer's Ingress rule
+# is the only gate on SERVING (see docs/consuming-repos/CUSTOM_DOMAINS.md §1).
+#
+# Whether Terraform OWNS them is a separate question that only a plan answers.
+# Read this PR's plan output before merging:
+#
+#   * "No changes"        -> state is in sync; nothing to do.
+#   * "N to add"          -> the records exist OUTSIDE state. The apply will FAIL
+#                            on duplicates rather than adopting them. Import each
+#                            one first:
+#         terraform import 'cloudflare_record.tenant_wildcard[0]' '<zone_id>/<record_id>'
+#         terraform import 'cloudflare_record.saas_connect[0]'    '<zone_id>/<record_id>'
+#         terraform import 'cloudflare_record.saas_origin[0]'     '<zone_id>/<record_id>'
+#   * any DESTROY on these -> STOP. That would replace a record currently serving
+#                            production traffic.
+#
+# The zone-level Cloudflare for SaaS fallback origin
+# (cloudflare_custom_hostname_fallback_origin.saas) is NOT a DNS record, so its
+# presence cannot be confirmed by resolution — the plan is the only evidence.
+# Without it, Cloudflare refuses to activate any custom hostname, so a missing
+# fallback origin fails in front of a customer rather than in CI.
 #
 # TLS is Cloudflare-terminated. Universal SSL already covers the apex and the
 # first-level wildcard `*.fuzefront.com` on every plan, so tenant subdomains get


### PR DESCRIPTION
The multi-tenant DNS/TLS resources (#410) were switched on in #412, but every
terraform apply on main since that commit has FAILED — six in a row, 07-27
through 07-29 — because bot-authored PRs meant the PR-time `plan` job never ran,
so the merge-time `apply` had no saved plan artifact to consume. That is fixed
now (#443 opens PRs as a real user), so this PR is the first since the feature
was enabled that can actually produce a plan and land an apply.

The purpose of this PR is that plan. Read it before merging.

What is already known, verified by resolution rather than assumed:

    connect.fuzefront.com        -> 104.21.14.243   (Cloudflare)
    saas-origin.fuzefront.com    -> 104.21.14.243   (Cloudflare)
    tenant-probe.fuzefront.com   -> 172.67.160.205  (served by the wildcard)

So the records EXIST and the hostnames work. I had previously concluded from the
run history that terraform "never applied" and therefore the records were
missing; resolution disproves that, and the comment block is corrected to match
the evidence instead of the inference.

What resolution CANNOT tell us, and what this plan will:
  - whether terraform owns these records in state, or they were created out of
    band (in which case the apply fails on duplicates and each needs an import —
    the exact commands are in the comment);
  - whether the zone-level Cloudflare for SaaS fallback origin is set. That is a
    zone setting, not a DNS record, so nothing about it is visible from outside.
    Without it Cloudflare refuses to activate any custom hostname, which fails in
    front of a customer rather than in CI.

No resource, variable, or default is changed — comments only. The diff is
deliberately inert so the plan reflects the CURRENT state of the world and
nothing this PR introduces.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EkVURsLwKFf5KKS1Z76C4f
