### PR TITLE
fix(custom-hostname-api): pin to a durable node — elastic nodes cannot reach the API server

### DIFF
--- a/helm/fuzeinfra/templates/custom-hostname-api.yaml
+++ b/helm/fuzeinfra/templates/custom-hostname-api.yaml
@@ -187,6 +187,33 @@ spec:
         checksum/profiles: {{ toYaml $chapi.routeProfiles | sha256sum }}
     spec:
       serviceAccountName: custom-hostname-api
+      # Pin to a DURABLE node: this API talks to the Kubernetes API server, and
+      # pods on elastic nodes currently cannot reach it. The `kubernetes` Service
+      # (10.43.0.1) advertises the control planes' PUBLIC IPs, but after the
+      # private-VLAN cutover every node's InternalIP is 10.0.0.x and only ONE of
+      # the three public endpoints is reachable from an elastic node:
+      #   161.97.118.134 (vmi3383846)      reachable
+      #   194.163.136.242 (mendys-worker-1) UNREACHABLE
+      #   95.111.238.66  (vmi3396106)      UNREACHABLE
+      # so 10.43.0.1:443 fails and /readyz reports
+      #   {"status":"degraded","detail":"Kubernetes API is unreachable."}
+      # leaving the Deployment permanently Available=False and fuzeinfra-prod
+      # Degraded. This is a workaround: the real fix is for the API server to
+      # advertise the VLAN addresses (or to open 6443 between nodes), which is
+      # part of the unfinished VLAN cutover and must be done deliberately.
+      # Durable nodes are identified by the ABSENCE of fuzeinfra.io/pool
+      # (elastic nodes carry pool=elastic, the CI node pool=ci).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: fuzeinfra.io/pool
+                    operator: DoesNotExist
+              - matchExpressions:
+                  - key: fuzeinfra.io/pool
+                    operator: NotIn
+                    values: ["elastic", "ci"]
       {{- with $chapi.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
`custom-hostname-api` has been `Available=False` since it was enabled, keeping `fuzeinfra-prod` **Degraded** even after its sync went clean (93/93 Synced).

## It is not a Cloudflare problem

With Cloudflare for SaaS now entitled, the pod's `GET /zones/<id>/custom_hostnames` returns **200**, and `/healthz` is **200**. Only `/readyz` fails:

```json
{"status":"degraded","provider":"cloudflare_for_saas",
 "detail":"{'error':'upstream_error','message':'Kubernetes API is unreachable.'}"}
```

## Root cause: cluster networking, not this app

The pod landed on `fuzeinfra-elastic-57543f68`. From an elastic node, `10.43.0.1:443` fails **5/5** while CoreDNS (also a ClusterIP) is fine — so it is not general service routing.

The `kubernetes` Service advertises the control planes' **public** IPs, but after the private-VLAN cutover every node's InternalIP is `10.0.0.x`, and only one of the three is reachable from elastic:

| endpoint (public) | node | from elastic |
|---|---|---|
| 161.97.118.134 | vmi3383846 | ✅ reachable |
| 194.163.136.242 | mendys-worker-1 | ❌ unreachable |
| 95.111.238.66 | vmi3396106 | ❌ unreachable |

Confirmed with probe pods: identical containers reach `10.43.0.1` on `vmi3383846` (durable) and cannot on the elastic node. The elastic node **can** reach `161.97.118.134:6443` directly — so it is the ClusterIP path into the two dead endpoints that breaks.

## This is a workaround, deliberately

Pins the Deployment to durable nodes — the same pattern already used for the DB backup CronJobs.

**The real fix** is for the API server to advertise the VLAN addresses (or to open 6443 node-to-node). That belongs to the unfinished VLAN cutover and must be done deliberately on a live HA control plane, not as a side effect of this change.

⚠️ **Blast radius worth knowing:** *any* pod on an elastic node that talks to the Kubernetes API will fail this way. `custom-hostname-api` is simply the first to surface it, because it happens to check the API in a readiness probe. Anything else affected would fail more quietly.

## Verified

`helm template` renders both `nodeSelectorTerms`; the selector matches exactly the 3 durable nodes and excludes all 5 elastic nodes, the CI node and `mendys-prod`.