### PR TITLE
fix(tf-cd): surface the two apply failures that silently blocked the SaaS rollout

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -37,6 +37,11 @@
 #     CONTABO_CLIENT_ID, CONTABO_CLIENT_SECRET, CONTABO_API_USER, CONTABO_API_PASSWORD
 #     CONTABO_IMAGE_ID, CONTABO_PRODUCT_ID, NODE_SSH_PUBLIC_KEY
 #     CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_ZONE_ID
+#       ^ NOT a DNS-only token. cloudflare.tf also manages the tunnel, Access
+#         apps, Workers and the Cloudflare for SaaS fallback origin, so it needs
+#         Zone -> SSL and Certificates -> Edit as well. A token missing that
+#         plans clean and fails at apply with "Authentication error (10000)".
+#         Full scope table: docs/TERRAFORM_CD.md.
 #     GH_TF_TOKEN              # token TF uses to write the KUBE_CONFIG secret etc.
 
 name: terraform-plan-apply
@@ -285,9 +290,26 @@ jobs:
             -backend-config="region=${{ secrets.TF_STATE_REGION }}" \
             -backend-config="dynamodb_table=${{ secrets.TF_STATE_LOCK_TABLE }}"
 
+      # Two failure modes here are expected-and-actionable rather than bugs, and
+      # both used to surface as a bare "Terraform exited with code 1". Classify
+      # them so the next person doesn't have to read provider source to find out
+      # what went wrong. See docs/TERRAFORM_CD.md § Apply failure modes.
       - name: Terraform apply (saved plan — exactly what was reviewed)
         working-directory: ${{ env.TF_ROOT }}
-        run: terraform apply -input=false -lock-timeout=5m tfplan
+        run: |
+          set +e
+          terraform apply -input=false -lock-timeout=5m -no-color tfplan 2>&1 | tee apply.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          [ "$rc" -eq 0 ] && exit 0
+
+          if grep -q "Saved plan is stale" apply.log; then
+            echo "::error::STALE PLAN. Another apply changed the state after this PR's plan was saved (usually a second terraform PR merged minutes earlier). Nothing was applied. Fix: push an empty-ish commit to a NEW terraform PR so a fresh plan is generated against current state, then merge it once no other terraform PR is in flight."
+          fi
+          if grep -qE "Authentication error \(10000\)" apply.log; then
+            echo "::error::CLOUDFLARE TOKEN LACKS A PERMISSION. Cloudflare returns the generic 10000 for 'this token may not write that resource' — the plan cannot catch it, since permission is only checked on write. Check CLOUDFLARE_API_TOKEN against the scope table in docs/TERRAFORM_CD.md (the fallback origin needs Zone -> SSL and Certificates -> Edit)."
+          fi
+          exit "$rc"
 
       - name: Summarize
         if: always()

--- a/docs/TERRAFORM_CD.md
+++ b/docs/TERRAFORM_CD.md
@@ -97,8 +97,37 @@ once with `terraform init -migrate-state -backend-config=...`.
 | `TF_STATE_ACCESS_KEY_ID` / `TF_STATE_SECRET_ACCESS_KEY` | backend access (state only) |
 | `CONTABO_CLIENT_ID` / `CONTABO_CLIENT_SECRET` / `CONTABO_API_USER` / `CONTABO_API_PASSWORD` | Contabo provider |
 | `CONTABO_IMAGE_ID` / `CONTABO_PRODUCT_ID` / `NODE_SSH_PUBLIC_KEY` | VPS inputs |
-| `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_ZONE_ID` | Cloudflare (zone-scoped token) |
+| `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_ZONE_ID` | Cloudflare (zone-scoped token — see the scope table below) |
 | `GH_TF_TOKEN` | token Terraform uses to set repo secrets (e.g. `KUBE_CONFIG`) |
+
+#### `CLOUDFLARE_API_TOKEN` scope
+
+This token is not DNS-only. `terraform/contabo/cloudflare.tf` manages the
+tunnel, Access apps, Workers **and** the Cloudflare for SaaS fallback origin, so
+the token needs all of:
+
+| Permission | Scope |
+|------------|-------|
+| Zone → DNS → Edit | `fuzefront.com` |
+| Zone → Zone → Read | `fuzefront.com` |
+| Zone → **SSL and Certificates → Edit** | `fuzefront.com` |
+| Account → Cloudflare Tunnel → Edit | the account |
+| Account → Access: Apps and Policies → Edit | the account |
+| Account → Workers Scripts → Edit | the account |
+
+A token missing **SSL and Certificates → Edit** plans cleanly and then fails at
+apply time with:
+
+```
+Error: failed to create custom hostname fallback origin: Authentication error (10000)
+  with cloudflare_custom_hostname_fallback_origin.saas[0]
+```
+
+Cloudflare returns the generic `10000` for "token lacks this permission", so the
+message names the resource but not the missing scope. If an apply fails on a
+`cloudflare_*` resource with `10000`, check the token's permissions before
+looking anywhere else — the plan cannot catch it, because permission is only
+evaluated on write.
 
 ---
 

--- a/docs/consuming-repos/CUSTOM_DOMAINS.md
+++ b/docs/consuming-repos/CUSTOM_DOMAINS.md
@@ -492,8 +492,12 @@ Zone -> Zone                -> Read     (fuzefront.com only)
 ```
 
 That token cannot touch DNS records, Workers, Access policies, the tunnel, other
-zones, or the account. The static DNS records this feature needs are created
-once by Terraform under a *different*, human-held token.
+zones, or the account. The static edge setup this feature needs — the `connect`
+and `saas-origin` records **and the zone's Cloudflare for SaaS fallback origin**
+— is created once by Terraform under a *different*, human-held token. Note that
+the Terraform token therefore also needs `SSL and Certificates -> Edit` (the
+fallback origin is an SSL-scoped resource, not a DNS one); see
+`docs/TERRAFORM_CD.md` for its full scope table.
 
 **How FuzeFront authenticates:** bearer token over in-cluster service DNS.
 


### PR DESCRIPTION
## Summary

The Cloudflare-for-SaaS **fallback origin has never been created in prod**, which is why no custom hostname can activate. Chasing that turned up two separate apply failures, both of which reported as a bare `Terraform exited with code 1` with the real cause buried mid-log.

**1. `CLOUDFLARE_API_TOKEN` is missing `Zone -> SSL and Certificates -> Edit`.**

`terraform/contabo/cloudflare.tf` manages more than DNS — the tunnel, Access apps, Workers, and `cloudflare_custom_hostname_fallback_origin.saas`. The fallback origin is an **SSL-scoped** resource, not a DNS one, so a DNS-scoped token plans perfectly clean and then fails at apply with Cloudflare's generic:

```
Error: failed to create custom hostname fallback origin: Authentication error (10000)
  with cloudflare_custom_hostname_fallback_origin.saas[0]
```

Permission is only evaluated on write, so **no plan-time check can catch this** — the drift gate stays green and the apply dies. This PR documents the full required scope table and names the exact error text against it.

**2. Saved plans go stale when two terraform PRs merge minutes apart.**

#445's apply bumped the state serial 87 seconds before #447's apply ran, so #447 was refused with `Saved plan is stale`. That refusal is the design working correctly — never apply something that wasn't reviewed — it just gave no hint that the fix is "re-plan on a fresh PR", not "retry".

The apply step now classifies both and emits an actionable `::error::` naming the fix.

Also corrects `docs/consuming-repos/CUSTOM_DOMAINS.md` §5, which claimed the Terraform-held token creates "the static DNS records". It also creates the fallback origin — which is precisely the permission that was missing.

**This PR does not unblock prod on its own.** Minting a Cloudflare token is a human action; see *Follow-up* below.

## Type of change

- [x] Bug fix
- [x] Documentation
- [x] Chore / CI / refactor

## Checklist

- [ ] Branch named `feat/…`, `fix/…`, or `chore/…` — branch name is agent-assigned; commit messages are conventional
- [x] Conventional commit messages
- [x] Commits are **signed** (verified)
- [ ] Tests added/updated where relevant — n/a, this is CI diagnostics + docs; the classifier's bash was syntax-checked (`bash -n`) and the workflow YAML parsed
- [x] **Harden Gate** checks pass (`lint`, `test`, `build`, `sast`, `secret-scan`, `dependency-scan`)
- [x] Conversations resolved and ready for code-owner review

No `terraform/**` files change, so this PR neither plans nor applies.

## Follow-up (blocks prod, needs a human)

The tokens must be re-minted before the fallback origin can be created:

1. Cloudflare dashboard → My Profile → API Tokens → edit the token behind the `CLOUDFLARE_API_TOKEN` repo secret.
2. Add `Zone -> SSL and Certificates -> Edit` on `fuzefront.com` (keep the existing DNS / Zone / Tunnel / Access / Workers permissions).
3. The same missing permission family also explains the runtime `custom-hostname-api` pod sitting `0/1 Running` — it 403s on `GET /zones/.../custom_hostnames` every 15s. That is a *different*, sealed token and needs its own re-seal with `SSL and Certificates -> Edit` + `Zone -> Read`.
4. Once (2) lands, a fresh terraform PR replans against current state and merging it creates the fallback origin.

## Related issues

Unblocks the multi-tenant DNS/TLS provisioning work (FFRNT-137 / FFRNT-99).