### PR TITLE
feat(litellm): full Gemini model set + admin UI tile in the CF App Launcher

### DIFF
--- a/helm/litellm/templates/ingress.yaml
+++ b/helm/litellm/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.enabled .Values.ingress.enabled }}
+{{- $domain := required "ingress.domain is required when ingress.enabled=true" .Values.ingress.domain -}}
+{{- /*
+Traefik-only Ingress for the LiteLLM admin UI.
+
+No TLS block on purpose: Cloudflare terminates edge TLS and the tunnel delivers
+plain HTTP to Traefik, exactly like every other admin UI in this platform.
+Adding a tls: section here would not add encryption, it would just make Traefik
+try to serve a certificate it does not have.
+
+Path "/" rather than "/ui": LiteLLM's console loads its bundle from
+/litellm-asset-prefix/... and calls back to the API routes on the same origin,
+so scoping the Ingress to /ui would serve an HTML shell whose every asset and
+XHR 404s — a blank page, which is exactly how the Neo4j Browser issue presented.
+*/ -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: litellm
+  labels:
+    {{- include "litellm.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ printf "%s.%s" .Values.ingress.subdomain $domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: litellm
+                port:
+                  number: {{ .Values.port }}
+{{- end }}

--- a/helm/litellm/templates/networkpolicy.yaml
+++ b/helm/litellm/templates/networkpolicy.yaml
@@ -8,9 +8,19 @@ that as "from anywhere" — so the empty case must never render a rule. Same
 construction as the custom-hostname API's policy, for the same reason.
 
 policyTypes is Ingress-only on purpose: the gateway must egress to
-api.anthropic.com / api.openai.com, and adding Egress here would silently break
-every completion.
+api.anthropic.com / api.openai.com / generativelanguage.googleapis.com, and
+adding Egress here would silently break every completion.
+
+The ingress controller's namespace is appended AUTOMATICALLY when
+ingress.enabled — Traefik runs in kube-system, not fuzeinfra, so without this
+every request arriving through the Ingress is dropped by this policy and the
+App Launcher tile 502s. Deriving it here rather than asking the operator to
+remember it in values is the whole point.
 */ -}}
+{{- $allowed := .Values.networkPolicy.allowedNamespaces | default list -}}
+{{- if .Values.ingress.enabled -}}
+{{- $allowed = append $allowed (.Values.ingress.controllerNamespace | default "kube-system") -}}
+{{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -23,10 +33,10 @@ spec:
       {{- include "litellm.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
-{{- if .Values.networkPolicy.allowedNamespaces }}
+{{- if $allowed }}
   ingress:
     - from:
-        {{- range (.Values.networkPolicy.allowedNamespaces | uniq) }}
+        {{- range ($allowed | uniq) }}
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ . }}

--- a/helm/litellm/values-contabo.yaml
+++ b/helm/litellm/values-contabo.yaml
@@ -39,15 +39,34 @@ resources:
   requests: { cpu: "250m", memory: "512Mi" }
   limits:   { cpu: "1", memory: "3Gi" }
 
-# Cluster-internal only. No Ingress, no Cloudflare tunnel route, no CF Access
-# app — the gateway holds live provider keys and must stay unreachable from
-# outside the cluster by construction.
 networkPolicy:
   enabled: true
   allowedNamespaces:
     # FuzeFront chat-service + doc indexer (LITELLM_URL, and the indexer's
     # /embeddings calls).
     - fuzefront
+    # kube-system (Traefik) is appended automatically by the template because
+    # ingress.enabled is true below — do not add it here as well.
+
+# LiteLLM admin UI at https://litellm.prod.fuzefront.com, reached through the
+# Cloudflare tunnel and gated by the *.prod email-OTP Access app. The App
+# Launcher tile is declared in terraform/contabo/cloudflare.tf
+# (local.launcher_services).
+#
+# No per-host tunnel rule, CNAME or Access app is needed: litellm.prod lands
+# under the existing *.prod wildcard, so the catch-all tunnel rule → Traefik,
+# the *.prod CNAME and the *.prod OTP app already cover routing, DNS and gating.
+#
+# Understand what this exposes before changing it: LiteLLM serves the UI and the
+# API from one port, so /chat/completions and /embeddings are reachable at this
+# hostname too. The gates are Cloudflare Access OTP (admin allowlist) plus
+# LITELLM_MASTER_KEY on every API call. Traefik remains ClusterIP; no host port
+# is opened.
+ingress:
+  enabled: true
+  className: traefik
+  subdomain: litellm
+  domain: prod.fuzefront.com
 
 # NOTE ON NODE PINNING: FuzeFront's own values-prod.yaml pins a `litellm`
 # affinity to node `fuzefront-node-2`. That node does not exist in this cluster

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -115,13 +115,29 @@ models:
   - name: gpt-4.1-mini
     provider: openai/gpt-4.1-mini
     keyEnv: OPENAI_API_KEY
-  # Gemini is the LAST hop and is currently NON-FUNCTIONAL: the key returns
-  # "You exceeded your current quota" (free-tier exhausted). Kept wired so it
-  # starts working the moment billing is fixed, with no chart change. It costs
-  # nothing in the normal path — fallbacks stop at the first success, so this is
-  # only ever reached if BOTH Anthropic and OpenAI have failed.
+  # --- Gemini ------------------------------------------------------------------
+  # ALL of these are currently NON-FUNCTIONAL: the key returns "You exceeded your
+  # current quota" (free tier exhausted). Wired anyway so they start working the
+  # moment billing is fixed, with no chart change. Costs nothing in the normal
+  # path — fallbacks stop at the first success, so gemini is only ever reached if
+  # BOTH Anthropic and OpenAI have failed.
+  #
+  # Model IDs taken from the key's own ListModels response (filtered to those
+  # advertising generateContent), not guessed.
+  - name: gemini-2.5-pro
+    provider: gemini/gemini-2.5-pro
+    keyEnv: GEMINI_API_KEY
+  - name: gemini-2.5-flash
+    provider: gemini/gemini-2.5-flash
+    keyEnv: GEMINI_API_KEY
+  - name: gemini-2.5-flash-lite
+    provider: gemini/gemini-2.5-flash-lite
+    keyEnv: GEMINI_API_KEY
   - name: gemini-2.0-flash
     provider: gemini/gemini-2.0-flash
+    keyEnv: GEMINI_API_KEY
+  - name: gemini-2.0-flash-lite
+    provider: gemini/gemini-2.0-flash-lite
     keyEnv: GEMINI_API_KEY
   # --- embeddings -------------------------------------------------------------
   # FuzeFront's LITELLM_EMBEDDING_MODEL default. OpenAI, not Anthropic —
@@ -161,23 +177,49 @@ generalSettings: {}
 #
 # Every name on BOTH sides of these maps must exist in `models` above.
 # -----------------------------------------------------------------------------
+# Each hop is matched to the primary's TIER, so a provider outage never silently
+# upgrades or downgrades what a caller gets: frontier falls back to frontier,
+# cheap/fast falls back to cheap/fast. Getting this wrong is how an outage
+# quietly multiplies cost per turn (or halves answer quality).
 routerSettings:
   fallbacks:
-    - claude-opus-4-5: ["gpt-4.1", "gemini-2.0-flash"]
-    - claude-opus-5: ["gpt-4.1", "gemini-2.0-flash"]
-    - claude-sonnet-5: ["gpt-4.1", "gemini-2.0-flash"]
-    # Haiku is the cheap/fast tier — fall back to a cheap/fast peer, not to a
-    # frontier model, so a provider outage cannot quietly multiply cost per turn.
-    - claude-haiku-4-5: ["gpt-4.1-mini", "gemini-2.0-flash"]
+    - claude-opus-4-5: ["gpt-4.1", "gemini-2.5-pro"]
+    - claude-opus-5: ["gpt-4.1", "gemini-2.5-pro"]
+    - claude-sonnet-5: ["gpt-4.1", "gemini-2.5-flash"]
+    - claude-haiku-4-5: ["gpt-4.1-mini", "gemini-2.5-flash-lite"]
 
 # -----------------------------------------------------------------------------
 # Defence in depth: only the namespaces listed here may open a connection to the
-# gateway. It holds live provider credentials, so it is never exposed through an
-# Ingress or the Cloudflare tunnel — cluster-internal only, by construction.
+# gateway.
 #
 # Egress is deliberately unrestricted (no Egress policyType): the gateway must
-# reach api.anthropic.com and api.openai.com.
+# reach api.anthropic.com, api.openai.com and generativelanguage.googleapis.com.
+#
+# NOTE: when `ingress.enabled` is true the template ALSO admits the ingress
+# controller's namespace automatically. Leaving that to the operator is how you
+# get a tile that 502s — Traefik runs in kube-system, not in fuzeinfra, so the
+# policy would otherwise drop every request coming through the Ingress.
 # -----------------------------------------------------------------------------
 networkPolicy:
   enabled: false
   allowedNamespaces: []
+
+# -----------------------------------------------------------------------------
+# Ingress — the LiteLLM ADMIN UI (/ui), reachable at
+# litellm.<domain> through the Cloudflare tunnel.
+#
+# SECURITY POSTURE, read before enabling. This service holds live provider API
+# keys, and exposing it publishes the FULL API surface (/chat/completions,
+# /embeddings) at that hostname, not just the UI — LiteLLM serves them from one
+# port and there is no path split here. Two independent gates stand in front:
+#   1. Cloudflare Access email-OTP on *.prod.fuzefront.com (admin allowlist), and
+#   2. LITELLM_MASTER_KEY, still required on every API call.
+# Traefik stays ClusterIP and all traffic arrives via the tunnel, so this opens
+# no host port. Off by default; prod turns it on deliberately.
+# -----------------------------------------------------------------------------
+ingress:
+  enabled: false
+  className: traefik
+  # Rendered host is "<subdomain>.<domain>". domain MUST be set when enabled.
+  subdomain: litellm
+  domain: ""

--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -552,6 +552,16 @@ locals {
     #               authentik.prod.fuzefront.com Ingress; tile lands on /if/admin/)
     "unleash"   = { name = "Unleash", logo = "https://avatars.githubusercontent.com/u/23053233?s=200&v=4", path = "" }
     "authentik" = { name = "Authentik", logo = "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/authentik.png", path = "/if/admin/" }
+    # LiteLLM gateway admin UI (helm/litellm, Ingress → svc litellm:4000).
+    # Under the *.prod wildcard like the rest, so this bookmark is all that is
+    # needed — no per-host tunnel rule, CNAME or Access app.
+    #
+    # path = "/ui" because "/" redirects to the console anyway and landing
+    # straight on it saves a hop. NOTE the Ingress is deliberately scoped to "/",
+    # not "/ui": the console loads its bundle from /litellm-asset-prefix/... and
+    # calls the API on the same origin, so a /ui-only route would render a blank
+    # page (the Neo4j Browser failure mode).
+    "litellm" = { name = "LiteLLM", logo = "https://avatars.githubusercontent.com/u/121462774?s=200&v=4", path = "/ui" }
   }
 }
 


### PR DESCRIPTION
Two additions.

1) GEMINI MODELS
Previously only gemini-2.0-flash existed, and only as a fallback hop. Adds the
full set the key actually advertises: gemini-2.5-pro, 2.5-flash, 2.5-flash-lite,
2.0-flash, 2.0-flash-lite. IDs come from the key's own ListModels response
(filtered to those advertising generateContent), not guessed.

Fallback hops are now TIER-MATCHED rather than all pointing at one model, so a
provider outage never silently upgrades or downgrades what a caller gets:
  claude-opus-4-5 / -5  -> gpt-4.1       -> gemini-2.5-pro
  claude-sonnet-5       -> gpt-4.1       -> gemini-2.5-flash
  claude-haiku-4-5      -> gpt-4.1-mini  -> gemini-2.5-flash-lite

All Gemini models remain quota-dead upstream ("You exceeded your current
quota"); they self-heal when billing is fixed, with no chart change.

2) APP LAUNCHER TILE
Adds a `litellm` bookmark to local.launcher_services and an Ingress so Traefik
host-routes litellm.prod.fuzefront.com -> svc litellm:4000. It lands under the
existing *.prod wildcard, so no per-host tunnel rule, CNAME or Access app is
needed — the catch-all tunnel rule, the *.prod CNAME and the *.prod email-OTP
Access app already cover routing, DNS and gating.

THIS CHANGES THE SERVICE'S EXPOSURE, deliberately, and the chart comments that
claimed "cluster-internal by construction" are updated rather than left to
contradict it. LiteLLM serves the UI and the API from one port, so
/chat/completions and /embeddings are reachable at that hostname too. Two
independent gates remain: Cloudflare Access email-OTP (admin allowlist) and
LITELLM_MASTER_KEY on every API call. Traefik stays ClusterIP; no host port opens.

Two failure modes designed out rather than discovered in prod:
  - The NetworkPolicy now appends the ingress controller's namespace
    AUTOMATICALLY when ingress.enabled. Traefik runs in kube-system, not
    fuzeinfra, so without it the policy drops every request arriving through the
    Ingress and the tile 502s. Verified rendered: admits [fuzefront, kube-system].
  - The Ingress is scoped to "/" and NOT "/ui". The console loads its bundle from
    /litellm-asset-prefix/... and calls the API on the same origin, so a /ui-only
    route serves an HTML shell whose assets and XHRs all 404 — a blank page,
    exactly how the Neo4j Browser issue presented. The tile's path is /ui so the
    link still lands on the console.

Verified: helm lint clean; kubeconform -strict 5/5 valid; rendered Ingress is
litellm.prod.fuzefront.com / -> litellm:4000; every fallback target exists in
model_list; terraform fmt canonical. /ui confirmed serving HTTP 200 on the live
pod (LiteLLM renders the console without a DATABASE_URL; virtual keys and spend
tracking would need one).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session-Id: c2b5ed19-6122-49ad-a96e-918eb61a8bd0
