### PR TITLE
fix(litellm): raise the memory limit — 1Gi OOMKilled the gateway on startup

### DIFF
--- a/helm/litellm/values-contabo.yaml
+++ b/helm/litellm/values-contabo.yaml
@@ -22,11 +22,22 @@ enabled: true
 
 replicas: 1
 
-# 4 vCPU / 8 GB nodes: the gateway is I/O-bound (it proxies, it does not infer),
-# so keep it small. Raise limits only if you see throttling under real load.
+# The gateway is I/O-bound at runtime (it proxies, it does not infer) but the
+# LiteLLM image is NOT cheap to START: it imports the full provider SDK surface
+# before it serves anything.
+#
+# MEASURED, NOT GUESSED: a 1Gi limit OOMKilled the container (exit 137) ~17s
+# into startup, before it could emit a single log line — 56 restarts in 4h40m.
+# The old "keep it small, raise only under load" note was wrong: the ceiling
+# that matters here is the import-time peak, which load testing never reveals
+# because the process never reaches serving. 3Gi clears it with headroom.
+#
+# requests stays 512Mi (steady-state RSS is far below the startup peak), so this
+# reserves little on the node — limits are a ceiling, not a reservation. Nodes
+# are 8 GB and sat at 10-50% when this was set.
 resources:
   requests: { cpu: "250m", memory: "512Mi" }
-  limits:   { cpu: "1", memory: "1Gi" }
+  limits:   { cpu: "1", memory: "3Gi" }
 
 # Cluster-internal only. No Ingress, no Cloudflare tunnel route, no CF Access
 # app — the gateway holds live provider keys and must stay unreachable from

--- a/helm/litellm/values-local.yaml
+++ b/helm/litellm/values-local.yaml
@@ -20,9 +20,12 @@ enabled: false
 
 replicas: 1
 
+# 768Mi here would have hit the same import-time OOMKill that took prod down at
+# 1Gi (exit 137, ~17s in, no logs). Kept at 3Gi so a kind cluster reproduces
+# prod's behaviour rather than failing in a way prod does not.
 resources:
   requests: { cpu: "100m", memory: "256Mi" }
-  limits:   { cpu: "500m", memory: "768Mi" }
+  limits:   { cpu: "500m", memory: "3Gi" }
 
 # Off locally: kind ships no NetworkPolicy enforcer by default, so a policy here
 # is a no-op that only makes local behaviour diverge from prod.

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -33,9 +33,14 @@ replicas: 1
 # docs/consuming-repos/LITELLM_GATEWAY.md before touching them.
 port: 4000
 
+# The memory LIMIT is sized for the import-time peak, not steady state. LiteLLM
+# loads its whole provider SDK surface at startup; 1Gi OOMKilled the container
+# (exit 137) ~17s in, before it logged anything. Do not lower this below 2Gi
+# without watching a cold start — the failure looks like a crash with no logs,
+# not like memory pressure.
 resources:
   requests: { cpu: "250m", memory: "512Mi" }
-  limits:   { cpu: "1", memory: "1Gi" }
+  limits:   { cpu: "1", memory: "3Gi" }
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
The gateway never served a single request after being enabled. The pod
OOMKilled (exit 137) roughly 17s into startup, before emitting any log
line, and crashlooped 56 times over 4h40m.

Root cause: the memory limit was sized for steady state, but LiteLLM's
cost centre is STARTUP — it imports the full provider SDK surface before it
begins serving. The original comment ("the gateway is I/O-bound, raise
limits only if you see throttling under real load") was actively wrong:
load never reveals this ceiling, because the process is killed before it
can accept a connection.

Raise the limit 1Gi -> 3Gi in the base and contabo values, and 768Mi -> 3Gi
in values-local so a kind cluster reproduces prod instead of failing in a
way prod does not.

requests stays 512Mi: steady-state RSS is far below the import peak, and a
limit is a ceiling not a reservation, so this reserves nothing extra on the
node. Contabo nodes are 8 GB and sat at 10-50% memory when this was sized.

The diagnosis is measured, not inferred: exit code 137 with
reason=OOMKilled in the container's lastState, startedAt 06:02:02 ->
finishedAt 06:02:19.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session-Id: c2b5ed19-6122-49ad-a96e-918eb61a8bd0
