### PR TITLE
chore(terraform): refresh plan — re-apply CF for SaaS activation

### DIFF
--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -239,7 +239,7 @@ resource "cloudflare_record" "saas_origin" {
   comment = "Cloudflare for SaaS fallback origin -> tunnel -> Traefik."
 }
 
-# Enabling the fallback origin is what turns Cloudflare for SaaS on for the zone.
+# Enabling the fallback origin activates Cloudflare for SaaS on the zone.
 # It must point at a record that already exists and is proxied, hence depends_on.
 # Requires "Zone / Custom Hostnames: Edit" on the Cloudflare API token.
 resource "cloudflare_custom_hostname_fallback_origin" "saas" {


### PR DESCRIPTION
Previous apply on PR #459 failed with **Saved plan is stale** because the LiteLLM/Gemini PR merged concurrently and changed state between plan-save and apply.

This PR triggers a fresh plan against current state (trivial comment change to cloudflare.tf) so the apply can proceed cleanly.

**What this apply does:** creates `cloudflare_custom_hostname_fallback_origin.saas[0]`, `cloudflare_record.saas_connect[0]`, `cloudflare_record.saas_origin[0]` — the CF for SaaS activation resources.