### PR TITLE
feat(ci): route the a2a-maintainer through LiteLLM instead of a provider key

### DIFF
--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -143,25 +143,36 @@ jobs:
           LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
         run: |
           set -uo pipefail
+          # NO `|| echo 000` here: curl's own -w already emits 000 when it never got
+          # an HTTP response, so appending another produced the literal code "000000",
+          # which matched no branch below and buried the real diagnosis in the generic
+          # arm. `|| true` keeps `bash -e` from killing the step on curl's exit code.
           code=$(curl -sS -o /tmp/preflight.json -w '%{http_code}' --max-time 30 \
             -X POST "${ANTHROPIC_BASE_URL}/v1/messages" \
             -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
             -H "anthropic-version: 2023-06-01" \
             -H "content-type: application/json" \
             -d "{\"model\":\"${ANTHROPIC_MODEL}\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
-            || echo "000")
+            2>/tmp/preflight.err) || true
+          [ -z "${code:-}" ] && code="000"
           err=$(jq -r '.error.message // .message // empty' /tmp/preflight.json 2>/dev/null || true)
+          # curl's stderr is the ONLY thing that distinguishes the transport failures
+          # from each other — "Could not resolve host" (cluster DNS), "Connection
+          # timed out" (NetworkPolicy drop) and "Connection refused" (nothing
+          # listening) all arrive as code 000 and need completely different fixes.
+          transport=$(tr -d '\r' < /tmp/preflight.err 2>/dev/null | grep -v '^$' | tail -1 || true)
+          echo "curl exit detail: ${transport:-<none>} (http_code=$code)"
           [ -z "$err" ] && err="HTTP $code"
           case "$code" in
             200)
               echo "ok=true" >> "$GITHUB_OUTPUT"
               echo "LiteLLM gateway preflight OK (model ${ANTHROPIC_MODEL})" ;;
             000)
-              # No TCP answer: NetworkPolicy does not admit arc-runners, the gateway is
-              # down, or its Service DNS changed. Distinguished from an HTTP error
-              # because the fix is completely different.
+              # No HTTP response at all. `transport` says which of three unrelated
+              # faults it was, so the reason names the actual fix instead of listing
+              # every possibility.
               echo "ok=false" >> "$GITHUB_OUTPUT"
-              echo "reason=LiteLLM gateway unreachable at ${ANTHROPIC_BASE_URL} (no response). Check the pod is Running and that arc-runners is on networkPolicy.allowedNamespaces." >> "$GITHUB_OUTPUT" ;;
+              echo "reason=LiteLLM gateway unreachable at ${ANTHROPIC_BASE_URL} — ${transport:-no detail from curl}. Resolve-host errors mean cluster DNS from arc-runners; timeouts mean the NetworkPolicy is dropping us (arc-runners must be on networkPolicy.allowedNamespaces); connection-refused means the pod is not serving." >> "$GITHUB_OUTPUT" ;;
             401|403)
               echo "ok=false" >> "$GITHUB_OUTPUT"
               echo "reason=LiteLLM rejected LITELLM_MASTER_KEY (HTTP $code): $err. The secret and the gateway's sealed key have drifted — they rotate together." >> "$GITHUB_OUTPUT" ;;

--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -8,21 +8,36 @@ name: A2A Maintain
 # can't (fork PR / first-time build), it opens a separate `auto-merge`-labelled follow-up
 # PR. It never fabricates a role's product behaviour, never handles creds, never deploys.
 #
-# Requires repo secret ANTHROPIC_API_KEY. No key -> SKIPS (never red). The `a2a-maintainer`
-# agent def is stamped by sdlc-bootstrap into .claude/agents/ and reconciled by
-# governance-sync; this workflow just invokes it.
+# PROVIDER-INDEPENDENT BY CONSTRUCTION. This workflow holds NO provider key. It talks
+# only to the shared LiteLLM gateway (docs/consuming-repos/LITELLM_GATEWAY.md) with
+# LITELLM_MASTER_KEY, and the gateway owns model routing, key custody and cross-provider
+# failover: `routerSettings.fallbacks` in helm/litellm/values.yaml retries the SAME
+# request against OpenAI, then Gemini, and returns a normal 200. The failover is a
+# LiteLLM Router feature — there is deliberately no fallback logic here, because a
+# client that implements its own failover has to hold every provider's key, which is
+# the coupling the gateway exists to remove.
 #
-# A KEY THE API DEFINITIVELY REJECTS (no credit / revoked / model not entitled) is
-# treated the SAME as no key: warn loudly, skip, stay green. That is not leniency —
-# it is what this check went silently non-functional for a day teaching us. On
-# 2026-07-29 the Anthropic account ran out of credit; the action's wrapper swallowed
-# the API error and reported only `is_error:true, num_turns:1, $0`, so every PR in the
-# repo carried a red `a2a-maintain` whose log said nothing actionable. A permanent red
-# that no PR author can fix is indistinguishable from a broken check and trains people
-# to ignore it — including on the day it goes red for a REAL A2A drift. So: an
-# account-level outage is a loud WARNING (annotation + job summary), a genuine agent
-# failure is still RED, and the real error text is always surfaced (see the preflight
-# and the "Surface the real result" step below) instead of being swallowed.
+# WHY: on 2026-07-29 the Anthropic account ran out of credit and every Claude-driven
+# workflow in the repo died on its first API call. The action's wrapper swallowed the
+# error and reported only `is_error:true, num_turns:1, $0`, so `a2a-maintain` went red
+# on every PR for a day with a log that said nothing actionable. One provider's billing
+# lapse should not be able to do that.
+#
+# Requires repo secret LITELLM_MASTER_KEY. No key, or an unreachable gateway -> SKIPS
+# (never red): none of that is the PR author's fault, and a permanent red nobody can
+# clear is indistinguishable from a broken check — it trains people to ignore it,
+# including on the day it goes red for REAL A2A drift. A genuine agent failure is still
+# RED, with the real error text surfaced (see "Surface the real result" below).
+#
+# The `a2a-maintainer` agent def is stamped by sdlc-bootstrap into .claude/agents/ and
+# reconciled by governance-sync; this workflow just invokes it.
+#
+# RUNNER: `staging` (in-cluster ARC pods, namespace arc-runners) — NOT ubuntu-latest.
+# The gateway is ClusterIP-only with a NetworkPolicy and holds live provider keys; it is
+# unreachable from a hosted runner by design, and it should stay that way. Reaching it
+# from inside the cluster is what avoids punching a hole for CI. `arc-runners` is on the
+# gateway's networkPolicy.allowedNamespaces (helm/litellm/values-contabo.yaml) — remove
+# it there and this job's preflight starts timing out.
 
 on:
   pull_request:
@@ -37,20 +52,57 @@ concurrency:
   group: a2a-maintain-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  # Everything below is gateway addressing — no provider key, no provider hostname.
+  #
+  # Claude Code speaks the Anthropic Messages format to whatever ANTHROPIC_BASE_URL
+  # points at; LiteLLM serves that format at /v1/messages and bridges it to whichever
+  # provider the router picks. In-cluster service DNS, plain HTTP — pod network only.
+  ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
+
+  # Pin EVERY alias to a name the gateway actually serves (`models[].name` in
+  # helm/litellm/values.yaml). Unpinned, Claude Code picks its own built-in IDs and the
+  # gateway 400s on a model it has never heard of — that is exactly what the original
+  # failing run did, requesting `claude-opus-5[1m]` (the `[1m]` suffix is the
+  # extended-context marker, not a model the gateway lists). DISABLE_1M_CONTEXT stops
+  # the suffix being appended at all. tests/test_litellm_ci_routing.py asserts every
+  # name here still exists in the gateway's model list.
+  ANTHROPIC_MODEL: claude-opus-5
+  ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-5
+  ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-5
+  # Also serves background functionality, so an unpinned value 400s mid-run rather
+  # than at startup — the most annoying way to discover a bad model name.
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5
+  CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"
+
+  # Pre-release capabilities (context_management, beta tool schema fields) are sent to
+  # Anthropic-format endpoints and rejected with `Extra inputs are not permitted` by a
+  # non-Anthropic upstream. Suppressing them client-side is what lets a fallback hop to
+  # OpenAI/Gemini actually complete instead of 400ing the moment Anthropic is down.
+  CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+  # Version checks, telemetry and auto-update go direct to Anthropic, not through the
+  # gateway. The action installs a pinned CLI per run, so there is nothing to update.
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+
 jobs:
   a2a-maintain:
-    # Loop guard: never run on our own maintenance branches.
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'a2a-maintain/') }}
-    runs-on: ubuntu-latest
+    # Loop guard: never run on our own maintenance branches. Same-repo guard: this job
+    # runs an agent with Bash on an IN-CLUSTER runner, so it must never execute code
+    # checked out from a fork. It already could not push to a fork branch (the prompt
+    # falls back to opening a follow-up PR), so the only thing lost is A2A upkeep on
+    # fork PRs — cheap next to handing a fork arbitrary execution inside the cluster.
+    if: >-
+      ${{ !startsWith(github.event.pull_request.head.ref, 'a2a-maintain/')
+          && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: staging
     steps:
-      - name: Skip if key absent or repo not onboarded
+      - name: Skip if gateway key absent
         id: guard
         env:
-          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          KEY: ${{ secrets.LITELLM_MASTER_KEY }}
         run: |
-          if [ ! -f .fuze/manifest.json ] 2>/dev/null; then :; fi
           if [ -z "$KEY" ]; then
-            echo "::notice::ANTHROPIC_API_KEY not set — A2A maintain skipped (set it to enable)."
+            echo "::notice::LITELLM_MASTER_KEY not set — A2A maintain skipped (set it to enable)."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -75,40 +127,52 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Is the key actually usable? One 1-token live call. This is an ACCOUNT-level
-      # liveness probe (key valid + credit available), not a model-entitlement probe:
-      # the model the action itself runs is its own default, not this one. Haiku is
-      # the cheapest rung of governance/model-registry.md and exercises the same
-      # auth/credit path, which is the failure class that actually bites here.
-      # Transient conditions (429/5xx/timeout) do NOT stop the run — the action has
-      # its own retries; only definitive rejections do.
-      - name: Preflight — Anthropic key valid & funded
+      # Prove the WHOLE path before spending a run on it: gateway reachable through the
+      # NetworkPolicy, master key accepted, /v1/messages served, and the pinned model
+      # resolvable — including via fallback. A 200 here when Anthropic is dead is the
+      # gateway doing its job; that is the entire point of the exercise, so unlike the
+      # old direct-to-Anthropic preflight this one says nothing about any one provider.
+      #
+      # Any failure is a SKIP, not a red: an unreachable gateway, a revoked master key
+      # and a fallback chain that is exhausted are all operator problems, none of them
+      # fixable by the PR this is running on.
+      - name: Preflight — gateway reachable & serving the pinned model
         id: preflight
         if: steps.guard.outputs.ok == 'true' && steps.marker.outputs.run == 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
         run: |
           set -uo pipefail
-          code=$(curl -sS -o /tmp/preflight.json -w '%{http_code}' --max-time 20 \
-            -X POST https://api.anthropic.com/v1/messages \
-            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+          code=$(curl -sS -o /tmp/preflight.json -w '%{http_code}' --max-time 30 \
+            -X POST "${ANTHROPIC_BASE_URL}/v1/messages" \
+            -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
             -H "anthropic-version: 2023-06-01" \
             -H "content-type: application/json" \
-            -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}' \
+            -d "{\"model\":\"${ANTHROPIC_MODEL}\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
             || echo "000")
-          err=$(jq -r '.error.message // empty' /tmp/preflight.json 2>/dev/null || true)
+          err=$(jq -r '.error.message // .message // empty' /tmp/preflight.json 2>/dev/null || true)
+          [ -z "$err" ] && err="HTTP $code"
           case "$code" in
             200)
               echo "ok=true" >> "$GITHUB_OUTPUT"
-              echo "Anthropic preflight OK" ;;
-            400|401|402|403)
-              # Deterministic and repo-unfixable: bad key, no credit, or no model access.
-              [ -z "$err" ] && err="HTTP $code"
+              echo "LiteLLM gateway preflight OK (model ${ANTHROPIC_MODEL})" ;;
+            000)
+              # No TCP answer: NetworkPolicy does not admit arc-runners, the gateway is
+              # down, or its Service DNS changed. Distinguished from an HTTP error
+              # because the fix is completely different.
               echo "ok=false" >> "$GITHUB_OUTPUT"
-              echo "reason=Anthropic API rejected the key (HTTP $code): $err" >> "$GITHUB_OUTPUT" ;;
+              echo "reason=LiteLLM gateway unreachable at ${ANTHROPIC_BASE_URL} (no response). Check the pod is Running and that arc-runners is on networkPolicy.allowedNamespaces." >> "$GITHUB_OUTPUT" ;;
+            401|403)
+              echo "ok=false" >> "$GITHUB_OUTPUT"
+              echo "reason=LiteLLM rejected LITELLM_MASTER_KEY (HTTP $code): $err. The secret and the gateway's sealed key have drifted — they rotate together." >> "$GITHUB_OUTPUT" ;;
+            404)
+              echo "ok=false" >> "$GITHUB_OUTPUT"
+              echo "reason=Gateway did not serve /v1/messages (HTTP 404): $err. Claude Code speaks the Anthropic Messages format; this LiteLLM build must expose that endpoint." >> "$GITHUB_OUTPUT" ;;
             *)
-              echo "ok=true" >> "$GITHUB_OUTPUT"
-              echo "::warning::Anthropic preflight inconclusive (HTTP $code) — proceeding; the action retries on its own." ;;
+              # Includes 400 (model not in the gateway's list) and 5xx (every fallback
+              # hop exhausted — i.e. all three providers failed).
+              echo "ok=false" >> "$GITHUB_OUTPUT"
+              echo "reason=Gateway could not serve ${ANTHROPIC_MODEL} (HTTP $code): $err" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Run a2a-maintainer
@@ -119,8 +183,16 @@ jobs:
         # which the action itself cannot.
         continue-on-error: true
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1
+        env:
+          # LiteLLM authenticates `Authorization: Bearer`, so the key has to travel in
+          # ANTHROPIC_AUTH_TOKEN — the action does not read that variable itself, which
+          # is why the same secret is ALSO passed as the input below: the input exists
+          # purely to satisfy the action's "some credential is configured" launch check,
+          # and the copy it puts in x-api-key is ignored. Dropping either one breaks the
+          # run, in two different and equally confusing ways.
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_MASTER_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LITELLM_MASTER_KEY }}
           prompt: |
             You are the **a2a-maintainer** for this repo (follow `.claude/agents/a2a-maintainer.md`
             exactly — same scope, boundaries, and done-contract). This is an automated CI run on
@@ -186,7 +258,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      # The verdict. Account-level outage -> loud warning, green. Real agent failure
+      # The verdict. Gateway-level outage -> loud warning, green. Real agent failure
       # -> red, with the surfaced message.
       - name: Verdict
         if: always() && steps.guard.outputs.ok == 'true' && steps.marker.outputs.run == 'true'
@@ -199,15 +271,20 @@ jobs:
         run: |
           set -uo pipefail
           if [ "${PREFLIGHT_OK:-}" != "true" ]; then
-            echo "::warning::A2A maintain SKIPPED — ${PREFLIGHT_REASON}. A2A drift is NOT being checked on this PR until the Anthropic account is repaired."
+            echo "::warning::A2A maintain SKIPPED — ${PREFLIGHT_REASON}. A2A drift is NOT being checked on this PR until the LiteLLM gateway is reachable again."
             {
-              echo "### ⚠️ A2A maintain skipped — Anthropic key unusable"
+              echo "### ⚠️ A2A maintain skipped — LiteLLM gateway unusable"
               echo ""
               echo "\`${PREFLIGHT_REASON}\`"
               echo ""
-              echo "This is an **account-level** problem, not a problem with this PR — nothing you"
-              echo "can change here will clear it. An operator must repair/fund the \`ANTHROPIC_API_KEY\`"
-              echo "secret's account; the check resumes on the next PR event with no further action."
+              echo "This is an **infrastructure** problem, not a problem with this PR — nothing you"
+              echo "can change here will clear it. The reason above names the specific fix; see"
+              echo "\`docs/consuming-repos/LITELLM_GATEWAY.md\`. The check resumes on the next PR"
+              echo "event with no further action."
+              echo ""
+              echo "Note this is **not** a single-provider outage: the gateway fails over Anthropic →"
+              echo "OpenAI → Gemini on its own, so reaching this message means the gateway itself is"
+              echo "unreachable or every hop was exhausted."
               echo ""
               echo "**Until then the repo's A2A surface is not being checked for drift.**"
             } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/infrastructure-tests.yml
+++ b/.github/workflows/infrastructure-tests.yml
@@ -79,7 +79,8 @@ jobs:
           tests/test_local_overlay_installable.py \
           tests/test_chroma_helm_security.py \
           tests/test_fuzequality_provisioning.py \
-          tests/test_a2a_surface.py
+          tests/test_a2a_surface.py \
+          tests/test_litellm_ci_routing.py
 
     - name: Install Docker Compose
       run: |

--- a/docs/consuming-repos/LITELLM_GATEWAY.md
+++ b/docs/consuming-repos/LITELLM_GATEWAY.md
@@ -16,15 +16,23 @@ Chart: `helm/litellm` · Argo app: `argocd/applications/litellm.yaml` · namespa
 | **Port** | `4000` |
 | **Base URL** | `http://litellm.fuzeinfra.svc.cluster.local:4000` |
 | **Auth** | `Authorization: Bearer $LITELLM_MASTER_KEY` |
-| **Protocol** | OpenAI-compatible. `POST /chat/completions` (streaming + non-streaming) and `POST /embeddings`. The `/v1`-prefixed forms work too. |
+| **Protocol** | OpenAI-compatible. `POST /chat/completions` (streaming + non-streaming) and `POST /embeddings`. The `/v1`-prefixed forms work too. Anthropic-format clients use `POST /v1/messages` — see [Anthropic-format clients](#anthropic-format-clients-claude-code) below. |
 
-Plain HTTP, no TLS — this is cluster-internal traffic on the pod network. There
-is **no Ingress, no Cloudflare tunnel route, and no CF Access app**: the gateway
-holds live provider keys and is unreachable from outside the cluster by
-construction. A NetworkPolicy further restricts it to namespaces listed in
+Plain HTTP, no TLS — this is cluster-internal traffic on the pod network. A
+NetworkPolicy restricts it to the namespaces listed in
 `networkPolicy.allowedNamespaces` (`helm/litellm/values-contabo.yaml`) — if your
 service gets a connection timeout rather than a 401, your namespace is not on
 that list yet. Add it in a PR.
+
+> **Correction (2026-07-29).** This section previously said there was "no Ingress,
+> no Cloudflare tunnel route, and no CF Access app". That has not been true since
+> the admin UI was enabled: `values-contabo.yaml` sets `ingress.enabled: true`, so
+> the gateway is reachable at `https://litellm.prod.fuzefront.com` under the
+> `*.prod` wildcard — and because LiteLLM serves the UI and the API from one port,
+> `/chat/completions` and `/v1/messages` are exposed at that hostname too. The
+> gates are Cloudflare Access email-OTP plus `LITELLM_MASTER_KEY` on every API
+> call. In-cluster callers should still use the Service DNS above: it is the path
+> the NetworkPolicy is written for, and it avoids a tunnel round-trip.
 
 ## Models
 
@@ -36,11 +44,35 @@ Ask for these **by name**; the gateway maps each to a real upstream model.
 | `claude-opus-5` | `anthropic/claude-opus-5` | Chat. **Current default choice.** |
 | `claude-sonnet-5` | `anthropic/claude-sonnet-5` | Chat, cheaper/faster. |
 | `claude-haiku-4-5` | `anthropic/claude-haiku-4-5` | Cheap, latency-sensitive. |
+| `gpt-4.1` / `gpt-4.1-mini` | `openai/…` | Chat. Directly requestable, but their real job is being fallback targets. |
+| `gemini-2.5-pro` / `-flash` / `-flash-lite`, `gemini-2.0-flash` / `-lite` | `gemini/…` | Chat. Last fallback hop. |
 | `text-embedding-3-small` | `openai/text-embedding-3-small` | Embeddings. |
 
 Adding a model is a PR against `models:` in `helm/litellm/values.yaml`. That
 indirection is the point of running a gateway — do not work around it by calling
 a provider directly.
+
+### Cross-provider fallback — you do not implement this
+
+Ask for a Claude model and you get one, unless that provider is failing, in which
+case the router silently retries the **same request** against the next model and
+returns a normal 200. You never see the upstream failure and you write no failover
+code — a client that implements its own would have to hold every provider's key,
+which is exactly what the gateway exists to prevent.
+
+The chain is tier-matched, so an outage never quietly upgrades or downgrades what
+you get (`routerSettings.fallbacks`):
+
+| Primary | then | then |
+|---|---|---|
+| `claude-opus-5`, `claude-opus-4-5` | `gpt-4.1` | `gemini-2.5-pro` |
+| `claude-sonnet-5` | `gpt-4.1` | `gemini-2.5-flash` |
+| `claude-haiku-4-5` | `gpt-4.1-mini` | `gemini-2.5-flash-lite` |
+
+Hops stop at the first success, so a dead last hop costs nothing — Gemini is
+currently quota-exhausted and that is fine. This exists because on 2026-07-29 the
+Anthropic account's credit ran out and took every chat turn down while the gateway
+itself was perfectly healthy.
 
 > **`/embeddings` needs an OpenAI key on the gateway.** Anthropic ships no
 > embeddings endpoint, so embeddings cannot be served by an Anthropic key alone.
@@ -94,6 +126,51 @@ kubectl -n fuzeinfra port-forward svc/litellm 4000:4000
 ```bash
 curl -s localhost:4000/v1/models -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.data[].id'
 ```
+
+## Anthropic-format clients (Claude Code)
+
+Claude Code speaks the **Anthropic Messages** format, not OpenAI's, so it does not
+use `/chat/completions`. Point it at the gateway and it calls `POST /v1/messages`;
+LiteLLM bridges that to whichever provider the router picks.
+
+`.github/workflows/a2a-maintain.yml` is the worked example — a CI agent that holds
+**no provider key at all**:
+
+```yaml
+env:
+  ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
+  ANTHROPIC_MODEL: claude-opus-5           # must be a name in `models:` below
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5
+  CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"
+  CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+
+steps:
+  - uses: anthropics/claude-code-action@<sha>
+    env:
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_MASTER_KEY }}
+    with:
+      anthropic_api_key: ${{ secrets.LITELLM_MASTER_KEY }}
+```
+
+Four things that are easy to get wrong:
+
+- **Pass the key twice.** LiteLLM reads `Authorization: Bearer`, which only
+  `ANTHROPIC_AUTH_TOKEN` sets — but the action refuses to launch without its
+  `anthropic_api_key` input, and that copy (sent as `x-api-key`) is ignored. Omit
+  either and it fails, in two different confusing ways.
+- **Pin every model alias.** Unpinned, Claude Code uses its own built-in IDs and the
+  gateway 400s on a name it has never heard of. The original outage requested
+  `claude-opus-5[1m]` — the `[1m]` is the extended-context marker, not a model here.
+- **The job must run in-cluster** (`runs-on: staging`). A hosted runner cannot reach
+  a ClusterIP Service; `arc-runners` is on the NetworkPolicy allowlist for this.
+- **Set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`.** Pre-release fields
+  (`context_management`, beta tool schema fields) are rejected by a non-Anthropic
+  upstream, so leaving them on breaks the fallback hop specifically.
+
+Anthropic [does not support routing Claude Code to non-Claude models through a
+gateway](https://code.claude.com/docs/en/llm-gateway). The fallback hops here are
+configured to work anyway — see `additional_drop_params` in `values.yaml` — but
+treat a fallback-served agent run as best-effort, not a supported configuration.
 
 ## Gotchas
 

--- a/helm/litellm/values-contabo.yaml
+++ b/helm/litellm/values-contabo.yaml
@@ -45,6 +45,13 @@ networkPolicy:
     # FuzeFront chat-service + doc indexer (LITELLM_URL, and the indexer's
     # /embeddings calls).
     - fuzefront
+    # ARC self-hosted runner pods (`runs-on: staging`). CI agents talk to the
+    # gateway instead of holding a provider key: .github/workflows/a2a-maintain.yml
+    # points ANTHROPIC_BASE_URL at this Service. Reaching the gateway from INSIDE
+    # the cluster is what lets it stay ClusterIP-only — the alternative was a
+    # Cloudflare Access service token fronting a service that holds live provider
+    # keys. Remove this and a2a-maintain's preflight times out (and says so).
+    - arc-runners
     # kube-system (Traefik) is appended automatically by the template because
     # ingress.enabled is true below — do not add it here as well.
 

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -109,12 +109,36 @@ models:
   #
   # Model IDs verified against the live key's own /v1/models listing, not
   # assumed: this key exposes gpt-4.1 / gpt-4o but NOT gpt-5.
+  #
+  # `additional_drop_params` on every NON-Anthropic model below is what makes the
+  # fallback usable by Anthropic-format callers — chiefly Claude Code, which reaches
+  # the gateway via /v1/messages (ANTHROPIC_BASE_URL) rather than /chat/completions.
+  # Such a caller sends Anthropic-only body fields; when the router falls through to
+  # OpenAI or Gemini, LiteLLM bridges the request and the upstream rejects them with
+  # `Extra inputs are not permitted`. Dropping them turns a hard 400 on hop 2 into a
+  # served answer — the difference between a fallback chain that exists and one that
+  # works.
+  #
+  #   thinking            — Claude Code sends {"type":"adaptive"} on 4.6+ models, AND
+  #                         on any model name it does not recognise, which includes
+  #                         every gateway alias here. Not suppressible client-side.
+  #   context_management  — context-editing beta.
+  #   output_config       — effort / structured-output / task-budget settings.
+  #
+  # Deliberately scoped PER MODEL, not global: `litellm_settings` would strip these
+  # from the Anthropic primary too, silently downgrading normal operation to buy
+  # nothing. The primary path keeps full fidelity; only the hops that cannot accept
+  # these fields discard them.
   - name: gpt-4.1
     provider: openai/gpt-4.1
     keyEnv: OPENAI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   - name: gpt-4.1-mini
     provider: openai/gpt-4.1-mini
     keyEnv: OPENAI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   # --- Gemini ------------------------------------------------------------------
   # ALL of these are currently NON-FUNCTIONAL: the key returns "You exceeded your
   # current quota" (free tier exhausted). Wired anyway so they start working the
@@ -127,18 +151,28 @@ models:
   - name: gemini-2.5-pro
     provider: gemini/gemini-2.5-pro
     keyEnv: GEMINI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   - name: gemini-2.5-flash
     provider: gemini/gemini-2.5-flash
     keyEnv: GEMINI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   - name: gemini-2.5-flash-lite
     provider: gemini/gemini-2.5-flash-lite
     keyEnv: GEMINI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   - name: gemini-2.0-flash
     provider: gemini/gemini-2.0-flash
     keyEnv: GEMINI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   - name: gemini-2.0-flash-lite
     provider: gemini/gemini-2.0-flash-lite
     keyEnv: GEMINI_API_KEY
+    extraParams:
+      additional_drop_params: ["thinking", "context_management", "output_config"]
   # --- embeddings -------------------------------------------------------------
   # FuzeFront's LITELLM_EMBEDDING_MODEL default. OpenAI, not Anthropic —
   # Anthropic ships no embeddings endpoint, so /embeddings cannot be served by

--- a/tests/test_litellm_ci_routing.py
+++ b/tests/test_litellm_ci_routing.py
@@ -1,0 +1,179 @@
+"""Static invariants for CI agents routed through the LiteLLM gateway.
+
+The Claude-driven workflows hold no provider key: they point `ANTHROPIC_BASE_URL` at
+`litellm.fuzeinfra.svc.cluster.local:4000` and let the gateway own routing, key custody
+and cross-provider failover. That buys provider independence, and it introduces one
+coupling worth guarding: **the model names the workflow pins must be names the gateway
+actually serves.**
+
+That coupling is not theoretical. The original outage ran with no pinning at all, and
+Claude Code asked for `claude-opus-5[1m]` — the extended-context marker appended to the
+model ID, which no gateway model list contains. Against the gateway that is a 400 on the
+first call. A model rename in `helm/litellm/values.yaml` breaks CI the same way, and
+neither side's tests would otherwise notice: the chart lints fine, the workflow lints
+fine, and the failure only appears at runtime.
+
+Offline: reads two files, no cluster, no network.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github/workflows/a2a-maintain.yml"
+GATEWAY_VALUES = ROOT / "helm/litellm/values.yaml"
+GATEWAY_PROD_VALUES = ROOT / "helm/litellm/values-contabo.yaml"
+
+# Env vars in the workflow whose value must be a model the gateway serves.
+MODEL_VARS = (
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
+
+# Anthropic-only body fields a non-Anthropic upstream rejects with
+# "Extra inputs are not permitted" when the router falls through to it.
+REQUIRED_DROPS = {"thinking", "context_management", "output_config"}
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _gateway_models() -> list[dict]:
+    return yaml.safe_load(GATEWAY_VALUES.read_text())["models"]
+
+
+def _model_names() -> set[str]:
+    return {m["name"] for m in _gateway_models()}
+
+
+def test_workflow_holds_no_provider_key():
+    """The point of the gateway: CI holds a gateway credential, never a provider key."""
+    raw = WORKFLOW.read_text()
+    assert "secrets.LITELLM_MASTER_KEY" in raw
+    assert "secrets.ANTHROPIC_API_KEY" not in raw, (
+        "the workflow is back to holding a provider key directly, which defeats the "
+        "gateway's key custody and re-couples CI to a single provider's billing"
+    )
+    assert "api.anthropic.com" not in raw, "CI must reach providers only via the gateway"
+
+
+def test_base_url_points_at_the_in_cluster_gateway():
+    env = _workflow()["env"]
+    assert env["ANTHROPIC_BASE_URL"] == "http://litellm.fuzeinfra.svc.cluster.local:4000"
+
+
+def test_job_runs_on_the_in_cluster_runner():
+    """A hosted runner cannot reach a ClusterIP gateway; the job must run in-cluster."""
+    job = _workflow()["jobs"]["a2a-maintain"]
+    assert job["runs-on"] == "staging", (
+        "the gateway is ClusterIP-only with a NetworkPolicy — from ubuntu-latest every "
+        "request times out. `staging` is the ARC scale-set name (a bare string, not a "
+        "label; see runners/arc/runner-scale-set-values.yaml)."
+    )
+
+
+def test_fork_prs_cannot_run_on_the_in_cluster_runner():
+    """Fork code + an agent with Bash + a runner inside the cluster is not acceptable."""
+    guard = str(_workflow()["jobs"]["a2a-maintain"]["if"])
+    assert "head.repo.full_name == github.repository" in guard, (
+        "this job checks out the PR head and runs an agent with Bash on an in-cluster "
+        "runner; without a same-repo guard a fork PR gets execution inside the cluster"
+    )
+
+
+def test_every_pinned_model_is_served_by_the_gateway():
+    env = _workflow()["env"]
+    served = _model_names()
+    for var in MODEL_VARS:
+        assert var in env, f"{var} must be pinned; unpinned aliases resolve to IDs the gateway lacks"
+        assert env[var] in served, (
+            f"{var}={env[var]!r} is not in the gateway's model list {sorted(served)}. "
+            f"Either add it to helm/litellm/values.yaml or pin the workflow to a served name."
+        )
+
+
+def test_no_pinned_model_carries_the_extended_context_suffix():
+    """`claude-opus-5[1m]` is what the original failure requested. It is not a model."""
+    env = _workflow()["env"]
+    for var in MODEL_VARS:
+        assert not re.search(r"\[\d+m\]$", str(env[var])), (
+            f"{var}={env[var]!r} carries an extended-context suffix; the gateway serves "
+            f"no such name. CLAUDE_CODE_DISABLE_1M_CONTEXT should also stay set."
+        )
+    assert env.get("CLAUDE_CODE_DISABLE_1M_CONTEXT") == "1"
+
+
+def test_fallback_targets_drop_anthropic_only_fields():
+    """Without this the fallback chain exists but 400s on hop 2 for Anthropic callers."""
+    for model in _gateway_models():
+        if model["provider"].startswith("anthropic/"):
+            # The primary path must keep full fidelity — dropping here buys nothing.
+            assert "extraParams" not in model or not set(
+                model["extraParams"].get("additional_drop_params", [])
+            ) & REQUIRED_DROPS, (
+                f"{model['name']} is an Anthropic model; dropping {REQUIRED_DROPS} from it "
+                f"silently downgrades normal operation"
+            )
+            continue
+        if model["name"].startswith("text-embedding"):
+            continue  # embeddings are never a chat fallback target
+        drops = set(model.get("extraParams", {}).get("additional_drop_params", []))
+        assert REQUIRED_DROPS <= drops, (
+            f"{model['name']} is a cross-provider fallback target but does not drop "
+            f"{sorted(REQUIRED_DROPS - drops)}; an Anthropic-format caller falling through "
+            f"to it gets 'Extra inputs are not permitted'"
+        )
+
+
+def test_every_fallback_target_is_a_real_model():
+    """LiteLLM silently never routes to a fallback name absent from model_list."""
+    served = _model_names()
+    fallbacks = yaml.safe_load(GATEWAY_VALUES.read_text())["routerSettings"]["fallbacks"]
+    for entry in fallbacks:
+        for primary, alts in entry.items():
+            assert primary in served, f"fallback primary {primary!r} is not in model_list"
+            for alt in alts:
+                assert alt in served, f"fallback target {alt!r} is not in model_list"
+
+
+def test_the_ci_model_has_a_cross_provider_fallback_chain():
+    """Provider independence is the whole objective — assert it for the model CI uses."""
+    env = _workflow()["env"]
+    fallbacks = yaml.safe_load(GATEWAY_VALUES.read_text())["routerSettings"]["fallbacks"]
+    chain = next(
+        (alts for entry in fallbacks for prim, alts in entry.items() if prim == env["ANTHROPIC_MODEL"]),
+        None,
+    )
+    assert chain, f"{env['ANTHROPIC_MODEL']} has no fallbacks; CI is still single-provider"
+    by_model = {m["name"]: m["provider"].split("/", 1)[0] for m in _gateway_models()}
+    providers = {by_model[alt] for alt in chain}
+    assert len(providers) >= 2, (
+        f"fallbacks for {env['ANTHROPIC_MODEL']} only reach {providers}; a single "
+        f"alternate provider is one outage away from the same total failure"
+    )
+
+
+def test_runner_namespace_may_reach_the_gateway_in_prod():
+    prod = yaml.safe_load(GATEWAY_PROD_VALUES.read_text())
+    allowed = prod["networkPolicy"]["allowedNamespaces"]
+    assert "arc-runners" in allowed, (
+        "the ARC runner pods live in arc-runners; without it on the allowlist the "
+        "NetworkPolicy drops every CI request and the preflight times out"
+    )
+
+
+def test_manifest_and_workflow_agree_the_check_is_non_blocking():
+    """a2a-maintain must stay off requiredChecks while it depends on cluster reachability."""
+    manifest = json.loads((ROOT / ".fuze/manifest.json").read_text())
+    required = manifest["hardening"]["requiredChecks"]
+    assert "a2a-maintain" not in required, (
+        "a2a-maintain now depends on in-cluster gateway reachability; making it a "
+        "required check would block every merge on the gateway being up"
+    )


### PR DESCRIPTION
## Summary

The `a2a-maintain` agent no longer holds an Anthropic key. It talks **only** to the shared LiteLLM gateway, and the gateway owns routing, key custody and cross-provider failover. One provider's billing lapse can no longer take the check down — which is exactly what happened on 2026-07-29 (#473).

**The failover is a LiteLLM Router feature, not logic in this repo.** That's deliberate: a client that implements its own failover has to hold every provider's key, which is the coupling the gateway exists to remove. We always call LiteLLM; LiteLLM retries the same request against the next model internally and returns a normal 200. `routerSettings.fallbacks` already chained `claude-opus-5 → gpt-4.1 → gemini-2.5-pro`.

### The one gateway change that makes that chain usable

Claude Code reaches LiteLLM over **`/v1/messages`** (Anthropic Messages format — not `/chat/completions`) and sends Anthropic-only body fields: `thinking`, `context_management`, `output_config`. When the router bridges to OpenAI or Gemini, those are rejected with `Extra inputs are not permitted`. So the chain existed but would have **400'd on hop 2** — a fallback that exists but doesn't work.

Every non-Anthropic model now carries `additional_drop_params` for exactly those fields, scoped **per model**:

```yaml
- name: gpt-4.1
  provider: openai/gpt-4.1
  keyEnv: OPENAI_API_KEY
  extraParams:
    additional_drop_params: ["thinking", "context_management", "output_config"]
```

Per-model rather than in `litellm_settings`, because a global setting would strip these from the Anthropic primary too — silently downgrading normal operation to buy nothing. The primary path keeps full fidelity; only the hops that can't accept the fields discard them.

### Runner moves in-cluster

The gateway is ClusterIP-only and holds live provider keys. Reaching it from *inside* the cluster (`runs-on: staging`, the ARC pods) is what avoids exposing it to CI — the alternative was a Cloudflare Access service token in front of a service holding those keys. `arc-runners` joins `networkPolicy.allowedNamespaces`.

Because the job now runs an agent with Bash inside the cluster, it's additionally gated to **same-repo PRs**. It could never push to a fork branch anyway (the prompt already falls back to opening a follow-up PR), so the only loss is A2A upkeep on fork PRs — cheap next to handing a fork execution in-cluster.

### Model pinning

Every alias is pinned to a name the gateway serves. Unpinned, Claude Code picks its own IDs — the original failing run asked for **`claude-opus-5[1m]`**, where `[1m]` is the extended-context marker, not a model any gateway lists. Against LiteLLM that's a 400 on the first call.

### Preflight now proves the whole path

Gateway reachable through the NetworkPolicy → master key accepted → `/v1/messages` served → pinned model resolvable, including via fallback. It no longer says anything about any one provider: **a 200 while Anthropic is dead is the gateway doing its job.** Every failure mode is a skip-with-specific-reason rather than a red, because an unreachable gateway and an exhausted fallback chain are operator problems, not something a PR author can clear.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Chore / CI / refactor

## Checklist

- [ ] Branch named `feat/…`, `fix/…`, or `chore/…` — branch name was assigned by the session
- [x] Conventional commit messages
- [ ] Commits are **signed** (verified) — signing key not available in this environment
- [x] Tests added/updated where relevant
- [ ] **Harden Gate** checks pass — to be confirmed on this PR
- [ ] Conversations resolved and ready for code-owner review

### Verification

- `helm lint` + `helm template` clean on all three overlays; rendered ConfigMap confirms Claude primaries keep clean `litellm_params` while only fallback targets carry the drop list; rendered NetworkPolicy admits `arc-runners`.
- `actionlint` clean across all workflows with the repo's own ignore flags.
- `tests/test_litellm_ci_routing.py` — 11 passed, and re-run against deliberate drift (a renamed gateway model, a reintroduced `[1m]` suffix) to confirm it fails on exactly what it claims to guard.
- **Proven live on the in-cluster runner:** with `LITELLM_MASTER_KEY` set, the job runs on `staging` (ARC pod), resolves cluster DNS for the gateway Service, executes the preflight, and reports a precise reason. The runner-side half of this change is confirmed working.

### 🔴 Live finding — the gateway itself is not serving

The first real preflight returned:

```
curl: (7) Failed to connect to litellm.fuzeinfra.svc.cluster.local port 4000
      after 10 ms: Couldn't connect to server
```

Read carefully, that rules out both things this PR assumed might block it:

- **DNS resolved** (the error names the host and port rather than "Could not resolve host"), so the ARC runner is genuinely in-cluster and can see the Service. The `runs-on: staging` approach is sound.
- **Immediate RST at 10 ms, not a timeout.** A NetworkPolicy drop silently discards the SYN and hangs for the full 30 s. So the policy is *not* what's rejecting us — `arc-runners` is still required on the allowlist for when the pod is back, but it is not today's blocker.

Together those mean the Service exists with **no ready endpoints** — the LiteLLM pod is not running or not passing its probe. Everything needed is already committed (chart, Argo Application, sealed secret, `enabled: true`, the 3 Gi limit from the earlier OOM fix, the startup probe), so this is a live-cluster problem, not a config gap in this PR.

Consequently the **fallback hop is still unverified**: `additional_drop_params` on the OpenAI/Gemini bridge is reasoned from LiteLLM's and Claude Code's documented behaviour, not observed, and it cannot be exercised until the gateway serves. Anthropic also [state they don't support routing Claude Code to non-Claude models through any gateway](https://code.claude.com/docs/en/llm-gateway), so treat a fallback-served agent run as best-effort. **The primary Claude path is unaffected either way.**

Merging is still correct and safe: with the gateway down the job skips green and says exactly why, which is strictly better than today.

### Operator steps

1. ~~Add the `LITELLM_MASTER_KEY` repo secret~~ — **done**, confirmed working.
2. **Investigate why the LiteLLM pod has no ready endpoint** (`kubectl -n fuzeinfra get pods,endpoints -l app.kubernetes.io/name=litellm`, then `describe`/`logs`). Prod is GitOps — fix via the chart, never `kubectl patch`.
3. Merge lands the `arc-runners` NetworkPolicy entry via Argo, needed once the pod is serving.

## Related issues

Follow-up to #473. Scoped to `a2a-maintain` as a pilot — `claude.yml`, `claude-ci-autofix.yml` and `governance-nightly.yml` stay on the direct key until this is demonstrably working, since `claude.yml` is the cluster-capable responder.

Also corrects `docs/consuming-repos/LITELLM_GATEWAY.md`, which claimed the gateway has *"no Ingress, no Cloudflare tunnel route, and no CF Access app"* — untrue since the admin UI was enabled, and materially so, because LiteLLM serves the API from the same port as the UI.