### PR TITLE
fix(k3s): advertise the PRIVATE address so pods can reach the API server

### DIFF
--- a/terraform/contabo/provisioning.tf
+++ b/terraform/contabo/provisioning.tf
@@ -126,6 +126,17 @@ resource "null_resource" "provision" {
       "%{if local.private_net_enabled}flannel-iface: ${var.private_iface}%{endif}",
       "%{if local.private_net_enabled}node-ip: ${var.private_node_ip}%{endif}",
       "%{if local.private_net_enabled}node-external-ip: ${local.server_ip}%{endif}",
+      # advertise-address -> the address the API server publishes in the
+      # `kubernetes` Service (10.43.0.1) endpoints. MUST be the private IP.
+      # k3s defaults advertise-address to node-external-ip when that is set, so
+      # without this the Service advertises PUBLIC IPs while 6443 is firewalled
+      # on the public interface of most nodes. Pods on elastic nodes then cannot
+      # reach 10.43.0.1:443 at all (measured 0/5), which silently breaks every
+      # workload that talks to the Kubernetes API — custom-hostname-api sat
+      # Available=False for days on exactly this, reporting only
+      # "Kubernetes API is unreachable" from its readiness probe.
+      # With the private address advertised, the same probe is 8/8.
+      "%{if local.private_net_enabled}advertise-address: ${var.private_node_ip}%{endif}",
       "tls-san:",
       "  - ${local.server_ip}",
       # Private tls-san so kubeconfigs/agents can reach the API over the private IP.


### PR DESCRIPTION
Codifies a fix already applied live, node by node with verification.

## The bug

The `kubernetes` Service (10.43.0.1) published the control planes' **public** IPs — but 6443 is firewalled on the public interface of two of the three. From an elastic node, `10.43.0.1:443` was unreachable **0/5**, while CoreDNS (also a ClusterIP) was fine and the private addresses `10.0.0.2:6443` / `10.0.0.3:6443` were **open**.

**Cause:** k3s defaults `advertise-address` to `node-external-ip` when that is set — and the private-network block sets `node-external-ip` to the *public* IP. So every control plane advertised an address most of the cluster cannot reach.

## Why it mattered more than one app

**Any pod on an elastic node that talks to the Kubernetes API fails** — 5 of 10 nodes. `custom-hostname-api` sat `Available=False` for days keeping `fuzeinfra-prod` Degraded, reporting only `"Kubernetes API is unreachable"` from `/readyz`; the Cloudflare side was healthy throughout. It only surfaced because it happens to check the API in a **readiness probe** — anything without one fails silently.

## Applied live, verified between each node

Restart k3s → confirm `healthz=ok` and 3/3 control planes Ready → only then proceed.

```
endpoints  161.97.118.134 194.163.136.242 95.111.238.66   (1 of 3 reachable)
        -> 10.0.0.2 10.0.0.3 10.0.0.6                     (all reachable)
```

| check | before | after |
|---|---|---|
| elastic → `10.43.0.1:443` | **0/5** | **8/8** |
| `custom-hostname-api` | Available=False | ready 1/1, `/readyz` → `200 {"status":"ok"}` |
| `fuzeinfra-prod` | Synced/**Degraded** | Synced/**Healthy** |

Each `config.yaml` was backed up to `config.yaml.bak-preadvertise` first.

This PR makes the change survive a node rebuild — it was applied imperatively, which is precisely the drift pattern this repo has been fighting all week.

## Follow-ups this exposed

- **Only the primary server is provisioned by `provisioning.tf`.** The other two control planes were joined by hand during the HA work and carry inconsistent configs (one had no `flannel-iface` at all). Bringing them under Terraform is real follow-up work.
- **#471 is closed** — the node-affinity workaround it proposed is no longer needed, and would have hidden this for one workload while leaving the rest broken.

Verified: `terraform validate` passes on 1.15.6 (the version CD pins).