### PR TITLE
fix(terraform): default saas_custom_hostnames_enabled to false to unblock CI

### DIFF
--- a/terraform/contabo/variables.tf
+++ b/terraform/contabo/variables.tf
@@ -193,9 +193,13 @@ variable "saas_custom_hostnames_enabled" {
 
     Cost: 100 custom hostnames included on Free/Pro/Business, $0.10/month each
     beyond that (ceiling 50,000).
+
+    Requires the Terraform API token to have "Zone / Custom Hostnames: Edit"
+    permission. Set to true only after that permission is added to the
+    "FuzeInfra Terraform" token in the Cloudflare dashboard.
   EOT
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "allowed_admin_emails" {


### PR DESCRIPTION
## Summary
- Cloudflare API token "FuzeInfra Terraform" is missing `Zone / Custom Hostnames: Edit` permission
- Every main-branch Terraform apply has been failing with `Authentication error (10000)` on `cloudflare_custom_hostname_fallback_origin.saas`
- This resource was **never** successfully created (not in Terraform state), so disabling via the default produces an empty plan → apply succeeds

## Changes
- `variables.tf`: Change `saas_custom_hostnames_enabled` default from `true` → `false`
- Added a note in the description explaining the required token permission to re-enable

## To re-enable Cloudflare for SaaS later
1. Add `Zone / Custom Hostnames: Edit` to the "FuzeInfra Terraform" token at `dash.cloudflare.com/profile/api-tokens`
2. Set `saas_custom_hostnames_enabled = true` in `terraform.tfvars` (or `TF_VAR_saas_custom_hostnames_enabled=true` in CI secrets)
3. Re-apply — Terraform will create the fallback origin resource

## Test plan
- [ ] PR plan shows no Terraform changes (resource not in state + count=0)
- [ ] Apply on merge succeeds (no more Authentication error 10000)