### PR TITLE
fix(ci): apply-cluster-config was a silent no-op — runner lost kubectl

### DIFF
--- a/.github/workflows/apply-cluster-config.yml
+++ b/.github/workflows/apply-cluster-config.yml
@@ -43,10 +43,38 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # `runs-on: staging` is a self-hosted runner and does NOT ship kubectl.
+      # It used to be present in the image: this workflow last succeeded
+      # 2026-07-05 and then failed with "kubectl: command not found" on
+      # 2026-07-29, i.e. the runner drifted underneath us. Because every step
+      # here is a kubectl call, the whole workflow became a silent no-op that
+      # only surfaced when someone actually needed it to land a change.
+      #
+      # Install it explicitly rather than trusting the image, so the workflow is
+      # self-contained and survives the next runner rebuild.
+      - name: Install kubectl
+        run: |
+          if command -v kubectl >/dev/null 2>&1; then
+            echo "kubectl already present: $(kubectl version --client -o yaml 2>/dev/null | head -3 | tr '\n' ' ')"
+            exit 0
+          fi
+          # Pin to the cluster's minor version rather than `stable.txt`: kubectl
+          # supports +/-1 minor from the API server, so an unpinned client can
+          # drift out of the support window without warning.
+          KUBECTL_VERSION="v1.31.4"
+          curl -fsSLo /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          chmod +x /tmp/kubectl
+          mkdir -p "$HOME/.local/bin"
+          mv /tmp/kubectl "$HOME/.local/bin/kubectl"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "installed kubectl ${KUBECTL_VERSION}"
+
       - name: Configure kubectl
         run: |
           mkdir -p "$HOME/.kube"
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          kubectl version --client=true -o yaml >/dev/null
+          echo "kubectl configured."
 
       - name: Apply argocd/cluster-config
         run: |


### PR DESCRIPTION
## The problem

Every step in `apply-cluster-config.yml` is a `kubectl` call, and the `staging` self-hosted runner no longer ships kubectl.

| run | result |
|---|---|
| 2026-07-05 | success |
| **2026-07-29** | **failure — `kubectl: command not found`** |

The runner image drifted underneath the workflow. Nothing surfaced in between because nothing needed it to land — the breakage only appeared when it became load-bearing.

## Why this is worse than one red run

This is the GitOps path for **ArgoCD's own ConfigMaps** and for cluster bootstrap manifests (repo-cred templates, image-pull secrets). While it is broken, commits to `argocd/cluster-config/` and `argocd/cluster-settings/` look merged and applied while the cluster never receives them.

It is currently blocking the ArgoCD OIDC config from #470 — `argocd-cm` and `argocd-rbac-cm` were merged but never reached the cluster.

## The fix

Install kubectl explicitly rather than trusting the runner image, so the workflow is self-contained across rebuilds.

Version is **pinned** (`v1.31.4`) rather than following `stable.txt`: kubectl supports only ±1 minor from the API server, so an unpinned client silently drifts out of the support window. Bump it in step with the cluster.

The install is a no-op when kubectl is already present, so this does not fight a future runner image that ships it again.

Also adds a client-version check to the `Configure kubectl` step so a broken install fails loudly at setup rather than three steps later.

## Verified

YAML parses. **Not verified:** the actual apply — that can only be confirmed by this running on the `staging` runner post-merge, which is the point of the change. I'll check the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)