### PR TITLE
feat(backups): expire S3 db/ backups after 30 days via bucket lifecycle

### DIFF
--- a/helm/fuzeinfra/templates/backup-s3-lifecycle.yaml
+++ b/helm/fuzeinfra/templates/backup-s3-lifecycle.yaml
@@ -1,0 +1,76 @@
+{{- /*
+=================== S3 backup retention (bucket lifecycle policy) ===================
+With sink=s3 the CronJobs upload and exit — the in-pod `keep=N` prune only ever
+applied to the PVC sink, so nothing ages out S3 objects. Retention therefore has
+to be a BUCKET LIFECYCLE POLICY, exactly as backup-cronjobs.yaml says.
+
+This applies it the GitOps way: a declarative Argo PostSync hook Job that asserts
+the policy on every sync. put-bucket-lifecycle-configuration is a full replace, so
+it is idempotent — re-running converges rather than accumulating rules, and the
+policy is re-asserted if anything mutates it out of band.
+
+Deletion is done by the storage provider, not by us: no pod has to run on time,
+and a missed CronJob can never cause unbounded growth.
+*/ -}}
+{{- $b := .Values.backups }}
+{{- if and $b.enabled (eq $b.sink "s3") (gt (int $b.s3.lifecycleExpireDays) 0) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fuzeinfra-backup-s3-lifecycle
+  labels:
+    {{- include "fuzeinfra.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: backup-lifecycle
+  annotations:
+    # Runs after the chart syncs, so the bucket/secret it needs already exist.
+    argocd.argoproj.io/hook: PostSync
+    # Replace the previous hook Job each sync — Job spec is immutable, so without
+    # this a second sync fails with "field is immutable".
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- include "fuzeinfra.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: backup-lifecycle
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: lifecycle
+          image: {{ $b.awsCliImage | quote }}
+          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" $ }}
+          env:
+            {{- include "fuzeinfra.backup.s3env" (dict "b" $b "root" $) | nindent 12 }}
+            - name: EXPIRE_DAYS
+              value: {{ $b.s3.lifecycleExpireDays | quote }}
+            - name: PREFIX
+              value: {{ $b.s3.prefix | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # IMDS is not reachable in-cluster; without this the CLI stalls on it.
+              export AWS_EC2_METADATA_DISABLED=true
+              cat > /tmp/lifecycle.json <<JSON
+              {
+                "Rules": [
+                  {
+                    "ID": "expire-db-backups",
+                    "Status": "Enabled",
+                    "Filter": { "Prefix": "${PREFIX}/" },
+                    "Expiration": { "Days": ${EXPIRE_DAYS} },
+                    "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 7 }
+                  }
+                ]
+              }
+              JSON
+              aws --endpoint-url "$S3_ENDPOINT" s3api put-bucket-lifecycle-configuration \
+                --bucket "$S3_BUCKET" --lifecycle-configuration file:///tmp/lifecycle.json
+              echo "Lifecycle applied: s3://${S3_BUCKET}/${PREFIX}/ expires after ${EXPIRE_DAYS} days."
+              # Read it back so the Job fails loudly if the provider silently ignored it.
+              aws --endpoint-url "$S3_ENDPOINT" s3api get-bucket-lifecycle-configuration \
+                --bucket "$S3_BUCKET"
+{{- end }}

--- a/helm/fuzeinfra/values-contabo.yaml
+++ b/helm/fuzeinfra/values-contabo.yaml
@@ -170,6 +170,7 @@ backups:
     bucket: "fuzeinfra-backups"
     prefix: "db"
     existingSecret: "fuzeinfra-backups-s3"
+    lifecycleExpireDays: 30   # provider expires db/ objects after 30 days
 airflow:
   replicas: 0 # TEMP headroom (#93): webserver/scheduler/flower -> 0 pods
   workerReplicas: 0 # TEMP headroom (#93): celery worker -> 0 pods

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -529,6 +529,11 @@ backups:
     existingSecret: ""
     accessKeyIdKey: BACKUP_S3_ACCESS_KEY_ID
     secretAccessKeyKey: BACKUP_S3_SECRET_ACCESS_KEY
+    # Age-out for the dumps, applied as a BUCKET LIFECYCLE POLICY (the provider
+    # deletes them, not us). Required with sink=s3: the in-pod `pvc.keep` prune
+    # only ever applied to the PVC sink, so without this S3 grows forever.
+    # 0 disables the policy entirely.
+    lifecycleExpireDays: 30
   # Per-database toggles. Each dumps a *running* instance (no downtime) and is
   # independently gated so an overlay can enable only the DBs it runs.
   postgres:


### PR DESCRIPTION
With `sink: s3` **nothing ages the dumps out**. The in-pod `keep=N` prune only ever applied to the PVC sink, so the bucket grows without bound. `backup-cronjobs.yaml` already stated retention "is an S3 bucket lifecycle policy, not this template" — but no policy existed.

Adds it **as GitOps**: a declarative Argo `PostSync` hook Job that asserts the policy on every sync.

```
Prefix db/  ·  Expiration 30 days  ·  AbortIncompleteMultipartUpload after 7
```

Deletion is performed by the **storage provider**, so no pod has to run on time and a missed CronJob can never cause unbounded growth. The multipart rule stops a failed upload leaving paid-for orphaned parts.

## Why a hook Job, and why that delete-policy

`put-bucket-lifecycle-configuration` is a **full replace**, so the hook is idempotent — re-running converges rather than accumulating rules, and the policy is re-asserted if anything mutates it out of band.

`hook-delete-policy: BeforeHookCreation` is **required**: a Job spec is immutable, so without it the second sync fails with `field is immutable`.

Configurable via `backups.s3.lifecycleExpireDays` (default **30**, `0` disables). Gated on `enabled` + `sink=s3` + `days>0`, so the PVC sink is untouched.

## Verified against the live bucket before shipping

Contabo S3 supporting lifecycle configuration at all was the real risk, so I ran the rendered Job as a one-off and **read the policy back**:

```json
Lifecycle applied: s3://fuzeinfra-backups/db/ expires after 30 days.
{"Rules":[{"Expiration":{"Days":30},"ID":"expire-db-backups",
  "Filter":{"Prefix":"db/"},"Status":"Enabled",
  "AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}]}
```

**The policy is already active on the bucket** — this PR puts it under GitOps so it stays that way.

Also verified: renders with the correct secret refs (`fuzeinfra-backups-s3` → `BACKUP_S3_*`), and gates **off** for `sink=pvc` and for `lifecycleExpireDays=0`.