### PR TITLE
fix(chart): local overlay is uninstallable — consumer namespace never exists

### DIFF
--- a/helm/fuzeinfra/templates/custom-hostname-api.yaml
+++ b/helm/fuzeinfra/templates/custom-hostname-api.yaml
@@ -41,10 +41,38 @@ metadata:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
 {{- range $index, $profile := $chapi.routeProfiles }}
 {{- if $profile.enabled }}
+{{- if $profile.createNamespace }}
+---
+# The consumer's namespace, created by US only when the profile opts in.
+#
+# Default OFF, and it must stay that way for every real cluster: in prod the
+# consumer owns its own namespace (its Argo Application creates it), and having
+# two releases claim the same Namespace object is how you get a sync loop — or
+# a `helm uninstall` that deletes somebody else's running workloads.
+#
+# It exists for the standalone case: a fresh kind/Docker-Desktop cluster where
+# nothing but this chart is installed. There the profile's Role/RoleBinding
+# below are the FIRST things to reference the namespace, and Helm fails the
+# whole install with `namespaces "<name>" not found` — the chart is
+# uninstallable on a clean machine, which is exactly what `make dev` is.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $profile.namespace }}
+  labels:
+    {{- include "fuzeinfra.labels" $root | nindent 4 }}
+    # Let the NetworkPolicy's namespaceSelector match this namespace the same
+    # way it matches a consumer-created one.
+    kubernetes.io/metadata.name: {{ $profile.namespace }}
+{{- end }}
 ---
 # Ingress-only, namespace-scoped write access — one Role per route profile, in
 # that profile's namespace. The service can never touch any other resource kind
 # or any namespace a profile does not name.
+#
+# NOTE: this is the first resource that requires the profile's namespace to
+# exist. If the consumer does not create it and `createNamespace` is false, the
+# install fails here.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/fuzeinfra/values-local.yaml
+++ b/helm/fuzeinfra/values-local.yaml
@@ -82,6 +82,11 @@ customHostnameApi:
     - name: fuzefront
       enabled: true
       namespace: fuzefront
+      # Local only. Nothing else installs FuzeFront on a kind/Docker-Desktop
+      # cluster, so this chart has to create the namespace its Role/RoleBinding
+      # land in — otherwise the install is rejected outright with
+      # `namespaces "fuzefront" not found`. Never set this in a real overlay.
+      createNamespace: true
       service: fuzefront-frontend
       port: 80
       paths: ["/", "/api", "/socket.io"]

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -840,12 +840,22 @@ customHostnameApi:
   #   service:   Service the Ingress backends to
   #   port:      Service port
   #   paths:     path prefixes to route (the consumer's full fan-out)
+  #   createNamespace:
+  #              create `namespace` ourselves. Keep FALSE on any cluster where
+  #              the consumer deploys itself — it owns that namespace, and two
+  #              releases claiming one Namespace object means an Argo sync loop
+  #              or a `helm uninstall` that takes their workloads with it.
+  #              Set true ONLY for a standalone cluster (kind / Docker Desktop)
+  #              where this chart is the only thing installed; without it the
+  #              profile's Role/RoleBinding fail with `namespaces "<x>" not
+  #              found` and the whole install is rejected.
   # Defaults are OFF; the prod overlay flips `enabled: true` once the
   # SealedSecret carrying that profile's token is in the fuzeinfra namespace.
   routeProfiles:
     - name: fuzefront
       enabled: false
       namespace: fuzefront
+      createNamespace: false
       service: fuzefront-frontend
       port: 80
       paths: ["/"]

--- a/tests/test_local_overlay_installable.py
+++ b/tests/test_local_overlay_installable.py
@@ -121,6 +121,86 @@ def test_sealed_secrets_are_prod_only():
     )
 
 
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_every_referenced_namespace_is_created_or_is_the_release_namespace():
+    """Second way the local overlay turned out to be uninstallable on a bare cluster.
+
+    The CRD guard above passed, and the chart still could not install. The
+    custom-hostname-api route profile puts a Role + RoleBinding in the CONSUMER's
+    namespace (`fuzefront`), which exists in prod because FuzeFront deploys
+    itself there — and does not exist on a fresh kind cluster. Helm applies the
+    rest of the chart, hits those two objects, and rejects the whole install:
+
+        Error: 2 errors occurred:
+            * namespaces "fuzefront" not found
+            * namespaces "fuzefront" not found
+
+    Note the shape of the failure: 25+ pods are already created when it fires, so
+    the cluster *looks* like it is coming up. Only the helm exit code says
+    otherwise.
+
+    A namespace is a precondition, not a schema, so neither `helm lint` nor
+    `kubeconform` can see this. The rule: if the local overlay puts a resource in
+    some namespace, the local overlay must also create that namespace.
+    """
+    rendered = subprocess.run(
+        ["helm", "template", "fuzeinfra", str(CHART),
+         "--namespace", "fuzeinfra", "-f", str(LOCAL_VALUES)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+    docs = [d for d in yaml.safe_load_all(rendered) if d and "apiVersion" in d]
+    created = {
+        (d.get("metadata") or {}).get("name")
+        for d in docs if d.get("kind") == "Namespace"
+    }
+    missing: dict[str, set[str]] = {}
+    for doc in docs:
+        ns = (doc.get("metadata") or {}).get("namespace")
+        # No namespace => cluster-scoped, or defaulted to the release namespace.
+        if not ns or ns == "fuzeinfra" or ns in created:
+            continue
+        missing.setdefault(ns, set()).add(
+            f"{doc.get('kind', '?')}/{(doc.get('metadata') or {}).get('name', '?')}"
+        )
+
+    assert not missing, (
+        "values-local.yaml puts resources in namespaces that nothing creates, so "
+        "`helm install` is rejected on a fresh cluster with "
+        '`namespaces \"<name>\" not found`:\n'
+        + "\n".join(f"  {ns}: {sorted(v)}" for ns, v in sorted(missing.items()))
+        + "\n\nEither render the Namespace for local (e.g. a route profile's "
+          "`createNamespace: true`, which must stay false in real overlays where "
+          "the consumer owns its namespace), or gate the resources off locally.\n"
+          "NOTE: helm lint and kubeconform CANNOT catch this — a namespace is an "
+          "install-time precondition, not a schema property."
+    )
+
+
+def test_prod_overlay_does_not_create_consumer_namespaces():
+    """The inverse guard: `createNamespace` must never be on in a real overlay.
+
+    Two releases claiming one Namespace object is an Argo ownership fight, and a
+    `helm uninstall` would take the consumer's running workloads with it. The
+    escape hatch is for standalone clusters only.
+    """
+    import re
+    for overlay in ("values.yaml", "values-contabo.yaml", "values-aws.yaml"):
+        path = CHART / overlay
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        enabled = [
+            line for line in text.splitlines()
+            if re.match(r"\s*createNamespace:\s*true\b", line)
+        ]
+        assert not enabled, (
+            f"{overlay} sets createNamespace: true ({enabled}). Only "
+            "values-local.yaml may do this — on a real cluster the consumer owns "
+            "its own namespace."
+        )
+
+
 def test_setup_kind_installs_the_crds_this_test_assumes():
     """Keep the allowlist honest: it must describe what setup-kind.sh really does.
 


### PR DESCRIPTION
## Summary

The first `kind-validate` run to get past the SealedSecret gate (#444) still failed, 94s in. With #444's classifier no longer swallowing it, the cause is now visible:

```
Error: 2 errors occurred:
	* namespaces "fuzefront" not found
	* namespaces "fuzefront" not found
```

Those two are the **Role and RoleBinding** that each `customHostnameApi` route profile puts in the **consumer's** namespace. That namespace exists in prod because FuzeFront deploys itself there. On a fresh kind or Docker Desktop cluster nothing creates it, so `helm install` is rejected outright — `make dev` cannot work on a clean machine.

**The failure mode is misleading, which is worth recording.** Helm creates the other 25+ pods first and only then hits the two rejected objects. So `kubectl get pods` shows a stack that is visibly coming up. In the run I diagnosed every pod was 11 seconds old, all `ContainerCreating`/`Init:0/1`/`Pending`, on nodes with **no memory or disk pressure, 101 GB free, memory requests at 3–7%**. It reads like a capacity problem until you find the helm exit code. It is not capacity — the hosted runner is fine.

### Fix

A per-route-profile `createNamespace`, **default `false`**, set `true` only in `values-local.yaml`.

Default-false is load-bearing. On any cluster where the consumer deploys itself, it owns that Namespace; two releases claiming one Namespace object is an Argo ownership fight, or a `helm uninstall` that takes their running workloads with it. `values.yaml`, `values-contabo.yaml` and `values-aws.yaml` are unchanged in effect — **prod renders exactly what it did**.

### Guards

Both added to `tests/test_local_overlay_installable.py`, which already exists for "the local overlay must be installable on a bare cluster":

- every namespace referenced by the local render must be the release namespace or be created by that same render;
- `createNamespace: true` must never appear in a non-local overlay.

Neither `helm lint` nor `kubeconform` can catch this class — a namespace is an **install-time precondition, not a schema property**. That is why it reached main behind a green `helm-validate`, exactly like the SealedSecret did. The file is already in the Infrastructure Tests gate, so the new tests run on every PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore / CI / refactor

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] Conventional commit messages
- [x] Commits are **signed** (verified)
- [x] Tests added/updated where relevant
- [x] **Harden Gate** checks pass (`lint`, `test`, `build`, `sast`, `secret-scan`, `dependency-scan`)
- [x] Conversations resolved and ready for code-owner review

### Verified here

- Template conditionals balance (42 `if`/`range`/`end` tokens, final depth 0, no underflow)
- The new guard's logic mutation-tested against synthetic renders: non-empty pre-fix, empty post-fix
- The inverse guard run against the real files: only `values-local.yaml` sets the flag

### NOT verified here

**The actual `helm template` output and the cluster install.** This sandbox has neither `helm` nor outbound network, so nothing could be rendered or installed locally. `kind-validate` on this PR is the proof — and this PR's paths trigger it, so it tests itself before merging.

This is the next blocker, not necessarily the last one; the stack has never completed a full bring-up on a hosted runner, so more may surface behind it.

## Related issues

Follow-up to #442 (hosted-runner `kind-validate`) and #444 (SealedSecret gate + failure classification).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkVURsLwKFf5KKS1Z76C4f)_