### PR TITLE
claude/litellm startup probe

### DIFF
--- a/helm/litellm/templates/deployment.yaml
+++ b/helm/litellm/templates/deployment.yaml
@@ -66,14 +66,32 @@ spec:
           # /health — that one requires the master key AND round-trips every
           # configured model to the provider, so it bills real tokens on every
           # kubelet probe.
+          #
+          # The startupProbe is load-bearing, not boilerplate. LiteLLM imports
+          # its whole provider SDK surface before binding the port, and a cold
+          # start measured MINUTES on a 4 vCPU node. Without this, liveness
+          # (initialDelay 20s + 3x20s) fired at ~80s and the kubelet killed the
+          # container mid-boot — "failed liveness probe, will be restarted",
+          # exit 137 reason=Error — an infinite restart loop that looks like a
+          # crash but is self-inflicted. Liveness/readiness stay disabled until
+          # this succeeds, so 60 x 10s allows a 10-minute cold start (which also
+          # covers a slow first image pull on a fresh node) while still catching
+          # a genuinely wedged process.
+          startupProbe:
+            httpGet: { path: /health/liveliness, port: http }
+            periodSeconds: 10
+            failureThreshold: 60
+          # No initialDelaySeconds on either of these: the startupProbe already
+          # gates them, and adding a delay on top would only slow recovery from
+          # a real hang after the app is up.
           livenessProbe:
             httpGet: { path: /health/liveliness, port: http }
-            initialDelaySeconds: 20
             periodSeconds: 20
+            failureThreshold: 3
           readinessProbe:
             httpGet: { path: /health/readiness, port: http }
-            initialDelaySeconds: 10
             periodSeconds: 15
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/helm/litellm/values-contabo.yaml
+++ b/helm/litellm/values-contabo.yaml
@@ -22,11 +22,22 @@ enabled: true
 
 replicas: 1
 
-# 4 vCPU / 8 GB nodes: the gateway is I/O-bound (it proxies, it does not infer),
-# so keep it small. Raise limits only if you see throttling under real load.
+# The gateway is I/O-bound at runtime (it proxies, it does not infer) but the
+# LiteLLM image is NOT cheap to START: it imports the full provider SDK surface
+# before it serves anything.
+#
+# MEASURED, NOT GUESSED: a 1Gi limit OOMKilled the container (exit 137) ~17s
+# into startup, before it could emit a single log line — 56 restarts in 4h40m.
+# The old "keep it small, raise only under load" note was wrong: the ceiling
+# that matters here is the import-time peak, which load testing never reveals
+# because the process never reaches serving. 3Gi clears it with headroom.
+#
+# requests stays 512Mi (steady-state RSS is far below the startup peak), so this
+# reserves little on the node — limits are a ceiling, not a reservation. Nodes
+# are 8 GB and sat at 10-50% when this was set.
 resources:
   requests: { cpu: "250m", memory: "512Mi" }
-  limits:   { cpu: "1", memory: "1Gi" }
+  limits:   { cpu: "1", memory: "3Gi" }
 
 # Cluster-internal only. No Ingress, no Cloudflare tunnel route, no CF Access
 # app — the gateway holds live provider keys and must stay unreachable from

--- a/helm/litellm/values-local.yaml
+++ b/helm/litellm/values-local.yaml
@@ -20,9 +20,12 @@ enabled: false
 
 replicas: 1
 
+# 768Mi here would have hit the same import-time OOMKill that took prod down at
+# 1Gi (exit 137, ~17s in, no logs). Kept at 3Gi so a kind cluster reproduces
+# prod's behaviour rather than failing in a way prod does not.
 resources:
   requests: { cpu: "100m", memory: "256Mi" }
-  limits:   { cpu: "500m", memory: "768Mi" }
+  limits:   { cpu: "500m", memory: "3Gi" }
 
 # Off locally: kind ships no NetworkPolicy enforcer by default, so a policy here
 # is a no-op that only makes local behaviour diverge from prod.

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -33,9 +33,14 @@ replicas: 1
 # docs/consuming-repos/LITELLM_GATEWAY.md before touching them.
 port: 4000
 
+# The memory LIMIT is sized for the import-time peak, not steady state. LiteLLM
+# loads its whole provider SDK surface at startup; 1Gi OOMKilled the container
+# (exit 137) ~17s in, before it logged anything. Do not lower this below 2Gi
+# without watching a cold start — the failure looks like a crash with no logs,
+# not like memory pressure.
 resources:
   requests: { cpu: "250m", memory: "512Mi" }
-  limits:   { cpu: "1", memory: "1Gi" }
+  limits:   { cpu: "1", memory: "3Gi" }
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
- **fix(litellm): raise the memory limit — 1Gi OOMKilled the gateway on startup**
- **fix(litellm): add a startupProbe — liveness was killing the gateway mid-boot**
