### PR TITLE
fix(launcher,litellm): prune duplicate App Launcher tiles; give the LiteLLM UI its database

### DIFF
--- a/docs/consuming-repos/LITELLM_GATEWAY.md
+++ b/docs/consuming-repos/LITELLM_GATEWAY.md
@@ -130,6 +130,38 @@ Register the Argo Application once on a new cluster:
 kubectl apply -f argocd/applications/litellm.yaml
 ```
 
+## The admin UI
+
+`https://litellm.prod.fuzefront.com/ui`, reached from the Cloudflare App
+Launcher tile and gated by the `*.prod.fuzefront.com` email-OTP Access app. Log
+in as **`admin`** with the `LITELLM_MASTER_KEY` value — LiteLLM falls back to
+the master key when `UI_USERNAME`/`UI_PASSWORD` are unset, which is why neither
+is wired into the chart.
+
+**The UI needs Postgres; the gateway does not.** Proxying (`/chat/completions`,
+`/embeddings`) is stateless and ran for weeks with no database. The console is
+not: the first thing it does after loading is mint a UI session key, and that is
+a database write. With no `DATABASE_URL` the request never completes, the page
+sits on "Loading", and Cloudflare eventually returns **error 522** for the
+origin. The origin log is the tell — every
+`/litellm-asset-prefix/_next/static/*` chunk returns 200 and then the log simply
+stops, because uvicorn writes its access-log line when a response is *sent*, so
+a request that hangs forever leaves no trace.
+
+`database.enabled: true` (`helm/litellm/values-contabo.yaml`) wires
+`DATABASE_URL` to a dedicated `litellm` database on the shared
+`fuzeinfra-postgres`, created idempotently by the `ensure-database`
+initContainer. Credentials come from `fuzeinfra-secrets`, the same way Airflow
+connects — no SealedSecret needed, because LiteLLM lives in the `fuzeinfra`
+namespace alongside them.
+
+Two consequences worth knowing before you touch it:
+
+- LiteLLM runs `prisma migrate deploy` at startup once `DATABASE_URL` is set, so
+  cold starts are slower. The `startupProbe` allows 10 minutes.
+- Reverting is one value: `database.enabled: false` restores a working gateway
+  with a non-functional UI.
+
 ## Related
 
 - [`CHROMADB_PROVISIONING.md`](CHROMADB_PROVISIONING.md) — vector store for RAG.

--- a/helm/litellm/templates/deployment.yaml
+++ b/helm/litellm/templates/deployment.yaml
@@ -26,6 +26,64 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.database.enabled }}
+      # LiteLLM runs `prisma migrate deploy` against DATABASE_URL at startup, and
+      # prisma will NOT create the database itself — it expects to connect to one
+      # that exists. So the database has to be there before the main container
+      # starts, which is exactly what an initContainer guarantees (a PostSync Job
+      # would race the Deployment).
+      #
+      # Idempotent by construction: it re-runs on every pod start and every
+      # rollout, and does nothing when the database already exists.
+      initContainers:
+        - name: ensure-database
+          image: {{ .Values.database.provisionImage | default "postgres:15" }}
+          imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              echo "Waiting for ${PGHOST}:${PGPORT} ..."
+              until pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" >/dev/null 2>&1; do
+                sleep 3
+              done
+              # CREATE DATABASE cannot run inside a transaction or a DO block, so
+              # it is guarded by a SELECT rather than an IF NOT EXISTS.
+              if psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres -tAc \
+                   "SELECT 1 FROM pg_database WHERE datname = '${LITELLM_DB}'" | grep -q 1; then
+                echo "Database '${LITELLM_DB}' already exists."
+              else
+                psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres \
+                  -c "CREATE DATABASE \"${LITELLM_DB}\""
+                echo "Database '${LITELLM_DB}' created."
+              fi
+          env:
+            - name: PGHOST
+              value: {{ .Values.database.host | quote }}
+            - name: PGPORT
+              value: {{ .Values.database.port | quote }}
+            - name: LITELLM_DB
+              value: {{ .Values.database.name | quote }}
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.credentialsSecret }}
+                  key: {{ .Values.database.userKey }}
+            # psql and pg_isready both read PGPASSWORD from the environment, so
+            # the password never appears in an argv anyone can read from `ps`.
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.credentialsSecret }}
+                  key: {{ .Values.database.passwordKey }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests: { cpu: "10m", memory: "32Mi" }
+            limits:   { cpu: "250m", memory: "128Mi" }
+      {{- end }}
       containers:
         - name: litellm
           image: "{{ .Values.image }}:{{ .Values.tag }}"
@@ -57,6 +115,24 @@ spec:
                   name: {{ $.Values.secretName }}
                   key: {{ .name }}
                   optional: {{ not .required }}
+            {{- end }}
+            {{- if .Values.database.enabled }}
+            # ORDER IS LOAD-BEARING: Kubernetes only expands $(VAR) references to
+            # variables declared EARLIER in this list, so these two must precede
+            # DATABASE_URL. Same construction as the Airflow env block
+            # (helm/fuzeinfra/templates/airflow.yaml).
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.credentialsSecret }}
+                  key: {{ .Values.database.userKey }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.credentialsSecret }}
+                  key: {{ .Values.database.passwordKey }}
+            - name: DATABASE_URL
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }}"
             {{- end }}
           volumeMounts:
             - name: config

--- a/helm/litellm/values-contabo.yaml
+++ b/helm/litellm/values-contabo.yaml
@@ -39,6 +39,26 @@ resources:
   requests: { cpu: "250m", memory: "512Mi" }
   limits:   { cpu: "1", memory: "3Gi" }
 
+# Postgres backing store — REQUIRED for the admin UI below to work at all.
+#
+# Without it the console renders and then hangs on its first session call, which
+# Cloudflare surfaces as error 522 (see the long note in values.yaml). The
+# gateway's PROXYING path never needed a database, which is why it ran fine for
+# weeks and only the UI was broken.
+#
+# `fuzeinfra-postgres` is the shared server in this namespace and `litellm` is a
+# dedicated logical database on it, created idempotently by the ensure-database
+# initContainer using the same fuzeinfra-secrets credentials Airflow uses.
+#
+# WATCH THE FIRST ROLLOUT: LiteLLM runs `prisma migrate deploy` at startup once
+# DATABASE_URL is set, so the cold start gets slower and a migration failure
+# CrashLoops a gateway that FuzeFront's chat-service depends on. The startupProbe
+# (60 x 10s) covers the extra time. If it ever does wedge, setting
+# `database.enabled: false` here reverts to the previous behaviour — a working
+# gateway with a broken UI — in one commit.
+database:
+  enabled: true
+
 networkPolicy:
   enabled: true
   allowedNamespaces:

--- a/helm/litellm/values-local.yaml
+++ b/helm/litellm/values-local.yaml
@@ -31,3 +31,14 @@ resources:
 # is a no-op that only makes local behaviour diverge from prod.
 networkPolicy:
   enabled: false
+
+# Off locally because a bare `helm install litellm` on kind has no
+# fuzeinfra-postgres and no fuzeinfra-secrets to read, and the ensure-database
+# initContainer would block the pod in Init forever waiting for a server that
+# will never answer.
+#
+# The gateway's PROXYING path does not need this — only the admin UI does (see
+# values.yaml). If you are working ON the UI, bring the umbrella chart up first
+# so Postgres exists, then `--set database.enabled=true`.
+database:
+  enabled: false

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -62,6 +62,51 @@ affinity: {}
 # -----------------------------------------------------------------------------
 secretName: litellm-secret
 
+# -----------------------------------------------------------------------------
+# Postgres backing store.
+#
+# THE ADMIN UI DOES NOT WORK WITHOUT THIS — that is upstream behaviour, not a
+# preference. LiteLLM's console serves its static bundle happily with no
+# database, which is why "GET /ui returns 200" was mistaken for "the UI works"
+# when the tile was added. The first thing the console does after booting is
+# mint a UI session key, and key generation is a database write. With no
+# DATABASE_URL that request never completes, the page sits on "Loading", and
+# Cloudflare eventually gives up on the origin and serves error 522. The origin
+# log shows exactly that shape: every /litellm-asset-prefix/_next/static/* chunk
+# 200s, and then nothing — uvicorn only writes an access-log line once a
+# response is sent, so a request that hangs forever leaves no trace at all.
+# Upstream: https://docs.litellm.ai/docs/proxy/ui and BerriAI/litellm#30328.
+#
+# CREDENTIALS follow the Airflow precedent rather than the serviceDatabases one.
+# LiteLLM is a FuzeInfra-owned component living in the `fuzeinfra` namespace, so
+# it reads POSTGRES_USER/POSTGRES_PASSWORD straight out of `fuzeinfra-secrets`
+# the same way helm/fuzeinfra/templates/airflow.yaml does — no SealedSecret has
+# to be minted and no credential is committed. serviceDatabases exists for the
+# other case: a CONSUMER repo that seals its own password into this namespace.
+#
+# HARDENING FOLLOW-UP: those are the Postgres SUPERUSER credentials. Airflow
+# already connects this way so this is no worse than the status quo, but the
+# better end state is a dedicated `litellm_svc` role via serviceDatabases, which
+# needs a sealed password. Doing that later is a values change plus a
+# SealedSecret — no template change.
+#
+# `name` is a separate logical database on the shared server, so LiteLLM's
+# prisma migrations can never touch another service's tables.
+# -----------------------------------------------------------------------------
+database:
+  # Off in the base chart for the same reason `enabled` is: a chart rendered
+  # without the fuzeinfra umbrella has no fuzeinfra-secrets to read.
+  enabled: false
+  host: fuzeinfra-postgres
+  port: 5432
+  name: litellm
+  credentialsSecret: fuzeinfra-secrets
+  userKey: POSTGRES_USER
+  passwordKey: POSTGRES_PASSWORD
+  # Used by the ensure-database initContainer only. postgres:15 matches the
+  # server version the umbrella chart runs, and it ships psql + pg_isready.
+  provisionImage: postgres:15
+
 # Provider keys wired into the pod as env. `required: false` renders the env var
 # with optional=true, so a missing key leaves the var unset (and only the models
 # that need it fail) instead of blocking pod start.

--- a/terraform/contabo/cloudflare.tf
+++ b/terraform/contabo/cloudflare.tf
@@ -576,6 +576,82 @@ resource "cloudflare_zero_trust_access_application" "launcher_bookmark" {
   logo_url             = each.value.logo
 }
 
+# ---------------------------------------------------------------------------
+# DUPLICATE-TILE RECONCILER
+#
+# The launcher showed Unleash twice and Authentik twice — once from the bookmark
+# above (correct logo) and once from a `type = "self_hosted"` Access app a
+# consumer repo created out-of-band with `app_launcher_visible: true` and no
+# logo_url. izzywdev/FuzeFront's runbook records doing exactly that for
+# unleash.prod.fuzefront.com (app 514f8a21-3793-4726-858e-819556fbe346).
+#
+# Terraform cannot destroy what it never created and what is not in state, and
+# importing each duplicate by hand needs an app id nobody has until they go
+# looking. So the deletion is expressed as a reconciler that DISCOVERS them:
+# any launcher-visible Access app on a host `local.launcher_services` already
+# publishes a tile for, that Terraform does not own, is a duplicate by
+# definition. The script documents its full safety envelope; the short version
+# is that it only ever considers those exact hostnames, and never an id in
+# `local.terraform_owned_access_app_ids` or var.launcher_tile_prune_keep_ids.
+#
+# Deleting a duplicate does NOT open the host up: it falls back to the wildcard
+# *.prod.fuzefront.com email-OTP app that covered it before, whose allowlist the
+# consumer's policy was written to mirror.
+#
+# The trigger set is deliberately CONTENT-hashed rather than time-based — a
+# timestamp() trigger would make every plan non-empty and permanently trip the
+# drift gate in terraform-plan-apply.yml. It re-runs when the tile set, the
+# owned-id set, the keep-list, or the script itself changes.
+# ---------------------------------------------------------------------------
+variable "launcher_tile_prune_keep_ids" {
+  description = "Cloudflare Access application ids the duplicate-tile reconciler must never delete. Escape hatch for a deliberate per-host self-hosted app that should keep its own launcher tile."
+  type        = list(string)
+  default     = []
+}
+
+locals {
+  # The exact hostnames FuzeInfra publishes a tile for. Nothing outside this set
+  # is ever a deletion candidate.
+  launcher_hosts = [for key in keys(local.launcher_services) : "${key}.${local.prod_domain}"]
+
+  # EVERY Access application this root module owns. The reconciler treats this
+  # as the do-not-touch list, so adding a new Access app resource here is what
+  # keeps it safe from a future prune — remember to extend this list with it.
+  terraform_owned_access_app_ids = concat(
+    [for app in cloudflare_zero_trust_access_application.launcher_bookmark : app.id],
+    [for app in cloudflare_zero_trust_access_application.public_app : app.id],
+    cloudflare_zero_trust_access_application.admin_services[*].id,
+    cloudflare_zero_trust_access_application.app_launcher[*].id,
+    cloudflare_zero_trust_access_application.sealed_secrets_cert[*].id,
+    cloudflare_zero_trust_access_application.crit_alert_bridge[*].id,
+    cloudflare_zero_trust_access_application.handoff_mcp[*].id,
+  )
+}
+
+resource "null_resource" "prune_duplicate_launcher_tiles" {
+  count = local.cloudflare_enabled ? 1 : 0
+
+  triggers = {
+    hosts  = sha256(jsonencode(local.launcher_hosts))
+    owned  = sha256(jsonencode(local.terraform_owned_access_app_ids))
+    keep   = sha256(jsonencode(var.launcher_tile_prune_keep_ids))
+    script = filesha256("${path.module}/prune-duplicate-launcher-tiles.py")
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = "python3 '${path.module}/prune-duplicate-launcher-tiles.py'"
+
+    environment = {
+      CF_API_TOKEN    = var.cloudflare_api_token
+      CF_ACCOUNT_ID   = var.cloudflare_account_id
+      LAUNCHER_HOSTS  = join(",", local.launcher_hosts)
+      MANAGED_APP_IDS = join(",", local.terraform_owned_access_app_ids)
+      KEEP_APP_IDS    = join(",", var.launcher_tile_prune_keep_ids)
+    }
+  }
+}
+
 # Construct the cloudflared token from known fields.
 # Format: base64(JSON{ a: account_id, t: tunnel_id, s: base64_secret })
 locals {

--- a/terraform/contabo/prune-duplicate-launcher-tiles.py
+++ b/terraform/contabo/prune-duplicate-launcher-tiles.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Delete DUPLICATE Cloudflare Access App Launcher tiles.
+
+WHY THIS EXISTS
+---------------
+FuzeInfra owns the App Launcher. Every tile is a `type = "bookmark"` Access
+application declared in `local.launcher_services` (cloudflare.tf) — a pure link
+carrying a `logo_url`, with authentication supplied by the single wildcard
+self-hosted app on `*.prod.fuzefront.com`.
+
+Consumer repos do not have that context. Twice now a consumer created its OWN
+`type = "self_hosted"` Access application for a host FuzeInfra already publishes
+a tile for, with `app_launcher_visible: true`, out-of-band via the Cloudflare
+API — see izzywdev/FuzeFront `docs/runbooks/unleash-launcher-and-developer-flags.md`,
+which records creating app `514f8a21-3793-4726-858e-819556fbe346` for
+`unleash.prod.fuzefront.com`. The result is TWO tiles for one service: the
+Terraform bookmark (correct logo) and the consumer's self-hosted app (no
+`logo_url`, so the launcher renders a blank/generic icon).
+
+Terraform alone cannot fix this. The duplicates are not in state, and a resource
+that does not exist in configuration cannot be destroyed — importing each one by
+hand needs an app id nobody has until they look. So this reconciler runs at apply
+time and deletes, by discovery, any launcher-visible Access application for a
+host FuzeInfra already owns a tile for.
+
+WHAT IT WILL NOT TOUCH — the safety envelope, in order:
+  1. Anything Terraform owns (MANAGED_APP_IDS is every Access application id in
+     this root module) — so the bookmarks themselves can never be pruned.
+  2. Anything in KEEP_APP_IDS (var.launcher_tile_prune_keep_ids), the operator
+     escape hatch for a deliberate per-host self-hosted app.
+  3. Apps that are not launcher-visible. An invisible app carries policy but no
+     tile, so it is not a duplicate of anything and deleting it would change
+     access, not appearance.
+  4. Account-level app types that are not per-host tiles: app_launcher, warp,
+     biso, dash_sso.
+  5. Any host outside LAUNCHER_HOSTS — the exact `<key>.prod.fuzefront.com` set
+     derived from `local.launcher_services`. Nothing else in the account is even
+     considered.
+
+EFFECT ON ACCESS when a duplicate IS deleted: the host falls back to the
+wildcard `*.prod.fuzefront.com` email-OTP app that already covered it before the
+consumer's app existed. FuzeFront's runbook states its policy was written to
+mirror that wildcard's allowlist exactly, so effective access is unchanged — the
+tile goes away, the gate does not.
+
+Environment (all supplied by the null_resource in cloudflare.tf):
+  CF_API_TOKEN     Cloudflare API token — needs Account > Access: Apps and
+                   Policies > Edit (the same token that creates the bookmarks).
+  CF_ACCOUNT_ID    Cloudflare account id.
+  LAUNCHER_HOSTS   Comma-separated hostnames FuzeInfra publishes tiles for.
+  MANAGED_APP_IDS  Comma-separated Terraform-owned Access application ids.
+  KEEP_APP_IDS     Comma-separated ids to leave alone regardless.
+  PRUNE_DRY_RUN    Set to 1 to report what would be deleted without deleting.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from urllib.parse import urlsplit
+
+API = "https://api.cloudflare.com/client/v4"
+
+# Account-scoped app types that are not per-host launcher tiles. Deleting one of
+# these would break the launcher portal itself (app_launcher) or a device
+# posture integration, so they are never candidates however they are configured.
+NEVER_DELETE_TYPES = {"app_launcher", "warp", "biso", "dash_sso"}
+
+
+def env_set(name):
+    return {v.strip() for v in os.environ.get(name, "").split(",") if v.strip()}
+
+
+def api(method, path, token):
+    req = urllib.request.Request(
+        f"{API}{path}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {"success": False, "errors": [{"message": f"HTTP {exc.code}: {body}"}]}
+
+
+def hostname_of(domain):
+    """Access `domain` may be a bare host or a full URL with a path.
+
+    Bookmarks store `https://litellm.prod.fuzefront.com/ui`; self-hosted apps
+    store `unleash.prod.fuzefront.com`. Compare on the hostname alone, so a tile
+    is matched regardless of which shape the duplicate happens to use.
+    """
+    if not domain:
+        return ""
+    if "://" not in domain:
+        domain = f"//{domain}"
+    return (urlsplit(domain).hostname or "").lower()
+
+
+def list_apps(account_id, token):
+    apps, page = [], 1
+    while True:
+        result = api("GET", f"/accounts/{account_id}/access/apps?per_page=50&page={page}", token)
+        if not result.get("success"):
+            raise SystemExit(f"ERROR: listing Access apps failed: {result.get('errors')}")
+        batch = result.get("result") or []
+        apps.extend(batch)
+        info = result.get("result_info") or {}
+        # total_pages is absent on single-page accounts; a short batch also ends it.
+        if page >= info.get("total_pages", page) or not batch:
+            return apps
+        page += 1
+
+
+def main():
+    token = os.environ.get("CF_API_TOKEN", "")
+    account_id = os.environ.get("CF_ACCOUNT_ID", "")
+    if not token or not account_id:
+        raise SystemExit("ERROR: CF_API_TOKEN and CF_ACCOUNT_ID are required")
+
+    hosts = {h.lower() for h in env_set("LAUNCHER_HOSTS")}
+    protected = env_set("MANAGED_APP_IDS") | env_set("KEEP_APP_IDS")
+    dry_run = os.environ.get("PRUNE_DRY_RUN", "") == "1"
+
+    if not hosts:
+        print("No LAUNCHER_HOSTS supplied — nothing to reconcile.")
+        return 0
+
+    # Refuse to run without the Terraform-owned id list. An empty set here is
+    # indistinguishable from "Terraform owns nothing", and would make the
+    # bookmarks themselves candidates for deletion — the launcher would prune
+    # itself. Better to fail the apply than to erase every tile.
+    if not env_set("MANAGED_APP_IDS"):
+        raise SystemExit("ERROR: MANAGED_APP_IDS is empty — refusing to run (would prune FuzeInfra's own tiles)")
+
+    apps = list_apps(account_id, token)
+    print(f"Scanned {len(apps)} Access application(s) across {len(hosts)} launcher host(s).")
+
+    failures = 0
+    deleted = 0
+    for app in apps:
+        app_id = app.get("id", "")
+        if app_id in protected:
+            continue
+        if not app.get("app_launcher_visible"):
+            continue
+        if app.get("type") in NEVER_DELETE_TYPES:
+            continue
+        host = hostname_of(app.get("domain", ""))
+        if host not in hosts:
+            continue
+
+        label = f"{app.get('name', '?')!r} (id {app_id}, type {app.get('type')}, host {host})"
+        if dry_run:
+            print(f"  WOULD DELETE duplicate tile {label}")
+            continue
+
+        result = api("DELETE", f"/accounts/{account_id}/access/apps/{app_id}", token)
+        if result.get("success"):
+            print(f"  deleted duplicate tile {label}")
+            deleted += 1
+        else:
+            # A 404 means someone already removed it — that is the desired end
+            # state, not an error worth failing the apply over.
+            errors = result.get("errors") or []
+            if any(e.get("code") == 12109 or "not found" in str(e.get("message", "")).lower() for e in errors):
+                print(f"  already gone {label}")
+                continue
+            print(f"  FAILED to delete {label}: {errors}", file=sys.stderr)
+            failures += 1
+
+    if not deleted and not failures:
+        print("No duplicate launcher tiles found — nothing to do.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two launcher-facing defects reported together.

### 1. Unleash and Authentik each appear twice on the App Launcher

One tile has the right logo, the other has none. The logo-less one is a `type = "self_hosted"` Access application a consumer repo created **out-of-band via the Cloudflare API**, with `app_launcher_visible: true` and no `logo_url`. izzywdev/FuzeFront's own runbook (`docs/runbooks/unleash-launcher-and-developer-flags.md`) records doing exactly that for `unleash.prod.fuzefront.com` — app `514f8a21-3793-4726-858e-819556fbe346`. FuzeInfra's tiles are `type = "bookmark"` apps carrying a `logo_url`, so the two render side by side.

Terraform cannot destroy what it never created and what is not in state, and importing each duplicate by hand needs an app id nobody has until they go looking. So the deletion is expressed as a reconciler that **discovers** them: any launcher-visible Access app on a host `local.launcher_services` already publishes a tile for, whose id Terraform does not own, is a duplicate by definition. It runs from a `null_resource` at apply time.

Safety envelope, in order — it will never touch:

1. an id in `local.terraform_owned_access_app_ids` (every Access app this root module owns, so the bookmarks can never prune themselves);
2. an id in `var.launcher_tile_prune_keep_ids` (operator escape hatch);
3. a non-launcher-visible app — policy without a tile is not a duplicate, and deleting it would change access rather than appearance;
4. account-level types `app_launcher` / `warp` / `biso` / `dash_sso`;
5. any host outside the exact `<key>.prod.fuzefront.com` launcher set.

It also **refuses to run** if the owned-id list arrives empty, which is otherwise indistinguishable from "Terraform owns nothing" and would erase every tile.

Triggers are content-hashed rather than time-based on purpose: a `timestamp()` trigger would make every plan non-empty and permanently trip the drift gate in `terraform-plan-apply.yml`.

**Access is unchanged.** Deleting a duplicate returns the host to the wildcard `*.prod.fuzefront.com` email-OTP app that covered it before the consumer's app existed — and FuzeFront's runbook states its policy was written to mirror that allowlist exactly.

### 2. LiteLLM UI shows "Loading" and then Cloudflare error 522

Not a routing fault. Verified against prod with the read-only `cluster-query` workflow:

- pod `Running` `1/1`, `endpoints/litellm 10.42.16.178:4000`
- `ingress.networking.k8s.io/litellm` present, host `litellm.prod.fuzefront.com`
- the edge correctly 302s to CF Access (`cf-access-domain: *.prod.fuzefront.com`)
- the origin serves the **entire console bundle 200** through Traefik — every `/litellm-asset-prefix/_next/static/*` chunk, `/litellm/.well-known/litellm-ui-config`, `/get_favicon`, `/get_image`
- Traefik logs no backend error

…and then the origin log simply **stops**. That is the signature: uvicorn writes its access-log line when a response is *sent*, so a request that hangs forever leaves no trace at all.

The hang is the console's first session call. LiteLLM's admin UI mints a UI session key on boot, and key generation is a database write; with no `DATABASE_URL` it never completes, the page sits on "Loading", and Cloudflare gives up on the origin with 522. Upstream confirms the UI requires Postgres ([docs](https://docs.litellm.ai/docs/proxy/ui), [BerriAI/litellm#30328](https://github.com/BerriAI/litellm/issues/30328)).

The gateway's *proxying* path is stateless, which is why it ran fine for weeks and only the UI was broken — and why `/ui` returning 200 was mistaken for "the UI works" when the tile was added in #460.

**Fix:** a dedicated `litellm` database on the shared `fuzeinfra-postgres`, created idempotently by an `ensure-database` initContainer (prisma connects to a database, it does not create one), with `DATABASE_URL` built from `fuzeinfra-secrets` exactly the way `helm/fuzeinfra/templates/airflow.yaml` does. LiteLLM lives in the `fuzeinfra` namespace alongside that Secret, so no SealedSecret has to be minted and no credential is committed. Gated behind `database.enabled`, off in the base and local overlays.

Two trade-offs, both documented at the call site:

- Those are the Postgres **superuser** credentials. Airflow already connects this way so this is no worse than the status quo, but the better end state is a dedicated `litellm_svc` role via `serviceDatabases` — that needs a sealed password and is a values-only change later, no template change.
- LiteLLM runs `prisma migrate deploy` at startup once `DATABASE_URL` is set, so cold starts lengthen and a migration failure would CrashLoop a gateway FuzeFront's chat-service depends on. The existing 10-minute `startupProbe` covers the extra time, and `database.enabled: false` reverts in one commit.

UI login is `admin` + the `LITELLM_MASTER_KEY` value (LiteLLM's fallback when `UI_USERNAME`/`UI_PASSWORD` are unset), so no new credential is introduced.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Chore / CI / refactor

## Checklist

- [ ] Branch named `feat/…`, `fix/…`, or `chore/…` — the branch name is session-assigned (`claude/cloudflare-launcher-duplicates-litellm-a0yort`), commits follow the convention
- [x] Conventional commit messages
- [ ] Commits are **signed** (verified) — signing is not available from this environment
- [x] Tests added/updated where relevant — see Verification below
- [ ] **Harden Gate** checks pass (`lint`, `test`, `build`, `sast`, `secret-scan`, `dependency-scan`) — pending CI
- [ ] Conversations resolved and ready for code-owner review

### Verification performed

- `helm lint helm/litellm` clean on `values-local.yaml` and `values-contabo.yaml`.
- `kubeconform -strict -kubernetes-version 1.29.0 -ignore-missing-schemas`: 3/3 valid (local), 5/5 valid (contabo).
- Rendered `DATABASE_URL` is declared **after** `POSTGRES_USER`/`POSTGRES_PASSWORD` — Kubernetes only expands `$(VAR)` for variables defined earlier in the list, so the ordering is load-bearing and was checked in the rendered output.
- The reconciler's decision path was exercised against a stubbed Cloudflare API over a 9-application fixture: it deletes exactly the two duplicates and spares Terraform-owned bookmarks, the wildcard OTP app, the launcher portal, keep-list ids, non-visible apps and unowned hosts. The empty-`MANAGED_APP_IDS` guard was verified to abort.
- Prod state was **read, never modified** — no `kubectl apply/patch/edit`, consistent with the GitOps invariant.

**Note on merging:** the `terraform plan` check will go red. The drift gate fails on any non-empty plan by design, and this PR intentionally adds resources; the saved plan is exactly what merging applies.

## Related issues

Follow-up to #460, which added the LiteLLM tile and Ingress. The duplicate tiles originate in izzywdev/FuzeFront's out-of-band Access app — that repo's runbook should be updated to stop creating launcher-visible apps for hosts FuzeInfra already publishes tiles for.