### PR TITLE
fix(cluster-query): block Secret reads — read-only is not the same as safe-to-log

### DIFF
--- a/.github/workflows/cluster-query.yml
+++ b/.github/workflows/cluster-query.yml
@@ -6,7 +6,8 @@
 #
 # SECURITY: an allowed READ verb must appear as a token, AND no mutating/exec
 # token may appear (apply/delete/edit/patch/replace/exec/attach/cp/scale/
-# rollout/annotate/label/drain/cordon/proxy/port-forward/run/create/set).
+# rollout/annotate/label/drain/cordon/proxy/port-forward/run/create/set),
+# AND the Secret resource may not be read at all (see the guard below).
 #
 # Secret: KUBE_CONFIG (base64 kubeconfig) — same secret used by
 # apply-cluster-config.yml / argo-outofsync-autofix.yml.
@@ -16,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       kubectl_args:
-        description: 'kubectl args, e.g. "-n mendys-prod get pods -o wide". Must contain a read verb (get/describe/logs/…).'
+        description: 'kubectl args, e.g. "-n mendys-prod get pods -o wide". Must contain a read verb (get/describe/logs/…). Reading Secrets is blocked — output lands in this job log; see docs/SECRETS_MANAGEMENT.md §4.'
         required: false
         default: 'get nodes'
       curl_url:
@@ -69,6 +70,30 @@ jobs:
             case "$tok" in
               exec|attach|cp|port-forward|proxy|run|delete|apply|edit|patch|replace|scale|rollout|cordon|drain|annotate|label|set|create|taint|uncordon|debug)
                 echo "::error::Rejected mutating/exec token: '$tok'."; exit 1;;
+            esac
+          done
+          # Reject reads of the Secret resource. `get secret -o jsonpath=...` passes
+          # every check above and prints the credential verbatim into THIS job log,
+          # which is retained and readable by anyone with repo access. That is not a
+          # hypothetical: it happened on 2026-07-29 to fetch LITELLM_MASTER_KEY, and
+          # the log had to be deleted after the fact. Read-only is not the same as
+          # safe-to-log, so the guard is separate from the verb checks.
+          #
+          # Separators are normalised FIRST. `secret/foo`, `pods,secrets` and
+          # `secrets.v1.` all name the resource but are each a single $ARGS token, so
+          # matching the raw token would miss every one of them; kubectl also accepts
+          # `Secret`, hence the case fold. Splitting on - would be wrong: it must not
+          # match a Secret's NAME (`litellm-secret` is fine to mention, e.g. in
+          # `describe deployment litellm-secret-reader`).
+          #
+          # `sealedsecret` deliberately still passes: it is encrypted at rest and
+          # useless to an attacker, so blocking it would cost debuggability for
+          # nothing.
+          for tok in $(printf '%s' "$ARGS" | tr '[:upper:]' '[:lower:]' | tr '/,.' '   '); do
+            case "$tok" in
+              secret|secrets)
+                echo "::error::Rejected: reading Secret objects would write the credential into this job log, which is retained and readable by anyone with repo access. Use the operator SSH path in docs/SECRETS_MANAGEMENT.md §4, or rotate the value instead. SealedSecrets are readable here."
+                exit 1;;
             esac
           done
           echo "### kubectl $ARGS"

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -141,6 +141,37 @@ materializes the real `Secret` at sync time. Consequences:
 - The **private key never leaves the cluster** and is backed up by the operator
   out-of-band (see below).
 
+### Recovering a live value (operator only)
+
+You cannot unseal the committed blob, but the *materialized* `Secret` in the
+cluster still holds the plaintext, so an operator with node access can read it
+back. Pull the kubeconfig off the node and read the key directly:
+
+```bash
+ssh root@<server_ip> "cat /etc/rancher/k3s/k3s.yaml" \
+  | sed 's/127\.0\.0\.1/<server_ip>/g' > ~/.kube/contabo-prod.yaml
+chmod 600 ~/.kube/contabo-prod.yaml
+
+KUBECONFIG=~/.kube/contabo-prod.yaml kubectl -n fuzeinfra get secret <name> \
+  -o jsonpath='{.data.<KEY>}' | base64 -d; echo
+```
+
+`server_ip` is Terraform's output; SSH is key-based (the public key is injected
+via cloud-init in `terraform/contabo/vps.tf`), so there is no root password to
+know. If the private key is lost, recovery is Contabo's control panel — or
+rotation, which needs no cluster access at all.
+
+**Do not route this through `cluster-query`.** That workflow echoes kubectl output
+into a GitHub Actions job log, which is retained and readable by anyone with repo
+access — so `get secret -o jsonpath=…` there leaks the credential even though it
+is only a read. It is blocked for that reason
+(`.github/workflows/cluster-query.yml`, covered by
+`tests/test_cluster_query_guard.py`). SealedSecrets *are* readable there, being
+encrypted at rest.
+
+Treat any value recovered this way as exposed to whatever it passed through, and
+rotate if that set is wider than you want.
+
 ---
 
 ## 5. Key rotation
@@ -232,6 +263,9 @@ That gives every onboarded repo offline self-sealing with zero cluster access.
 - **Always fetch** the cert from the published URL; never hardcode a vendored cert.
 - **Seal offline**; decryption is **cluster-only**.
 - **No consumer gets a kubeconfig** — sealing needs only the public cert.
+- **Never read a `Secret` through a CI workflow.** Read-only is not the same as
+  safe-to-log: job logs are retained and repo-readable. Use the operator SSH path
+  in §4, or rotate.
 
 ## Related docs
 

--- a/tests/test_cluster_query_guard.py
+++ b/tests/test_cluster_query_guard.py
@@ -1,0 +1,155 @@
+"""Executable invariants for the cluster-query arg filter.
+
+cluster-query hands any agent session read-only kubectl against PROD and echoes the
+result into a GitHub Actions job log. Two properties have to hold, and only one of
+them is about mutation:
+
+  1. nothing that changes cluster state may run, and
+  2. nothing whose OUTPUT is a credential may run.
+
+(2) is the one that is easy to miss, because `kubectl get secret` is a read. It
+passes every mutation check, and it prints the credential verbatim into a log that
+is retained and readable by anyone with repo access. That happened on 2026-07-29 —
+LITELLM_MASTER_KEY was fetched this way and the run's logs had to be deleted after
+the fact. Read-only is not the same as safe-to-log.
+
+These tests EXECUTE the workflow's real filter rather than grepping it for keywords.
+A guard asserted by substring passes just as happily when the shell logic around it
+is broken, and the interesting cases here are exactly the ones where the logic is
+subtle: `secret/foo`, `pods,secrets` and `secrets.v1.` all name the Secret resource
+while being a single whitespace-delimited token, so the naive check misses all three.
+
+Offline: parses one YAML file and runs bash. No cluster, no network.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github/workflows/cluster-query.yml"
+
+STEP_NAME = "Run read-only kubectl"
+
+
+def _filter_script() -> str:
+    """The workflow's arg-filter step, with the kubectl call itself removed.
+
+    Everything up to `echo "### kubectl ..."` is validation; the line after it
+    actually talks to the cluster. Truncating there lets the real filter run
+    unmodified while making the script inert.
+    """
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    steps = wf["jobs"]["query"]["steps"]
+    script = next(s["run"] for s in steps if s.get("name") == STEP_NAME)
+
+    marker = 'echo "### kubectl'
+    assert marker in script, (
+        f"the {STEP_NAME!r} step no longer contains {marker!r}; this test truncates "
+        "the script there to keep it inert and must be updated with the step"
+    )
+    return script.split(marker)[0]
+
+
+def run_filter(args: str) -> subprocess.CompletedProcess:
+    """Run the real filter with ARGS=args. Returncode 0 means the args were allowed."""
+    return subprocess.run(
+        ["bash", "-e", "-c", _filter_script()],
+        env={"ARGS": args, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- reads that must keep working ------------------------------------------------
+# Regression cover for the guard being too broad. Every one of these is a read a
+# human legitimately needs, and several MENTION a secret without reading one.
+ALLOWED = [
+    "get nodes",
+    "-n fuzeinfra get pods -o wide",
+    "-n fuzeinfra get pods,svc,endpoints,ingress,networkpolicy -o wide",
+    "-n fuzeinfra logs litellm-69d54765ff-sc9gz --tail=120",
+    "-n fuzeinfra logs deploy/fuzeinfra-cloudflare-tunnel --tail=200",
+    "-n kube-system describe pod traefik",
+    "-n fuzeinfra get events --sort-by=.lastTimestamp",
+    # SealedSecrets are encrypted at rest — readable on purpose.
+    "-n fuzeinfra get sealedsecret litellm-secret -o yaml",
+    "-n fuzeinfra get sealedsecrets",
+    # Names that merely CONTAIN "secret" must not trip the guard.
+    "-n fuzeinfra describe deployment litellm-secret-reader",
+    "-n fuzeinfra logs job/fuzeinfra-sealed-secrets-sync",
+]
+
+# --- credential reads that must be rejected --------------------------------------
+# The bare forms plus every separator/casing variant that names the same resource
+# while surviving a naive token match.
+BLOCKED_SECRET_READS = [
+    "-n fuzeinfra get secret litellm-secret -o jsonpath={.data.LITELLM_MASTER_KEY}",
+    "-n fuzeinfra get secrets",
+    "get secrets -A -o yaml",
+    "-n fuzeinfra describe secret litellm-secret",
+    # separator variants — one $ARGS token each
+    "-n fuzeinfra get secret/litellm-secret -o yaml",
+    "-n fuzeinfra get pods,secrets",
+    "-n fuzeinfra get secrets.v1. -o yaml",
+    "-n fuzeinfra get secrets.v1.core/litellm-secret",
+    # kubectl accepts the capitalised kind
+    "-n fuzeinfra get Secret litellm-secret -o yaml",
+    "-n fuzeinfra get SECRETS",
+]
+
+# --- mutation/exec, i.e. the pre-existing guard ------------------------------------
+BLOCKED_MUTATIONS = [
+    "-n fuzeinfra delete pod litellm-69d54765ff-sc9gz",
+    "-n fuzeinfra exec litellm-0 -- env",
+    "-n fuzeinfra port-forward svc/litellm 4000:4000",
+    "apply -f helm/litellm",
+    "-n fuzeinfra patch deployment litellm --type=merge -p {}",
+]
+
+
+@pytest.mark.parametrize("args", ALLOWED)
+def test_legitimate_reads_are_allowed(args):
+    result = run_filter(args)
+    assert result.returncode == 0, (
+        f"cluster-query rejected a legitimate read: {args!r}\n{result.stdout}{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("args", BLOCKED_SECRET_READS)
+def test_secret_reads_are_rejected(args):
+    result = run_filter(args)
+    assert result.returncode != 0, (
+        f"cluster-query ALLOWED a Secret read: {args!r}\n"
+        "Its output would land in the job log, which is retained and readable by "
+        f"anyone with repo access.\n{result.stdout}{result.stderr}"
+    )
+    assert "job log" in result.stdout, (
+        "a Secret read was rejected, but not by the secret guard — the error should "
+        f"explain the logging risk and point at the SSH alternative.\n{result.stdout}"
+    )
+
+
+@pytest.mark.parametrize("args", BLOCKED_MUTATIONS)
+def test_mutating_args_are_rejected(args):
+    result = run_filter(args)
+    assert result.returncode != 0, (
+        f"cluster-query ALLOWED a mutating/exec command: {args!r}\n"
+        f"{result.stdout}{result.stderr}"
+    )
+
+
+def test_read_verb_is_still_required():
+    """A command with no read verb at all is refused (pre-existing behaviour)."""
+    result = run_filter("-n fuzeinfra")
+    assert result.returncode != 0
+    assert "read verb" in result.stdout
+
+
+def test_empty_args_are_a_no_op():
+    """The default dispatch path: no args is not an error."""
+    result = run_filter("")
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

`cluster-query` hands an agent session read-only kubectl against prod and echoes the result into a GitHub Actions job log. Its filter required a read verb and rejected mutating/exec tokens — which misses the case where **the read itself is the leak**. `get secret -o jsonpath=…` passes every existing check and prints the credential verbatim into a log that is retained and readable by anyone with repo access.

Not hypothetical: it was used exactly that way earlier today to recover `LITELLM_MASTER_KEY`, and the run's logs had to be deleted after the fact. This closes the path so the next person can't do it by accident.

### Why not a one-line token match

Adding `secret|secrets` to the existing loop looks sufficient and isn't. `$ARGS` is split on whitespace, so each of these is a **single token** that doesn't equal `"secret"` — and kubectl accepts all of them:

| args | token kubectl sees | naive match |
|---|---|---|
| `get secret/litellm-secret` | `secret/litellm-secret` | miss |
| `get pods,secrets` | `pods,secrets` | miss |
| `get secrets.v1.core/x` | `secrets.v1.core/x` | miss |
| `get Secret x` | `Secret` | miss |

So separators are normalised first — case fold, then `/`, `,`, `.` → space — and matched after. `-` is deliberately **not** a separator: splitting on it would match a Secret's *name* and reject innocuous args like `describe deployment litellm-secret-reader`.

`sealedsecret` still passes on purpose: encrypted at rest, useless to an attacker, and sometimes the thing you actually need to look at.

The guard is a separate loop rather than another arm of the mutation check, because it enforces a different property — that no *output* is a credential, not that no *state* changes.

### The test executes the guard, it doesn't grep for it

`tests/test_cluster_query_guard.py` parses the real filter out of the workflow YAML, truncates it before the `kubectl` call so it's inert, and runs it under bash. A guard asserted by substring passes just as happily when the shell logic around it is broken — and the interesting cases here are exactly the subtle ones above.

28 cases: 11 legitimate reads that must keep working (including three that merely *mention* a secret, plus `sealedsecret` reads), 10 credential reads across every separator/casing variant, 5 mutation/exec cases covering the pre-existing guard, and the no-read-verb / empty-args paths.

### Docs

The error message pointed at a sanctioned alternative that was documented nowhere. `docs/SECRETS_MANAGEMENT.md` §4 now covers recovering a live value over SSH — key-based, since no root password exists (the public key is injected via cloud-init in `vps.tf`) — why `cluster-query` is not that path, and a note to treat anything recovered that way as exposed. Added to §7 Rules too.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Chore / CI / refactor

## Checklist

- [ ] Branch named `feat/…`, `fix/…`, or `chore/…` — branch name is session-assigned; commit follows the convention
- [x] Conventional commit messages
- [ ] Commits are **signed** (verified) — signing not available from this environment
- [x] Tests added/updated where relevant
- [ ] **Harden Gate** checks pass — pending CI
- [ ] Conversations resolved and ready for code-owner review

### Verification performed

- `pytest tests/test_cluster_query_guard.py` → **28 passed**. `PyYAML` is already in `tests/requirements.txt`; the tests are offline (one YAML parse + bash, no cluster, no network).
- **Mutation-tested.** With the guard loop stripped from the script, all 10 secret cases are *allowed* — so the guard is provably the sole thing rejecting them, not an incidental side effect of the verb checks.
- Workflow YAML re-parsed after edit; all four steps intact.

## Related issues

Follow-up to #476. Raised there as a residual gap after `LITELLM_MASTER_KEY` was recovered through this workflow and the log deleted.

Two things this deliberately does **not** address, both worth their own change:

- **`configmap` is still readable**, and a ConfigMap can hold something sensitive. Blocking it would cost a lot of everyday debuggability, so it isn't in scope here — but the general lesson (read-only ≠ safe-to-log) applies to it too.
- **The LiteLLM UI password is still the API bearer token**, so anyone who can log into the console holds the key that bills your providers. Separate sealed `UI_USERNAME`/`UI_PASSWORD` would decouple them.