### PR TITLE
feat(terraform): re-enable Cloudflare for SaaS (token now has Custom Hostnames permission)

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -88,6 +88,8 @@ env:
   TF_VAR_crit_bridge_token: ${{ secrets.CRIT_BRIDGE_TOKEN }}
   TF_VAR_k3s_node_token: ${{ secrets.K3S_NODE_TOKEN }}
   TF_VAR_ci_worker_count: "1"
+  # CF token now has Zone/Custom Hostnames:Edit — re-enabled after token fix
+  TF_VAR_saas_custom_hostnames_enabled: "true"
 
 jobs:
   # =========================================================================

--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -241,6 +241,7 @@ resource "cloudflare_record" "saas_origin" {
 
 # Enabling the fallback origin is what turns Cloudflare for SaaS on for the zone.
 # It must point at a record that already exists and is proxied, hence depends_on.
+# Requires "Zone / Custom Hostnames: Edit" on the Cloudflare API token.
 resource "cloudflare_custom_hostname_fallback_origin" "saas" {
   count      = local.cloudflare_enabled && var.saas_custom_hostnames_enabled ? 1 : 0
   zone_id    = var.cloudflare_zone_id


### PR DESCRIPTION
## Summary
- CF token "FuzeInfra Terraform" now has `Zone / Custom Hostnames: Edit` permission (added manually)
- Re-enables `saas_custom_hostnames_enabled = true` via `TF_VAR_saas_custom_hostnames_enabled` in the CI workflow
- This apply will create `cloudflare_custom_hostname_fallback_origin.saas` plus the `connect.<zone>` and `saas-origin.<zone>` DNS records

## Changes
- `.github/workflows/terraform-plan-apply.yml`: add `TF_VAR_saas_custom_hostnames_enabled: "true"` env var

## Test plan
- [ ] Plan shows creates for `cloudflare_custom_hostname_fallback_origin.saas`, `cloudflare_record.saas_connect[0]`, `cloudflare_record.saas_origin[0]`  
- [ ] Apply succeeds with no Authentication error (10000)