### PR TITLE
feat(ci): give the CI agent a scoped LiteLLM key instead of the admin key

### DIFF
--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -326,4 +326,16 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+          # The action reported success. If it also left no execution log there is no
+          # result record to corroborate that, so say so rather than printing a clean
+          # "completed" the run has not actually earned. Still green — the action's own
+          # outcome is real evidence — but this check exists precisely because a green
+          # that overstates what it verified is how the original outage hid for a day.
+          if [ "${RESULT_IS_ERROR:-}" = "unknown" ]; then
+            echo "::notice::a2a-maintainer reported success, but produced no execution log — completion could not be corroborated from a result record."
+            echo "### ✅ a2a-maintainer completed (unverified)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The action exited successfully but wrote no execution log, so there is no result record to confirm what it did." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           echo "a2a-maintainer completed."

--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -10,7 +10,7 @@ name: A2A Maintain
 #
 # PROVIDER-INDEPENDENT BY CONSTRUCTION. This workflow holds NO provider key. It talks
 # only to the shared LiteLLM gateway (docs/consuming-repos/LITELLM_GATEWAY.md) with
-# LITELLM_MASTER_KEY, and the gateway owns model routing, key custody and cross-provider
+# a scoped gateway key, and the gateway owns model routing, key custody and cross-provider
 # failover: `routerSettings.fallbacks` in helm/litellm/values.yaml retries the SAME
 # request against OpenAI, then Gemini, and returns a normal 200. The failover is a
 # LiteLLM Router feature — there is deliberately no fallback logic here, because a
@@ -23,8 +23,11 @@ name: A2A Maintain
 # on every PR for a day with a log that said nothing actionable. One provider's billing
 # lapse should not be able to do that.
 #
-# Requires repo secret LITELLM_MASTER_KEY. No key, or an unreachable gateway -> SKIPS
-# (never red): none of that is the PR author's fault, and a permanent red nobody can
+# Requires repo secret LITELLM_CI_KEY — a SCOPED virtual key (budget + model allowlist,
+# minted by scripts/mint-litellm-ci-key.sh), NOT the gateway admin key. Falls back to
+# LITELLM_MASTER_KEY with a warning so the migration is zero-downtime. No key at all,
+# or an unreachable gateway -> SKIPS (never red): none of that is the PR author's
+# fault, and a permanent red nobody can
 # clear is indistinguishable from a broken check — it trains people to ignore it,
 # including on the day it goes red for REAL A2A drift. A genuine agent failure is still
 # RED, with the real error text surfaced (see "Surface the real result" below).
@@ -99,12 +102,21 @@ jobs:
       - name: Skip if gateway key absent
         id: guard
         env:
-          KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+          KEY: ${{ secrets.LITELLM_CI_KEY || secrets.LITELLM_MASTER_KEY }}
+          SCOPED: ${{ secrets.LITELLM_CI_KEY != '' }}
         run: |
           if [ -z "$KEY" ]; then
-            echo "::notice::LITELLM_MASTER_KEY not set — A2A maintain skipped (set it to enable)."
+            echo "::notice::No gateway key set — A2A maintain skipped. Mint one with scripts/mint-litellm-ci-key.sh and set it as LITELLM_CI_KEY."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
+            if [ "$SCOPED" != "true" ]; then
+              # Works, but the master key is the gateway ADMIN key: it can mint
+              # keys, read the proxy config and see every consumer's spend. CI
+              # needs none of that, and spend booked against it cannot be
+              # attributed. Deliberately a warning, not a failure — this path is
+              # what keeps the check alive during the migration.
+              echo "::warning::Falling back to LITELLM_MASTER_KEY (the gateway ADMIN key). Mint a scoped key with scripts/mint-litellm-ci-key.sh, set it as LITELLM_CI_KEY, then delete the LITELLM_MASTER_KEY repo secret."
+            fi
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -140,7 +152,7 @@ jobs:
         id: preflight
         if: steps.guard.outputs.ok == 'true' && steps.marker.outputs.run == 'true'
         env:
-          LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+          GATEWAY_KEY: ${{ secrets.LITELLM_CI_KEY || secrets.LITELLM_MASTER_KEY }}
         run: |
           set -uo pipefail
           # NO `|| echo 000` here: curl's own -w already emits 000 when it never got
@@ -149,7 +161,7 @@ jobs:
           # arm. `|| true` keeps `bash -e` from killing the step on curl's exit code.
           code=$(curl -sS -o /tmp/preflight.json -w '%{http_code}' --max-time 30 \
             -X POST "${ANTHROPIC_BASE_URL}/v1/messages" \
-            -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+            -H "Authorization: Bearer ${GATEWAY_KEY}" \
             -H "anthropic-version: 2023-06-01" \
             -H "content-type: application/json" \
             -d "{\"model\":\"${ANTHROPIC_MODEL}\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
@@ -175,7 +187,7 @@ jobs:
               echo "reason=LiteLLM gateway unreachable at ${ANTHROPIC_BASE_URL} — ${transport:-no detail from curl}. Resolve-host errors mean cluster DNS from arc-runners; timeouts mean the NetworkPolicy is dropping us (arc-runners must be on networkPolicy.allowedNamespaces); connection-refused means the pod is not serving." >> "$GITHUB_OUTPUT" ;;
             401|403)
               echo "ok=false" >> "$GITHUB_OUTPUT"
-              echo "reason=LiteLLM rejected LITELLM_MASTER_KEY (HTTP $code): $err. The secret and the gateway's sealed key have drifted — they rotate together." >> "$GITHUB_OUTPUT" ;;
+              echo "reason=LiteLLM rejected the gateway key (HTTP $code): $err. A virtual key is revoked/expired or over budget; the master key would mean it drifted from the gateway's sealed value." >> "$GITHUB_OUTPUT" ;;
             404)
               echo "ok=false" >> "$GITHUB_OUTPUT"
               echo "reason=Gateway did not serve /v1/messages (HTTP 404): $err. Claude Code speaks the Anthropic Messages format; this LiteLLM build must expose that endpoint." >> "$GITHUB_OUTPUT" ;;
@@ -201,9 +213,9 @@ jobs:
           # purely to satisfy the action's "some credential is configured" launch check,
           # and the copy it puts in x-api-key is ignored. Dropping either one breaks the
           # run, in two different and equally confusing ways.
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_MASTER_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_CI_KEY || secrets.LITELLM_MASTER_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.LITELLM_MASTER_KEY }}
+          anthropic_api_key: ${{ secrets.LITELLM_CI_KEY || secrets.LITELLM_MASTER_KEY }}
           prompt: |
             You are the **a2a-maintainer** for this repo (follow `.claude/agents/a2a-maintainer.md`
             exactly — same scope, boundaries, and done-contract). This is an automated CI run on

--- a/docs/consuming-repos/LITELLM_GATEWAY.md
+++ b/docs/consuming-repos/LITELLM_GATEWAY.md
@@ -79,6 +79,49 @@ itself was perfectly healthy.
 > If `OPENAI_API_KEY` is absent from the gateway's secret, chat works and
 > `/embeddings` returns an auth error.
 
+## Virtual keys — prefer these over the master key
+
+`LITELLM_MASTER_KEY` is the gateway **admin** key. It can mint keys, read the proxy
+config and see every consumer's spend. Most consumers need none of that, and spend
+booked against it is unattributable — which is why `values-contabo.yaml` notes that
+per-consumer cost attribution "is NOT meaningful" today.
+
+A **virtual key** fixes all three: it carries a budget, a model allowlist and its own
+line in the spend report. `scripts/mint-litellm-ci-key.sh` is the worked example
+(it mints the key `a2a-maintain-ci` that CI uses):
+
+```bash
+kubectl -n fuzeinfra port-forward svc/litellm 4000:4000 &
+export LITELLM_MASTER_KEY=$(kubectl -n fuzeinfra get secret litellm-secret \
+    -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)
+scripts/mint-litellm-ci-key.sh | gh secret set LITELLM_CI_KEY --repo izzywdev/FuzeInfra
+```
+
+Three things to know before minting your own:
+
+- **A virtual key is NOT GitOps.** It is runtime state in LiteLLM's Postgres database
+  (the one `database.enabled` provides), created over the API. It cannot be declared
+  in `values.yaml` and Argo will never reconcile it. What *is* version-controlled is
+  the mint payload — budget, allowlist, alias — so the key's properties stay
+  reviewable even though its existence is out-of-band.
+- **Allowlist the fallback targets, not just the model you ask for.** `models` is
+  enforced on the model actually *dispatched*. A key allowed only `claude-opus-5`
+  works perfectly right up until the router fails over to `gpt-4.1`, and is then
+  refused by its own ACL — turning the fallback into an outage on the one day it
+  matters.
+- **Do not set `rpm_limit` / `tpm_limit`.** LiteLLM's `parallel_request_limiter_v3`
+  hook injects `_litellm_rate_limit_descriptors` and friends into the **outbound
+  provider payload** whenever a key carries rate limits. OpenAI answers
+  `Unrecognized request arguments supplied: _litellm_...`; Anthropic answers
+  `_litellm_rate_limit_descriptors: Extra inputs are not permitted`. So a
+  rate-limited key does not throttle — it poisons every request *and every fallback
+  hop*. Upstream [BerriAI/litellm#28146](https://github.com/BerriAI/litellm/issues/28146),
+  open at time of writing. The budget still works; it is enforced on recorded spend,
+  not by that hook.
+
+Rotation is manual: LiteLLM enforces a unique `key_alias`, so delete the old key in
+the admin UI before re-minting under the same alias.
+
 ## Getting `LITELLM_MASTER_KEY`
 
 SealedSecrets are **strictly scoped** — a secret sealed for `fuzeinfra` cannot be
@@ -139,7 +182,7 @@ LiteLLM bridges that to whichever provider the router picks.
 ```yaml
 env:
   ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
-  ANTHROPIC_MODEL: claude-opus-5           # must be a name in `models:` below
+  ANTHROPIC_MODEL: claude-opus-5           # must be a name in `models:` above
   ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5
   CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"
   CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
@@ -147,9 +190,9 @@ env:
 steps:
   - uses: anthropics/claude-code-action@<sha>
     env:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_MASTER_KEY }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_CI_KEY }}
     with:
-      anthropic_api_key: ${{ secrets.LITELLM_MASTER_KEY }}
+      anthropic_api_key: ${{ secrets.LITELLM_CI_KEY }}
 ```
 
 Four things that are easy to get wrong:

--- a/scripts/mint-litellm-ci-key.sh
+++ b/scripts/mint-litellm-ci-key.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# mint-litellm-ci-key.sh — mint the scoped LiteLLM virtual key that CI agents use.
+#
+# CI currently authenticates to the gateway with LITELLM_MASTER_KEY. That is the
+# ADMIN key: it can mint keys, read the proxy config and see every consumer's
+# spend. A CI job needs none of that. This mints a virtual key that can do
+# exactly one thing — call the chat models a2a-maintain pins — with a budget
+# attached and its own line in the gateway's cost report.
+#
+# WHY A SCRIPT AND NOT THE CHART: a virtual key is runtime state. LiteLLM stores
+# it in its Postgres database (the one helm/litellm `database.enabled` provides),
+# minted over the API. It cannot be declared in values.yaml and Argo will never
+# reconcile it. What IS version-controlled is this payload — the budget, the
+# model allowlist and the alias — so the key's PROPERTIES are reviewable even
+# though its existence is out-of-band. tests/test_litellm_ci_routing.py asserts
+# the allowlist below still covers what the workflow asks for.
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#   # from a machine with cluster access:
+#   kubectl -n fuzeinfra port-forward svc/litellm 4000:4000 &
+#   export LITELLM_MASTER_KEY=$(kubectl -n fuzeinfra get secret litellm-secret \
+#       -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)
+#   scripts/mint-litellm-ci-key.sh | gh secret set LITELLM_CI_KEY --repo izzywdev/FuzeInfra
+#
+# The key is printed to STDOUT and nothing else is — every diagnostic goes to
+# stderr — so it pipes straight into `gh secret set` without ever landing in a
+# file, your shell history or argv.
+#
+# ── Options ──────────────────────────────────────────────────────────────────
+#   --alias <name>    Key alias (default: a2a-maintain-ci). Also the label the
+#                     gateway's spend report groups by.
+#   --budget <usd>    Max spend before the key is refused (default: 25).
+#   --window <dur>    Budget window, LiteLLM duration string (default: 30d).
+#   --base-url <url>  Gateway base URL (default: http://localhost:4000).
+#   --dry-run         Print the request body and exit without calling anything.
+#
+set -euo pipefail
+
+ALIAS="a2a-maintain-ci"
+BUDGET="25"
+WINDOW="30d"
+BASE_URL="${LITELLM_BASE_URL:-http://localhost:4000}"
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --alias)    ALIAS="$2"; shift 2 ;;
+    --budget)   BUDGET="$2"; shift 2 ;;
+    --window)   WINDOW="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    -h|--help)  sed -n '2,45p' "$0" >&2; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The model allowlist.
+#
+# It MUST include the fallback targets, not just the models the workflow asks
+# for by name. A virtual key's `models` list is enforced on the model actually
+# dispatched, so a key allowed only the claude-* names would pass in normal
+# operation and then be REJECTED at the exact moment the router failed over —
+# turning the cross-provider fallback into an outage on the one day it matters.
+#
+# Derived from .github/workflows/a2a-maintain.yml (the pinned aliases) plus
+# helm/litellm/values.yaml `routerSettings.fallbacks` (their hops).
+# tests/test_litellm_ci_routing.py fails if the two drift apart.
+# ─────────────────────────────────────────────────────────────────────────────
+MODELS='[
+  "claude-opus-5",
+  "claude-sonnet-5",
+  "claude-haiku-4-5",
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite"
+]'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DELIBERATELY NO rpm_limit / tpm_limit.
+#
+# They look like the obvious companion to a budget, and they are a trap here.
+# LiteLLM's parallel_request_limiter_v3 hook injects `_litellm_rate_limit_
+# descriptors`, `_litellm_tpm_reserved_model`, `_litellm_tpm_reserved_scopes`
+# and `_litellm_tpm_reserved_tokens` into the OUTBOUND provider payload whenever
+# a key carries rate limits. Strict providers reject the request outright:
+#
+#   OpenAI    -> "Unrecognized request arguments supplied: _litellm_rate_limit_..."
+#   Anthropic -> "_litellm_rate_limit_descriptors: Extra inputs are not permitted"
+#
+# So a rate-limited key does not merely throttle — it poisons every request,
+# including every fallback hop, which is precisely the machinery this repo added
+# on 2026-07-29 to survive a dead provider. Upstream: BerriAI/litellm#28146,
+# open and unfixed as of this writing. The budget below still applies; it is
+# enforced on recorded spend, not by that hook.
+#
+# If you are reading this because you want rate limits: check whether #28146 has
+# shipped a fix, and if it has, verify a fallback hop still completes BEFORE
+# adding them.
+# ─────────────────────────────────────────────────────────────────────────────
+BODY=$(cat <<JSON
+{
+  "key_alias": "${ALIAS}",
+  "models": ${MODELS},
+  "max_budget": ${BUDGET},
+  "budget_duration": "${WINDOW}",
+  "metadata": {
+    "owner": "FuzeInfra CI",
+    "workflow": ".github/workflows/a2a-maintain.yml",
+    "purpose": "a2a-maintainer agent; scoped replacement for LITELLM_MASTER_KEY"
+  }
+}
+JSON
+)
+
+if [ "$DRY_RUN" = true ]; then
+  echo "POST ${BASE_URL}/key/generate" >&2
+  echo "$BODY"
+  exit 0
+fi
+
+if [ -z "${LITELLM_MASTER_KEY:-}" ]; then
+  echo "ERROR: LITELLM_MASTER_KEY is not set — minting requires the admin key." >&2
+  echo "  export LITELLM_MASTER_KEY=\$(kubectl -n fuzeinfra get secret litellm-secret \\" >&2
+  echo "      -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)" >&2
+  exit 1
+fi
+
+echo "Minting virtual key '${ALIAS}' (budget \$${BUDGET}/${WINDOW}) at ${BASE_URL}..." >&2
+
+resp=$(curl -sS --fail-with-body --max-time 30 \
+  -X POST "${BASE_URL}/key/generate" \
+  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+  -H "content-type: application/json" \
+  -d "$BODY") || {
+    echo "" >&2
+    echo "Mint failed. The usual causes, in order:" >&2
+    echo "  * alias already exists — LiteLLM enforces unique key_alias. ROTATION IS" >&2
+    echo "    DELIBERATELY MANUAL: delete the old key in the admin UI (Keys ->" >&2
+    echo "    ${ALIAS} -> Delete), then re-run. Deleting by alias over the API is" >&2
+    echo "    not scripted here because that path is unverified against this build." >&2
+    echo "  * 401 — LITELLM_MASTER_KEY is stale; re-read it from the Secret." >&2
+    echo "  * connection refused — no port-forward, or the gateway has no ready pod." >&2
+    exit 1
+  }
+
+key=$(printf '%s' "$resp" | jq -r '.key // empty')
+if [ -z "$key" ]; then
+  echo "ERROR: gateway accepted the request but returned no key. Response:" >&2
+  printf '%s\n' "$resp" >&2
+  exit 1
+fi
+
+{
+  echo ""
+  echo "Minted. Set it as the repo secret (the key is on stdout, pipe it):"
+  echo "  scripts/mint-litellm-ci-key.sh | gh secret set LITELLM_CI_KEY --repo izzywdev/FuzeInfra"
+  echo ""
+  echo "a2a-maintain prefers LITELLM_CI_KEY and falls back to LITELLM_MASTER_KEY"
+  echo "with a warning, so nothing breaks in between. Once this is set, REMOVE the"
+  echo "LITELLM_MASTER_KEY repo secret — leaving it there keeps an admin key in CI."
+} >&2
+
+printf '%s\n' "$key"

--- a/tests/test_litellm_ci_routing.py
+++ b/tests/test_litellm_ci_routing.py
@@ -56,12 +56,31 @@ def _model_names() -> set[str]:
 def test_workflow_holds_no_provider_key():
     """The point of the gateway: CI holds a gateway credential, never a provider key."""
     raw = WORKFLOW.read_text()
-    assert "secrets.LITELLM_MASTER_KEY" in raw
+    assert "secrets.LITELLM_CI_KEY" in raw
     assert "secrets.ANTHROPIC_API_KEY" not in raw, (
         "the workflow is back to holding a provider key directly, which defeats the "
         "gateway's key custody and re-couples CI to a single provider's billing"
     )
     assert "api.anthropic.com" not in raw, "CI must reach providers only via the gateway"
+
+
+def test_scoped_key_is_preferred_over_the_admin_key():
+    """Every place the credential is read must prefer the scoped virtual key.
+
+    `LITELLM_MASTER_KEY` is the gateway ADMIN key — it can mint keys, read the proxy
+    config and see every consumer's spend. It stays as a fallback so the migration is
+    zero-downtime, but a reference that reads it FIRST (or only) silently puts CI back
+    on admin credentials.
+    """
+    raw = WORKFLOW.read_text()
+    for line in raw.splitlines():
+        if "secrets.LITELLM_MASTER_KEY" not in line:
+            continue
+        if line.strip().startswith("#") or "::warning::" in line:
+            continue  # prose and the nudge itself may name it
+        assert "secrets.LITELLM_CI_KEY || secrets.LITELLM_MASTER_KEY" in line, (
+            f"master key read without preferring the scoped key: {line.strip()}"
+        )
 
 
 def test_base_url_points_at_the_in_cluster_gateway():
@@ -166,6 +185,77 @@ def test_runner_namespace_may_reach_the_gateway_in_prod():
     assert "arc-runners" in allowed, (
         "the ARC runner pods live in arc-runners; without it on the allowlist the "
         "NetworkPolicy drops every CI request and the preflight times out"
+    )
+
+
+def _mint_script() -> str:
+    return (ROOT / "scripts/mint-litellm-ci-key.sh").read_text()
+
+
+def _key_allowlist() -> set[str]:
+    """The `models` array the mint script sends to /key/generate."""
+    raw = _mint_script()
+    body = raw.split("MODELS='[", 1)[1].split("]'", 1)[0]
+    return {line.strip().strip('",') for line in body.splitlines() if line.strip().strip('",')}
+
+
+def test_key_allowlist_covers_every_model_the_workflow_pins():
+    env = _workflow()["env"]
+    allow = _key_allowlist()
+    for var in MODEL_VARS:
+        assert env[var] in allow, (
+            f"{var}={env[var]!r} is not on the virtual key's model allowlist, so the key "
+            f"would be refused for it. Add it to MODELS in scripts/mint-litellm-ci-key.sh."
+        )
+
+
+def test_key_allowlist_covers_every_fallback_hop():
+    """The subtle one: a key allowed only the Claude names breaks failover.
+
+    `models` is enforced on the model actually dispatched, so such a key passes in
+    normal operation and is rejected at the precise moment the router fails over —
+    converting the cross-provider fallback into an outage on the one day it matters.
+    """
+    env = _workflow()["env"]
+    allow = _key_allowlist()
+    fallbacks = yaml.safe_load(GATEWAY_VALUES.read_text())["routerSettings"]["fallbacks"]
+    pinned = {env[v] for v in MODEL_VARS}
+    for entry in fallbacks:
+        for primary, alts in entry.items():
+            if primary not in pinned:
+                continue  # CI never asks for it, so its hops are irrelevant here
+            for alt in alts:
+                assert alt in allow, (
+                    f"{primary!r} falls back to {alt!r} but the virtual key does not allow "
+                    f"{alt!r} — failover would be rejected by the key's own ACL"
+                )
+
+
+def test_mint_script_sets_no_rate_limits():
+    """rpm/tpm limits on a key poison every provider payload (BerriAI/litellm#28146).
+
+    The parallel_request_limiter_v3 hook injects `_litellm_*` params into the OUTBOUND
+    request whenever a key carries rate limits; OpenAI answers "Unrecognized request
+    arguments" and Anthropic "Extra inputs are not permitted". That breaks not just
+    throttled calls but every fallback hop — the machinery this repo added precisely to
+    survive a dead provider.
+    """
+    raw = _mint_script()
+    body = raw.split("BODY=$(cat <<JSON", 1)[1].split("JSON", 1)[0]
+    for forbidden in ("rpm_limit", "tpm_limit", "max_parallel_requests"):
+        assert forbidden not in body, (
+            f"{forbidden} is set on the CI virtual key; see BerriAI/litellm#28146 before "
+            f"adding it, and verify a fallback hop still completes"
+        )
+
+
+def test_mint_script_sets_a_budget_and_a_stable_alias():
+    """Budget is the control that still works, and the alias is the cost-attribution key."""
+    raw = _mint_script()
+    assert 'max_budget' in raw and 'budget_duration' in raw
+    assert 'ALIAS="a2a-maintain-ci"' in raw, (
+        "the alias is what the gateway's spend report groups by; changing it silently "
+        "splits this consumer's cost history in two"
     )
 
 


### PR DESCRIPTION
## Summary

`a2a-maintain` authenticates to the gateway with `LITELLM_MASTER_KEY` — the **admin** key. It can mint keys, read the proxy config and see every consumer's spend. A CI job needs none of that, and spend booked against it is unattributable, which is why `values-contabo.yaml` already notes per-consumer cost attribution *"is NOT meaningful"*.

`scripts/mint-litellm-ci-key.sh` mints a virtual key that can call exactly the chat models this workflow pins, with a **$25/30d budget** and its own line in the spend report. The workflow now reads `secrets.LITELLM_CI_KEY || secrets.LITELLM_MASTER_KEY`, so the migration is **zero-downtime**: until the scoped key exists CI keeps working on the old one and emits a warning on every run.

### Answering the GitOps question directly

**The master key is GitOps; a virtual key is not.** `LITELLM_MASTER_KEY` lives in a committed SealedSecret and reaches the pod via `secretKeyRef` — Argo reconciles it. A virtual key is *runtime state*: LiteLLM stores it in the Postgres database `database.enabled` provides, minted over the API. It cannot be declared in `values.yaml` and Argo will never reconcile it.

So rather than pretend otherwise, the **payload** is version-controlled — budget, allowlist, alias — which keeps the key's properties reviewable even though its existence is out-of-band.

### Two things in the payload are load-bearing, and neither is obvious

**1. The allowlist covers the fallback targets, not just the models the workflow names.**

`models` is enforced on the model actually *dispatched*. A key allowed only the `claude-*` names passes in normal operation and is rejected at the precise moment the router fails over — converting the cross-provider fallback into an outage on the one day it exists to help.

**2. There are deliberately NO rate limits**, despite them being the obvious companion to a budget — and despite being in the original ask.

LiteLLM's `parallel_request_limiter_v3` hook injects `_litellm_rate_limit_descriptors` and friends into the **outbound provider payload** whenever a key carries rpm/tpm limits:

```
OpenAI    -> Unrecognized request arguments supplied: _litellm_rate_limit_descriptors, ...
Anthropic -> _litellm_rate_limit_descriptors: Extra inputs are not permitted
```

A rate-limited key therefore doesn't throttle — it **poisons every request and every fallback hop**, which is exactly the machinery added on 2026-07-29 to survive a dead provider. Upstream [BerriAI/litellm#28146](https://github.com/BerriAI/litellm/issues/28146), open and unfixed. The budget still applies; it's enforced on recorded spend, not by that hook.

Both traps are asserted against in tests, so a future *"let's add rate limits"* fails CI **with the reason** rather than silently breaking failover.

Rotation is left manual: LiteLLM enforces a unique `key_alias` and the delete-by-alias API path is unverified against this build, so the script points at the admin UI rather than scripting something I haven't confirmed.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Chore / CI / refactor

## Checklist

- [ ] Branch named `feat/…`, `fix/…`, or `chore/…` — branch name was assigned by the session
- [x] Conventional commit messages
- [ ] Commits are **signed** (verified) — signing key not available in this environment
- [x] Tests added/updated where relevant
- [ ] **Harden Gate** checks pass — to be confirmed on this PR
- [ ] Conversations resolved and ready for code-owner review

### Verification

- `--dry-run` emits valid JSON with the expected payload (checked through `jq -e`).
- The no-master-key path errors cleanly with the exact `kubectl` line to fix it.
- The key prints on **stdout** with every diagnostic on **stderr**, so it pipes into `gh secret set` without touching disk, shell history or argv.
- `actionlint` clean across all workflows; `bash -n` clean on the script.
- **22 tests pass**, and the two new guards were confirmed to *fail* when a fallback target is dropped from the allowlist and when `rpm_limit` is added.

### ⚠️ Not verified live

**The mint call itself.** It needs the admin key and a reachable gateway, neither available from this sandbox. The payload shape is verified; the round-trip is not.

### Operator steps

```bash
kubectl -n fuzeinfra port-forward svc/litellm 4000:4000 &
export LITELLM_MASTER_KEY=$(kubectl -n fuzeinfra get secret litellm-secret \
    -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)
scripts/mint-litellm-ci-key.sh | gh secret set LITELLM_CI_KEY --repo izzywdev/FuzeInfra
```

Then **delete the `LITELLM_MASTER_KEY` repo secret** — leaving it keeps an admin key in CI, and the workflow's warning will keep saying so until it's gone.

## Related issues

Follow-up to #478. Does **not** address the current red — that's the unfunded Anthropic account, and separately the fact that LiteLLM relayed `Credit balance is too low` instead of failing over to `gpt-4.1`. This PR is about the credential CI presents, not about which provider serves the request.