### PR TITLE
fix(chart): local overlay cannot cold-start chromadb or airflow

### DIFF
--- a/helm/fuzeinfra/templates/airflow.yaml
+++ b/helm/fuzeinfra/templates/airflow.yaml
@@ -59,6 +59,106 @@ referenced via $(VAR) interpolation to build the SQLAlchemy/Celery URLs.
       mountPath: /dags
 {{- end -}}
 
+{{- /*
+  `hook` (default, unchanged) or `inline`. See airflow.init.mode in values.yaml
+  for why the hook variant cannot cold-start.
+*/ -}}
+{{- define "fuzeinfra.airflowInitMode" -}}
+{{- dig "init" "mode" "hook" .Values.airflow -}}
+{{- end -}}
+
+{{- /*
+  Gate for `inline` mode: hold every Airflow pod at Init until the metadata
+  database exists AND its migrations have been applied.
+
+  Without it the pods start concurrently with the init Job, die immediately on
+  `database "airflow" does not exist`, and CrashLoopBackOff pushes the retry
+  interval out to ~5 minutes — so a pod can stay down long after the database is
+  ready, which is its own way of blowing helm's --wait budget. Blocking in an
+  init container converts that race into a deterministic wait.
+
+  `airflow db check-migrations` is the same readiness check the upstream Airflow
+  chart uses. `-t 5` bounds a single attempt so the loop keeps polling rather
+  than blocking on one long call; a missing database exits non-zero and retries.
+*/ -}}
+{{- define "fuzeinfra.airflowWaitForDb" -}}
+- name: wait-for-airflow-db
+  image: {{ .Values.airflow.image }}
+  imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+  env:
+    {{- include "fuzeinfra.airflowEnv" . | nindent 4 }}
+  command:
+    - bash
+    - -c
+    - |
+      until airflow db check-migrations -t 5 >/dev/null 2>&1; do
+        echo "waiting for the airflow metadata database to be created and migrated..."
+        sleep 5
+      done
+      echo "airflow metadata database is ready."
+  resources:
+    requests: { cpu: 50m, memory: 128Mi }
+    limits:   { cpu: 250m, memory: 512Mi }
+{{- end -}}
+
+{{- /*
+  Pod template for the init Job, factored out so its hash can name the Job in
+  `inline` mode. The body is identical in both modes — only the Job's name,
+  annotations and TTL differ.
+*/ -}}
+{{- define "fuzeinfra.airflowInitPodTemplate" -}}
+metadata:
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+    {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-init" "root" .) | nindent 4 }}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: airflow-init
+      image: {{ .Values.airflow.image }}
+      imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
+      env:
+        {{- include "fuzeinfra.airflowEnv" . | nindent 8 }}
+        - name: AIRFLOW_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fuzeinfra.secretName" . }}
+              key: AIRFLOW_ADMIN_USER
+        - name: AIRFLOW_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fuzeinfra.secretName" . }}
+              key: AIRFLOW_ADMIN_PASSWORD
+      command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Waiting for PostgreSQL..."
+          until PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do
+            sleep 2
+          done
+          echo "Ensuring 'airflow' database exists..."
+          PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -tc \
+            "SELECT 1 FROM pg_database WHERE datname = 'airflow'" | grep -q 1 || \
+            PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE airflow"
+          # Pre-create a database matching the role name ("$POSTGRES_USER").
+          # Clients/health-probes that connect without naming a database
+          # (e.g. `pg_isready -U $POSTGRES_USER`) fall back to a DB named
+          # after the role, otherwise spamming
+          # `FATAL: database "..." does not exist` on every probe.
+          echo "Ensuring role-default '$POSTGRES_USER' database exists..."
+          PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -tc \
+            "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_USER'" | grep -q 1 || \
+            PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE \"$POSTGRES_USER\""
+          echo "Running airflow db migrate..."
+          airflow db migrate
+          echo "Creating admin user (idempotent)..."
+          airflow users create \
+            --username "$AIRFLOW_ADMIN_USER" --firstname Admin --lastname User \
+            --role Admin --email admin@example.com --password "$AIRFLOW_ADMIN_PASSWORD" || true
+{{- end -}}
+
 {{- define "fuzeinfra.dagVolumes" -}}
 - name: dags
   emptyDir: {}
@@ -95,71 +195,40 @@ data:
         )
 ---
 {{- /* ===================== Airflow DB migrate / bootstrap Job ===================== */}}
+{{- $initMode := include "fuzeinfra.airflowInitMode" . }}
+{{- $initPodTemplate := include "fuzeinfra.airflowInitPodTemplate" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
+{{- if eq $initMode "inline" }}
+  {{- /* A plain Job's pod template is immutable, so a fixed name would make the
+         next `helm upgrade` fail with "field is immutable" as soon as anything
+         here changed. Suffixing with the template's own hash makes each distinct
+         spec a distinct Job, and an unchanged spec re-uses the completed one
+         instead of re-running it. */}}
+  name: fuzeinfra-airflow-init-{{ $initPodTemplate | sha256sum | trunc 8 }}
+{{- else }}
   name: fuzeinfra-airflow-init
+{{- end }}
   labels:
     {{- include "fuzeinfra.labels" . | nindent 4 }}
+{{- if eq $initMode "hook" }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
     "argocd.argoproj.io/hook": PostSync
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation
+{{- end }}
 spec:
   backoffLimit: 6
+{{- if eq $initMode "inline" }}
+  # Nothing reaps a non-hook Job. Well clear of helm's --wait budget, so the
+  # Job is still around to be waited on.
+  ttlSecondsAfterFinished: 3600
+{{- end }}
   template:
-    metadata:
-      labels:
-        {{- include "fuzeinfra.labels" . | nindent 8 }}
-        {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-init" "root" $) | nindent 8 }}
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: airflow-init
-          image: {{ .Values.airflow.image }}
-          imagePullPolicy: {{ include "fuzeinfra.pullPolicy" . }}
-          env:
-            {{- include "fuzeinfra.airflowEnv" . | nindent 12 }}
-            - name: AIRFLOW_ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "fuzeinfra.secretName" . }}
-                  key: AIRFLOW_ADMIN_USER
-            - name: AIRFLOW_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "fuzeinfra.secretName" . }}
-                  key: AIRFLOW_ADMIN_PASSWORD
-          command:
-            - bash
-            - -c
-            - |
-              set -e
-              echo "Waiting for PostgreSQL..."
-              until PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do
-                sleep 2
-              done
-              echo "Ensuring 'airflow' database exists..."
-              PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -tc \
-                "SELECT 1 FROM pg_database WHERE datname = 'airflow'" | grep -q 1 || \
-                PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE airflow"
-              # Pre-create a database matching the role name ("$POSTGRES_USER").
-              # Clients/health-probes that connect without naming a database
-              # (e.g. `pg_isready -U $POSTGRES_USER`) fall back to a DB named
-              # after the role, otherwise spamming
-              # `FATAL: database "..." does not exist` on every probe.
-              echo "Ensuring role-default '$POSTGRES_USER' database exists..."
-              PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -tc \
-                "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_USER'" | grep -q 1 || \
-                PGPASSWORD="$POSTGRES_PASSWORD" psql -h fuzeinfra-postgres -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE \"$POSTGRES_USER\""
-              echo "Running airflow db migrate..."
-              airflow db migrate
-              echo "Creating admin user (idempotent)..."
-              airflow users create \
-                --username "$AIRFLOW_ADMIN_USER" --firstname Admin --lastname User \
-                --role Admin --email admin@example.com --password "$AIRFLOW_ADMIN_PASSWORD" || true
+    {{- $initPodTemplate | nindent 4 }}
 ---
 {{- /* ===================== Airflow Webserver ===================== */}}
 apiVersion: v1
@@ -196,6 +265,9 @@ spec:
     spec:
       initContainers:
         {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
+        {{- if eq (include "fuzeinfra.airflowInitMode" .) "inline" }}
+        {{- include "fuzeinfra.airflowWaitForDb" . | nindent 8 }}
+        {{- end }}
       containers:
         - name: webserver
           image: {{ .Values.airflow.image }}
@@ -241,6 +313,9 @@ spec:
     spec:
       initContainers:
         {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
+        {{- if eq (include "fuzeinfra.airflowInitMode" .) "inline" }}
+        {{- include "fuzeinfra.airflowWaitForDb" . | nindent 8 }}
+        {{- end }}
       containers:
         - name: scheduler
           image: {{ .Values.airflow.image }}
@@ -274,6 +349,9 @@ spec:
     spec:
       initContainers:
         {{- include "fuzeinfra.dagInitContainer" . | nindent 8 }}
+        {{- if eq (include "fuzeinfra.airflowInitMode" .) "inline" }}
+        {{- include "fuzeinfra.airflowWaitForDb" . | nindent 8 }}
+        {{- end }}
       containers:
         - name: worker
           image: {{ .Values.airflow.image }}
@@ -324,6 +402,13 @@ spec:
         {{- include "fuzeinfra.labels" . | nindent 8 }}
         {{- include "fuzeinfra.selectorLabels" (dict "component" "airflow-flower" "root" $) | nindent 8 }}
     spec:
+      {{- /* Flower has no DAG sync, so this is its only init container. It
+             reads the Celery result backend, which is the same Postgres
+             database, so it crashloops on a cold start exactly like the rest. */}}
+      {{- if eq (include "fuzeinfra.airflowInitMode" .) "inline" }}
+      initContainers:
+        {{- include "fuzeinfra.airflowWaitForDb" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: flower
           image: {{ .Values.airflow.image }}

--- a/helm/fuzeinfra/templates/databases.yaml
+++ b/helm/fuzeinfra/templates/databases.yaml
@@ -468,6 +468,32 @@ spec:
 
 {{- /* ============================ ChromaDB ============================ */ -}}
 {{- if .Values.chromadb.enabled }}
+{{- $chromaAdmin := .Values.chromadb.auth.adminSecret }}
+{{- if (dig "devSecret" "enabled" false $chromaAdmin) }}
+{{- if not (dig "devSecret" "token" "" $chromaAdmin) }}
+{{- fail "chromadb.auth.adminSecret.devSecret.enabled=true requires a non-empty devSecret.token" }}
+{{- end }}
+---
+# LOCAL DEVELOPMENT ONLY. Renders the ChromaDB admin token so kind clusters work
+# with no SealedSecret ceremony — the same escape hatch customHostnameApi.devSecret
+# already uses in templates/custom-hostname-api.yaml.
+#
+# Without this the `render-auth-config` init container below fails closed with
+#   Error: secret "chromadb-admin-credentials" not found
+# forever, because the only thing that produces that Secret is
+# deploy/sealed-secrets/chromadb-admin-credentials.yaml — which needs a Sealed
+# Secrets controller and the prod private key. Prod/AWS keep taking it from
+# there; this must stay off in every real overlay.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ required "chromadb.auth.adminSecret.name is required" $chromaAdmin.name }}
+  labels:
+    {{- include "fuzeinfra.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ required "chromadb.auth.adminSecret.key is required" $chromaAdmin.key }}: {{ $chromaAdmin.devSecret.token | quote }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/fuzeinfra/values-local.yaml
+++ b/helm/fuzeinfra/values-local.yaml
@@ -23,6 +23,26 @@ elasticsearch:
 
 airflow:
   workerReplicas: 1
+  # A fresh cluster has no `airflow` database, and the default `hook` mode
+  # cannot create one: Helm runs post-install hooks only after `--wait` reports
+  # the release ready, and the Airflow pods can never be ready until the hook
+  # has run. `--wait` burns its full 10m, the hook never fires, and all four
+  # pods sit in CrashLoopBackOff on
+  #   FATAL:  database "airflow" does not exist
+  # Local is the only place that genuinely cold-starts, so it is the only place
+  # that needs `inline`. See airflow.init.mode in values.yaml.
+  init:
+    mode: inline
+
+# The admin token Secret is a SealedSecret in prod and does not exist on kind.
+# Without this the chromadb pod is stuck in Init:CreateContainerConfigError
+# forever. Throwaway value — never set this in a real overlay.
+chromadb:
+  auth:
+    adminSecret:
+      devSecret:
+        enabled: true
+        token: local-dev-chroma-admin-token
 
 # Optional local DNS server for *.dev.local. Exposed in-cluster; query it via the
 # dnsmasq Service. CoreDNS still handles in-cluster service names.

--- a/helm/fuzeinfra/values.yaml
+++ b/helm/fuzeinfra/values.yaml
@@ -308,6 +308,17 @@ chromadb:
     adminSecret:
       name: chromadb-admin-credentials
       key: token
+      # LOCAL DEVELOPMENT ONLY — must stay disabled in every real overlay.
+      # The Secret named above is produced solely by
+      # deploy/sealed-secrets/chromadb-admin-credentials.yaml, which needs a
+      # Sealed Secrets controller and the prod private key. On a bare kind or
+      # Docker Desktop cluster nothing creates it, so the StatefulSet's
+      # render-auth-config init container sits in CreateContainerConfigError
+      # (`secret "chromadb-admin-credentials" not found`) indefinitely.
+      # values-local.yaml turns this on to render a throwaway token instead.
+      devSecret:
+        enabled: false
+        token: ""
   networkPolicy:
     enabled: true
 
@@ -596,6 +607,26 @@ airflow:
   # Mount DAGs from a ConfigMap built from airflow-shared/dags? For real use,
   # prefer git-sync or a baked image. Default: empty dir + example DAG ConfigMap.
   loadExamples: false
+  # How `fuzeinfra-airflow-init` (create the `airflow` database -> db migrate ->
+  # create the admin user) is ordered against the Airflow Deployments.
+  #
+  #   hook   — a post-install/post-upgrade Helm hook, PostSync under Argo.
+  #            Correct on a cluster whose metadata database ALREADY exists,
+  #            which is every cluster this has ever run on. Default; prod
+  #            renders exactly what it did before this option existed.
+  #
+  #   inline — a plain Job in the main resource wave, plus a
+  #            wait-for-airflow-db init container on every Airflow pod.
+  #
+  # `inline` exists because `hook` cannot cold-start. Helm runs post-install
+  # hooks only AFTER `--wait` reports the release ready, and the Airflow pods
+  # can never become ready while the database the hook creates is missing — so
+  # the hook never runs, `--wait` burns its full timeout, and the pods sit in
+  # CrashLoopBackOff on `FATAL: database "airflow" does not exist`. Argo has the
+  # same ordering (PostSync runs after the sync goes healthy). Anything that
+  # must bootstrap from nothing needs `inline`.
+  init:
+    mode: hook
 
 # -----------------------------------------------------------------------------
 # DNS & external access

--- a/tests/test_local_overlay_installable.py
+++ b/tests/test_local_overlay_installable.py
@@ -212,3 +212,229 @@ def test_setup_kind_installs_the_crds_this_test_assumes():
         "CRD_GROUPS_INSTALLED_LOCALLY allows cert-manager.io, but setup-kind.sh no "
         "longer installs cert-manager — the allowlist is now lying. Update both."
     )
+
+
+# ---------------------------------------------------------------------------
+# Third and fourth ways the local overlay turned out to be uninstallable.
+#
+# The namespace guard above passed, the CRD guard passed, `helm install` itself
+# finally succeeded — and the stack still did not come up. 25 pods reached
+# Running; two workloads never did:
+#
+#   fuzeinfra-chromadb-0   Init:CreateContainerConfigError
+#     Error: secret "chromadb-admin-credentials" not found
+#
+#   fuzeinfra-airflow-{webserver,scheduler,worker,flower}   CrashLoopBackOff
+#     FATAL:  database "airflow" does not exist
+#
+# Same family as the namespace bug in every case: the local overlay assumed a
+# precondition that only production supplies. Neither is visible to `helm lint`
+# or `kubeconform` — one is a runtime object, the other is an ordering property.
+# ---------------------------------------------------------------------------
+
+
+def _render_local() -> list[dict]:
+    rendered = subprocess.run(
+        ["helm", "template", "fuzeinfra", str(CHART),
+         "--namespace", "fuzeinfra", "-f", str(LOCAL_VALUES)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [d for d in yaml.safe_load_all(rendered) if d and "apiVersion" in d]
+
+
+#: Kinds that carry a pod template we need to inspect, and where it lives.
+_POD_TEMPLATE_PATHS = {
+    "Deployment": ("spec", "template"),
+    "StatefulSet": ("spec", "template"),
+    "DaemonSet": ("spec", "template"),
+    "ReplicaSet": ("spec", "template"),
+    "Job": ("spec", "template"),
+}
+
+
+def _pod_specs(docs: list[dict]):
+    """Yield (owner, podSpec) for everything in the render that runs a pod."""
+    for doc in docs:
+        kind = doc.get("kind")
+        name = (doc.get("metadata") or {}).get("name", "?")
+        if kind == "Pod":
+            yield f"Pod/{name}", doc.get("spec") or {}
+        elif kind == "CronJob":
+            spec = (((doc.get("spec") or {}).get("jobTemplate") or {})
+                    .get("spec") or {}).get("template") or {}
+            yield f"CronJob/{name}", spec.get("spec") or {}
+        elif kind in _POD_TEMPLATE_PATHS:
+            a, b = _POD_TEMPLATE_PATHS[kind]
+            template = (doc.get(a) or {}).get(b) or {}
+            yield f"{kind}/{name}", template.get("spec") or {}
+
+
+def _required_secret_refs(pod_spec: dict) -> set[str]:
+    """Secret names this pod cannot start without (`optional: true` excluded)."""
+    names: set[str] = set()
+    containers = (pod_spec.get("containers") or []) + \
+                 (pod_spec.get("initContainers") or [])
+    for container in containers:
+        for env in container.get("env") or []:
+            ref = ((env.get("valueFrom") or {}).get("secretKeyRef")) or {}
+            if ref.get("name") and not ref.get("optional"):
+                names.add(ref["name"])
+        for envfrom in container.get("envFrom") or []:
+            ref = envfrom.get("secretRef") or {}
+            if ref.get("name") and not ref.get("optional"):
+                names.add(ref["name"])
+    for volume in pod_spec.get("volumes") or []:
+        secret = volume.get("secret") or {}
+        if secret.get("secretName") and not secret.get("optional"):
+            names.add(secret["secretName"])
+    return names
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_every_secret_a_local_pod_needs_is_created_by_the_same_render():
+    """A referenced-but-absent Secret is a permanent, silent wedge.
+
+    `helm install` SUCCEEDS — the manifest is valid and every object is
+    accepted. The pod then sits in `CreateContainerConfigError` forever, because
+    a missing Secret is not a retryable pull failure that eventually resolves;
+    nothing is ever going to create it. Locally that Secret only ever came from
+    `deploy/sealed-secrets/`, which needs the Sealed Secrets controller and the
+    production private key.
+
+    Same rule as the namespace guard: if the local overlay mounts it, the local
+    overlay must render it.
+    """
+    docs = _render_local()
+    created = {
+        (d.get("metadata") or {}).get("name")
+        for d in docs if d.get("kind") == "Secret"
+    }
+
+    missing: dict[str, set[str]] = {}
+    for owner, pod_spec in _pod_specs(docs):
+        for secret in _required_secret_refs(pod_spec) - created:
+            missing.setdefault(secret, set()).add(owner)
+
+    assert not missing, (
+        "values-local.yaml mounts Secrets that nothing in the local render "
+        "creates. `helm install` will succeed and the pods will then wedge in "
+        "CreateContainerConfigError indefinitely:\n"
+        + "\n".join(f"  {s}: needed by {sorted(v)}" for s, v in sorted(missing.items()))
+        + "\n\nRender a throwaway value for local (the `devSecret.enabled` "
+          "pattern used by customHostnameApi and chromadb, which must stay false "
+          "in every real overlay), or gate the workload off locally.\n"
+          "NOTE: helm lint and kubeconform CANNOT catch this — the manifest is "
+          "perfectly valid; the Secret is a runtime object."
+    )
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_airflow_init_is_not_a_hook_in_the_local_overlay():
+    """The cold-start deadlock, which is an ordering bug rather than a missing object.
+
+    `fuzeinfra-airflow-init` creates the `airflow` database, migrates it and
+    makes the admin user. As a `post-install` hook that can never run on a fresh
+    cluster: Helm runs post-install hooks only AFTER `--wait` reports the release
+    ready, and the four Airflow pods cannot become ready until the database the
+    hook creates exists. So `--wait` burns its full timeout, the hook never
+    fires, and the pods crashloop on `FATAL: database "airflow" does not exist`.
+    Argo has the identical ordering — PostSync runs after the sync goes healthy.
+
+    It only ever worked because every cluster it had run on already had the
+    database. `airflow.init.mode: inline` moves the Job into the main wave.
+    """
+    docs = _render_local()
+    jobs = [
+        d for d in docs
+        if d.get("kind") == "Job"
+        and str((d.get("metadata") or {}).get("name", "")).startswith("fuzeinfra-airflow-init")
+    ]
+    assert jobs, (
+        "the local render has no fuzeinfra-airflow-init Job at all — Airflow "
+        "cannot have a metadata database."
+    )
+    hooked = [
+        (j.get("metadata") or {}).get("name")
+        for j in jobs
+        if "helm.sh/hook" in ((j.get("metadata") or {}).get("annotations") or {})
+    ]
+    assert not hooked, (
+        f"fuzeinfra-airflow-init is still a Helm hook in the local overlay ({hooked}). "
+        "A post-install hook cannot cold-start the database it is responsible for "
+        "creating — see this test's docstring. Set airflow.init.mode: inline in "
+        "values-local.yaml."
+    )
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_every_local_airflow_pod_waits_for_the_metadata_database():
+    """The init Job alone is not enough — the pods must not race it.
+
+    Without a gate the Airflow pods start alongside the Job, die on the missing
+    database, and CrashLoopBackOff backs the retry off to ~5 minutes. A pod can
+    then still be down long after the database is ready, which blows the same
+    `--wait` budget by a different route. Blocking in an init container makes the
+    wait deterministic.
+    """
+    docs = _render_local()
+    offenders = []
+    for owner, pod_spec in _pod_specs(docs):
+        if not owner.startswith("Deployment/fuzeinfra-airflow-"):
+            continue
+        init_names = {c.get("name") for c in pod_spec.get("initContainers") or []}
+        if "wait-for-airflow-db" not in init_names:
+            offenders.append(owner)
+
+    assert not offenders, (
+        f"these Airflow workloads have no wait-for-airflow-db init container: "
+        f"{sorted(offenders)}. They will crashloop through the whole cold start."
+    )
+
+
+def test_prod_overlays_do_not_enable_local_only_bootstrap_escapes():
+    """Inverse guards for both escape hatches added here.
+
+    `chromadb.auth.adminSecret.devSecret` writes a plaintext admin token into an
+    ordinary Secret under the SAME name the SealedSecret uses — in prod that
+    would overwrite the real credential with a public one. `airflow.init.mode:
+    inline` strips the hook annotations, changing how Argo orders the Job; prod's
+    metadata database already exists and does not need it.
+
+    Parsed as YAML rather than regexed, so nesting and comments cannot fool it.
+    """
+    def walk(node, path=()):
+        """Yield (dotted-path, dict) for every mapping in the tree."""
+        if isinstance(node, dict):
+            yield ".".join(path), node
+            for key, value in node.items():
+                yield from walk(value, path + (str(key),))
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                yield from walk(value, path + (f"[{index}]",))
+
+    for overlay in ("values.yaml", "values-contabo.yaml", "values-aws.yaml"):
+        path = CHART / overlay
+        if not path.exists():
+            continue
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+        enabled_dev_secrets = [
+            where for where, node in walk(doc)
+            if where.endswith("devSecret") and node.get("enabled") is True
+        ]
+        assert not enabled_dev_secrets, (
+            f"{overlay} enables a devSecret at {enabled_dev_secrets}. Those render "
+            "a plaintext token into a Secret whose name the real SealedSecret also "
+            "uses — enabling it in a real overlay replaces the production "
+            "credential with a public one. kind only."
+        )
+
+        inline = [
+            where for where, node in walk(doc)
+            if where.endswith("init") and node.get("mode") == "inline"
+        ]
+        assert not inline, (
+            f"{overlay} sets init.mode: inline at {inline}. Only values-local.yaml "
+            "may — prod's metadata database already exists, and the hook ordering "
+            "is what Argo expects."
+        )


### PR DESCRIPTION
## Summary

The first full-stack bring-up to get past `helm install` (#453) reached **25 pods, 21 of them `1/1 Running`** — and still failed ([run 30445147655](https://github.com/izzywdev/FuzeInfra/actions/runs/30445147655/job/90553558306)). Two workloads never came up. Both are the same family as #453: *the local overlay assumed a precondition only production supplies.* Neither is a capacity problem — nodes reported `MemoryPressure False` / `DiskPressure False`, memory requests at 8–9%, 91 GB free.

### 1. chromadb — `Init:CreateContainerConfigError`

```
Warning  Failed  3m19s (x118 over 28m)  kubelet
  Error: secret "chromadb-admin-credentials" not found
```

`values.yaml` names that Secret; the only thing that produces it is `deploy/sealed-secrets/chromadb-admin-credentials.yaml`, which needs a Sealed Secrets controller and the prod private key. Nothing creates it on kind.

Worth noting how this one hides: **`helm install` succeeds.** The manifest is valid and every object is accepted — the pod then wedges forever, because a missing Secret is not a retryable pull failure that eventually resolves. Nothing is ever going to create it.

**Fix:** `chromadb.auth.adminSecret.devSecret`, default **off**, mirroring the `customHostnameApi.devSecret` escape hatch that already exists in this chart for exactly this situation. Rendering it requires a non-empty token, so it cannot half-apply.

### 2. All four Airflow pods — `CrashLoopBackOff`

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
  connection to server at "fuzeinfra-postgres" (10.244.2.13), port 5432 failed:
  FATAL:  database "airflow" does not exist
```

This is **not** a missing object — it is an ordering deadlock, and it is the more interesting of the two.

`fuzeinfra-airflow-init` *already* creates the database, migrates it and makes the admin user. But it is a `post-install` hook, and **Helm runs post-install hooks only after `--wait` reports the release ready.** The four Airflow pods can never become ready until the database that hook creates exists. So `--wait` burns its full 10 minutes, the hook never fires, and the pods crashloop the whole time. Argo has the identical ordering — PostSync runs after the sync goes healthy.

The confirming detail from the failed run: there is **no `fuzeinfra-airflow-init` pod anywhere in the cluster dump.** It never ran.

This has only ever worked because every cluster it has run on already had the database, created out-of-band long ago. The chart has never been able to cold-start Airflow.

**Fix:** `airflow.init.mode`, default `hook`. `inline` moves the Job into the main resource wave and adds a `wait-for-airflow-db` init container to all four pods.

Both halves are needed. Without the init container the pods still race the Job, die, and `CrashLoopBackOff` backs the retry off to ~5 minutes — so a pod can stay down long after the database is ready, blowing the same `--wait` budget by a different route. `airflow db check-migrations` is the readiness check the upstream Airflow chart uses.

The inline Job is named by the **hash of its own pod template**, because a plain Job's template is immutable and a fixed name would fail the next `helm upgrade` with `field is immutable` the moment anything changed.

### Prod is untouched

Both gates default to the existing behaviour, so `values.yaml`, `values-contabo.yaml` and `values-aws.yaml` **render exactly what they did**. Default-off is load-bearing in both cases, not just tidiness:

- the dev Secret uses the *same name* as the real SealedSecret, so enabling it in prod would replace a production credential with a public one;
- prod's metadata database already exists, and the hook ordering is what Argo expects.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore / CI / refactor

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] Conventional commit messages
- [ ] Commits are **signed** (verified) — *not locally; the admin squash-merge is GitHub-signed, which is what satisfies `required_signatures` here*
- [x] Tests added/updated where relevant
- [x] **Harden Gate** checks pass (`lint`, `test`, `build`, `sast`, `secret-scan`, `dependency-scan`)
- [x] Conversations resolved and ready for code-owner review

## Guards

Four, all in the existing `tests/test_local_overlay_installable.py`, which is already in the Infrastructure Tests gate:

- every Secret a local pod **requires** (`optional: true` excluded) must be created by the same render — the general form of bug 1, covering env, `envFrom` and volume mounts;
- the local `airflow-init` Job must not carry hook annotations;
- every local Airflow pod must have the `wait-for-airflow-db` init container;
- `devSecret.enabled` and `init.mode: inline` must never appear in a real overlay — parsed as YAML rather than regexed, so nesting and comments cannot fool it.

Neither failure is reachable by `helm lint` or `kubeconform`: one is a **runtime object**, the other is an **ordering property**. Both reached main behind a green `helm-validate`, exactly like the SealedSecret (#444) and the namespace (#453) before them. That is now three for three, which is the argument for these being render-level guards rather than schema checks.

### Verified here

- Go-template block balance in both edited templates (16 open / 16 end, final depth 0, never negative)
- The three render guards **mutation-tested** against synthetic manifests reproducing the exact CI failure: all three fire pre-fix, all three silent post-fix
- The inverse guard run against the real files: clean on `values.yaml` / `values-contabo.yaml` / `values-aws.yaml`, and it does find all three switches in `values-local.yaml` — so it is not blind
- Every other Secret-consuming component confirmed disabled locally (`handoffMcp`, `loki.s3`, `cloudflareTunnel`, `clusterAutoscaler`, `serviceDatabases`, `serviceMongoDatabases`, `serviceChromaCollections`), so the new secret guard cannot red the required gate on something unrelated
- The k8s Job rename is local-only and collides with nothing: every other `fuzeinfra-airflow-init` reference in the repo is the **docker-compose** container (`docker ps` / `docker inspect`), not Kubernetes

### NOT verified here

**The rendered output and the cluster install.** This sandbox has neither `helm` nor a cluster, so nothing could be rendered or installed locally — same constraint as #453. `devenv up (full)` on this PR is the proof, and this PR's paths trigger it.

Note that gate is **not** a required status check, so it does not block merge. It should only become required once it can actually pass — which is the point of this sequence.

## Related issues

Follow-up to #453 (consumer namespace), #444 (SealedSecret gate + failure classification) and #442 (hosted-runner `kind-validate`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkVURsLwKFf5KKS1Z76C4f)_